### PR TITLE
docs(examples): update examples and docs for evaluators reorganization

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,5 +2,5 @@ fixes:
   - "agent_control_server/::server/src/agent_control_server/"
   - "agent_control_engine/::engine/src/agent_control_engine/"
   - "agent_control_models/::models/src/agent_control_models/"
-  - "agent_control_evaluators/::evaluators/src/agent_control_evaluators/"
+  - "agent_control_evaluators/::evaluators/builtin/src/agent_control_evaluators/"
   - "agent_control/::sdks/python/src/agent_control/"

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -663,7 +663,7 @@ We welcome contributions! See [CONTRIBUTING.md](../CONTRIBUTING.md) for guidelin
 ### Adding an Evaluator
 
 1. Fork the repository
-2. Create your evaluator in `evaluators/src/agent_control_evaluators/`
+2. Create your evaluator in `evaluators/builtin/src/agent_control_evaluators/` (for builtins) or in `evaluators/extra/` (for external packages)
 3. Add tests in `evaluators/tests/`
 4. Submit a pull request
 

--- a/examples/deepeval/README.md
+++ b/examples/deepeval/README.md
@@ -56,7 +56,7 @@ examples/deepeval/
 
 5. **Entry Point Registration** ([pyproject.toml](pyproject.toml))
    - Registers evaluator with server via `project.entry-points`
-   - Depends on `agent-control-models>=3.0.0` and `agent-control-sdk>=3.0.0`
+   - Depends on `agent-control-evaluators>=5.0.0`, `agent-control-models>=5.0.0`, and `agent-control-sdk>=5.0.0`
    - In monorepo: uses workspace dependencies (editable installs)
    - For third-party: can use published PyPI packages
    - Enables automatic discovery when server starts
@@ -68,7 +68,7 @@ examples/deepeval/
 The evaluator follows the standard pattern for all agent-control evaluators:
 
 ```python
-from agent_control_models import Evaluator, EvaluatorMetadata, register_evaluator
+from agent_control_evaluators import Evaluator, EvaluatorMetadata, register_evaluator
 
 @register_evaluator
 class DeepEvalEvaluator(Evaluator[DeepEvalEvaluatorConfig]):
@@ -102,8 +102,9 @@ The evaluator is registered via `pyproject.toml`:
 ```toml
 [project]
 dependencies = [
-    "agent-control-models>=3.0.0",
-    "agent-control-sdk>=3.0.0",
+    "agent-control-evaluators>=5.0.0",
+    "agent-control-models>=5.0.0",
+    "agent-control-sdk>=5.0.0",
     "deepeval>=1.0.0",
     # ... other dependencies
 ]
@@ -340,7 +341,7 @@ This example shows the **evaluator architecture** for extending agent-control. W
 
 To create your own evaluator:
 
-1. **Extend the Evaluator base class** from `agent-control-models` (published on PyPI)
+1. **Extend the Evaluator base class** from `agent-control-evaluators` (published on PyPI)
 2. **Define a configuration model** using Pydantic
 3. **Register via entry points** in your `pyproject.toml`
 4. **Install your package** so the server can discover the entry point
@@ -350,8 +351,8 @@ For standalone packages outside the monorepo, use published versions:
 ```toml
 [project]
 dependencies = [
-    "agent-control-models>=3.0.0",  # From PyPI
-    "agent-control-sdk>=3.0.0",      # From PyPI
+    "agent-control-evaluators>=5.0.0",  # From PyPI - base classes
+    "agent-control-models>=5.0.0",       # From PyPI - data models
     "your-evaluation-library>=1.0.0"
 ]
 ```
@@ -405,7 +406,7 @@ Follow this pattern to create evaluators for other libraries:
 
 2. **Implement the Evaluator**
    ```python
-   from agent_control_models import Evaluator, EvaluatorMetadata, register_evaluator
+   from agent_control_evaluators import Evaluator, EvaluatorMetadata, register_evaluator
 
    @register_evaluator
    class MyEvaluator(Evaluator[MyEvaluatorConfig]):
@@ -445,7 +446,7 @@ You can create specialized evaluators for specific use cases:
 
 - **DeepEval Documentation**: https://deepeval.com/docs/metrics-llm-evals
 - **G-Eval Guide**: https://www.confident-ai.com/blog/g-eval-the-definitive-guide
-- **Agent Control Evaluators**: [Base evaluator class](../../models/src/agent_control_models/evaluator.py)
+- **Agent Control Evaluators**: [Base evaluator class](../../evaluators/builtin/src/agent_control_evaluators/_base.py)
 - **CrewAI Example**: [Using agent-control as a consumer](../crewai/)
 
 ## Key Takeaways

--- a/examples/deepeval/evaluator.py
+++ b/examples/deepeval/evaluator.py
@@ -9,12 +9,12 @@ Based on DeepEval documentation: https://deepeval.com/docs/metrics-llm-evals
 import logging
 from typing import Any
 
-from agent_control_models import (
+from agent_control_evaluators import (
     Evaluator,
     EvaluatorMetadata,
-    EvaluatorResult,
     register_evaluator,
 )
+from agent_control_models import EvaluatorResult
 
 from config import DeepEvalEvaluatorConfig
 

--- a/examples/deepeval/pyproject.toml
+++ b/examples/deepeval/pyproject.toml
@@ -10,8 +10,9 @@ dependencies = [
     "pydantic>=2.0.0",
     "httpx>=0.24.0",
     "google-re2>=1.1",
-    "agent-control-models>=3.0.0",
-    "agent-control-sdk>=3.0.0",
+    "agent-control-evaluators>=5.0.0",
+    "agent-control-models>=5.0.0",
+    "agent-control-sdk>=5.0.0",
 ]
 
 [project.optional-dependencies]

--- a/examples/galileo/README.md
+++ b/examples/galileo/README.md
@@ -84,5 +84,5 @@ Testing toxicity detection with Central Stage...
 
 - [Galileo Protect Overview](https://v2docs.galileo.ai/concepts/protect/overview)
 - [Luna-2 Python API Reference](https://v2docs.galileo.ai/sdk-api/python/reference/protect)
-- [Agent Control Luna-2 Evaluator](../../evaluators/src/agent_control_evaluators/galileo_luna2/)
+- [Agent Control Luna-2 Evaluator](../../evaluators/extra/galileo/)
 

--- a/examples/galileo/luna2_demo.py
+++ b/examples/galileo/luna2_demo.py
@@ -37,7 +37,7 @@ logging.getLogger("httpcore").setLevel(logging.WARNING)
 
 # Import our direct API client (no SDK required)
 try:
-    from agent_control_evaluators.galileo_luna2.client import (
+    from agent_control_evaluator_galileo.luna2.client import (
         GalileoProtectClient,
         Payload,
     )


### PR DESCRIPTION
Update import paths, dependencies, and documentation links after the v5.0.0 evaluators split into builtin + extra packages:

- Fix deepeval example imports (Evaluator, EvaluatorMetadata, register_evaluator now from agent_control_evaluators instead of agent_control_models)
- Fix galileo luna2_demo import path (agent_control_evaluator_galileo.luna2)
- Update deepeval pyproject.toml dependencies to v5.0.0
- Fix codecov.yml coverage path mapping for new evaluators/builtin/ location
- Update docs/OVERVIEW.md contributor instructions for new structure
- Fix documentation links to evaluator source code