### PR TITLE
feat(sdk): export ControlScope, ControlMatch, and EvaluatorResult models

### DIFF
--- a/sdks/python/src/agent_control/__init__.py
+++ b/sdks/python/src/agent_control/__init__.py
@@ -54,9 +54,12 @@ if TYPE_CHECKING:
         Agent,
         ControlAction,
         ControlDefinition,
+        ControlMatch,
+        ControlScope,
         ControlSelector,
         EvaluationRequest,
         EvaluationResult,
+        EvaluatorResult,
         EvaluatorSpec,
         Step,
         StepSchema,
@@ -102,9 +105,12 @@ try:
         Agent,
         ControlAction,
         ControlDefinition,
+        ControlMatch,
+        ControlScope,
         ControlSelector,
         EvaluationRequest,
         EvaluationResult,
+        EvaluatorResult,
         EvaluatorSpec,
         Step,
         StepSchema,
@@ -117,6 +123,15 @@ except ImportError:
             pass
 
         class ControlSelector:
+            pass
+
+        class ControlScope:
+            pass
+
+        class ControlMatch:
+            pass
+
+        class EvaluatorResult:
             pass
 
         class ControlAction:
@@ -1092,6 +1107,9 @@ __all__ = [
     "EvaluationResult",
     "ControlDefinition",
     "ControlSelector",
+    "ControlScope",
     "ControlAction",
+    "ControlMatch",
     "EvaluatorSpec",
+    "EvaluatorResult",
 ]

--- a/sdks/python/tests/test_init_validation.py
+++ b/sdks/python/tests/test_init_validation.py
@@ -1,6 +1,9 @@
 """Validation tests for agent_control.init()."""
 
 import pytest
+from agent_control_models import ControlMatch as ModelControlMatch
+from agent_control_models import ControlScope as ModelControlScope
+from agent_control_models import EvaluatorResult as ModelEvaluatorResult
 
 import agent_control
 
@@ -8,3 +11,18 @@ import agent_control
 def test_init_rejects_invalid_uuid() -> None:
     with pytest.raises(ValueError, match="agent_id must be a valid UUID"):
         agent_control.init(agent_name="Invalid UUID Agent", agent_id="not-a-uuid")
+
+
+def test_init_exports_control_scope() -> None:
+    assert agent_control.ControlScope is ModelControlScope
+    assert "ControlScope" in agent_control.__all__
+
+
+def test_init_exports_control_match() -> None:
+    assert agent_control.ControlMatch is ModelControlMatch
+    assert "ControlMatch" in agent_control.__all__
+
+
+def test_init_exports_evaluator_result() -> None:
+    assert agent_control.EvaluatorResult is ModelEvaluatorResult
+    assert "EvaluatorResult" in agent_control.__all__


### PR DESCRIPTION
Add missing model exports to SDK for users who want to:
- Create typed controls with ControlScope for scope configuration
- Inspect evaluation results via ControlMatch and EvaluatorResult

Also adds tests to verify exports match the models package.