### PR TITLE
feat(evaluators): add required_column_values for multi-tenant SQL validation

### DIFF
--- a/evaluators/builtin/src/agent_control_evaluators/sql/config.py
+++ b/evaluators/builtin/src/agent_control_evaluators/sql/config.py
@@ -99,6 +99,16 @@ class SQLEvaluatorConfig(EvaluatorConfig):
             "'all': Check all clauses including subqueries."
         ),
     )
+    required_column_values: dict[str, str] | None = Field(
+        default=None,
+        description=(
+            "Map of column references to context keys for value-based tenant filtering. "
+            "Each required column must appear in a top-level WHERE equality predicate "
+            "with a literal value that matches the corresponding context value. "
+            "Column references may be unqualified ('user_id') or table-qualified "
+            "('users.user_id')."
+        ),
+    )
 
     # Limits
     require_limit: bool = Field(
@@ -176,6 +186,31 @@ class SQLEvaluatorConfig(EvaluatorConfig):
                 "column_context is set but required_columns is empty - "
                 "column_context will be ignored"
             )
+        if self.required_column_values:
+            for column_ref, context_key in self.required_column_values.items():
+                if not column_ref.strip():
+                    raise ValueError(
+                        "required_column_values contains an empty column reference"
+                    )
+
+                if "." in column_ref:
+                    table_name, column_name = column_ref.split(".", 1)
+                    if not table_name.strip() or not column_name.strip():
+                        raise ValueError(
+                            "required_column_values column references must use "
+                            "'table.column' format when qualified"
+                        )
+
+                if not context_key.strip():
+                    raise ValueError(
+                        "required_column_values contains an empty context key"
+                    )
+
+            if self.column_context == "select":
+                warnings.warn(
+                    "required_column_values is configured with column_context='select' "
+                    "- value checks only apply to WHERE predicates"
+                )
 
         # Validate LIMIT controls
         if self.max_limit and not self.require_limit:

--- a/evaluators/builtin/src/agent_control_evaluators/sql/evaluator.py
+++ b/evaluators/builtin/src/agent_control_evaluators/sql/evaluator.py
@@ -51,6 +51,16 @@ class QueryAnalysis:
     defined_ctes: set[str] = field(default_factory=set)
 
 
+@dataclass(frozen=True)
+class RequiredColumnValueRule:
+    """Preprocessed required column/value mapping rule."""
+
+    raw_column: str
+    table: str | None
+    column: str
+    context_key: str
+
+
 @register_evaluator
 class SQLEvaluator(Evaluator[SQLEvaluatorConfig]):
     """Comprehensive SQL validation evaluator.
@@ -168,6 +178,9 @@ class SQLEvaluator(Evaluator[SQLEvaluatorConfig]):
         self._required_columns = self._build_set(
             config.required_columns, config.case_sensitive
         )
+        self._required_column_values = self._build_required_column_value_rules(
+            config.required_column_values
+        )
 
     def _build_set(self, items: list[str] | None, case_sensitive: bool) -> set[str] | None:
         """Build a set with proper casing."""
@@ -178,6 +191,34 @@ class SQLEvaluator(Evaluator[SQLEvaluatorConfig]):
     def _normalize_name(self, name: str) -> str:
         """Normalize table/schema/column name for comparison."""
         return name if self.config.case_sensitive else name.lower()
+
+    def _build_required_column_value_rules(
+        self, rules: dict[str, str] | None
+    ) -> list[RequiredColumnValueRule]:
+        """Preprocess required column/value rules for fast matching."""
+        if not rules:
+            return []
+
+        processed: list[RequiredColumnValueRule] = []
+        for raw_column, context_key in rules.items():
+            table_name: str | None = None
+            column_name = raw_column
+
+            if "." in raw_column:
+                table_part, column_part = raw_column.split(".", 1)
+                table_name = self._normalize_name(table_part.strip())
+                column_name = column_part
+
+            processed.append(
+                RequiredColumnValueRule(
+                    raw_column=raw_column,
+                    table=table_name,
+                    column=self._normalize_name(column_name.strip()),
+                    context_key=context_key,
+                )
+            )
+
+        return processed
 
     def _analyze_query_structure(self, stmt: exp.Expression) -> QueryAnalysis:
         """Analyze query structure in a single tree walk (performance optimization).
@@ -258,15 +299,15 @@ class SQLEvaluator(Evaluator[SQLEvaluatorConfig]):
         return analysis
 
     def _is_in_node_but_not_in_subqueries(
-        self, column: exp.Column, target_node: exp.Expression
+        self, node: exp.Expression, target_node: exp.Expression
     ) -> bool:
-        """Check if column is in target node but not in any subqueries within it."""
-        # Walk up from column to see if we hit target_node before hitting a SELECT
-        current = column.parent
+        """Check if node is in target node but not in any nested SELECT subqueries."""
+        # Walk up from node to see if we hit target_node before hitting a nested SELECT
+        current = node.parent
         while current:
             if current is target_node:
                 return True
-            # If we hit a SELECT node before the target, column is in a subquery
+            # If we hit a SELECT node before the target, node is in a subquery
             if isinstance(current, exp.Select) and current is not target_node:
                 return False
             current = current.parent
@@ -684,6 +725,271 @@ class SQLEvaluator(Evaluator[SQLEvaluatorConfig]):
 
         return metadata
 
+    def _extract_query_and_context(self, data: Any) -> tuple[str, dict[str, Any]]:
+        """Extract SQL query and optional runtime context from evaluation payload."""
+        if isinstance(data, str):
+            return data, {}
+
+        if not isinstance(data, dict):
+            return str(data), {}
+
+        context_data = data.get("context")
+        context = context_data if isinstance(context_data, dict) else {}
+
+        if "input" in data and "type" in data:
+            # Full step payload selected by selector="*"
+            input_data = data.get("input")
+            if isinstance(input_data, str):
+                return input_data, context
+
+            if isinstance(input_data, dict):
+                query_data = input_data.get("query", "")
+                if query_data is None:
+                    return "", context
+                return (
+                    query_data if isinstance(query_data, str) else str(query_data),
+                    context,
+                )
+
+            if input_data is None:
+                return "", context
+
+            return str(input_data), context
+
+        query_data = data.get("query", "")
+        if query_data is None:
+            return "", context
+        return query_data if isinstance(query_data, str) else str(query_data), context
+
+    def _is_scalar_context_value(self, value: Any) -> bool:
+        """Return True when context value is scalar and comparable to SQL literals."""
+        return isinstance(value, (str, int, float, bool))
+
+    def _statement_accesses_physical_tables(self, analysis: QueryAnalysis) -> bool:
+        """Return True when statement references at least one non-CTE table."""
+        for _schema, table_name in analysis.tables:
+            if self._normalize_name(table_name) not in analysis.defined_ctes:
+                return True
+        return False
+
+    def _get_top_level_where_clause(self, stmt: exp.Expression) -> exp.Where | None:
+        """Get top-level WHERE node for statement when present."""
+        where_node = stmt.args.get("where")
+        return where_node if isinstance(where_node, exp.Where) else None
+
+    def _has_ancestor_of_type(
+        self,
+        node: exp.Expression,
+        stop_node: exp.Expression,
+        ancestor_type: type[exp.Expression],
+    ) -> bool:
+        """Check whether node has a specific ancestor before reaching stop_node."""
+        current = node.parent
+        while current and current is not stop_node:
+            if isinstance(current, ancestor_type):
+                return True
+            current = current.parent
+        return False
+
+    def _build_alias_to_base_table_map(
+        self, stmt: exp.Expression, analysis: QueryAnalysis
+    ) -> tuple[dict[str, str], set[str]]:
+        """Build alias/base-table map for top-level table references."""
+        alias_to_base: dict[str, str] = {}
+        base_tables: set[str] = set()
+
+        for table_node in stmt.find_all(exp.Table):
+            if not table_node.name:
+                continue
+            if not self._is_in_node_but_not_in_subqueries(table_node, stmt):
+                continue
+
+            base_table = self._normalize_name(table_node.name)
+            if base_table in analysis.defined_ctes:
+                continue
+
+            base_tables.add(base_table)
+            alias_to_base[base_table] = base_table
+
+            alias_name = table_node.alias_or_name
+            if alias_name:
+                alias_to_base[self._normalize_name(alias_name)] = base_table
+
+        return alias_to_base, base_tables
+
+    def _extract_column_literal_from_eq(
+        self, eq_node: exp.EQ
+    ) -> tuple[exp.Column, exp.Literal] | None:
+        """Extract (column, literal) from EQ regardless of operand side order."""
+        if isinstance(eq_node.this, exp.Column) and isinstance(eq_node.expression, exp.Literal):
+            return eq_node.this, eq_node.expression
+        if isinstance(eq_node.expression, exp.Column) and isinstance(eq_node.this, exp.Literal):
+            return eq_node.expression, eq_node.this
+        return None
+
+    def _column_matches_rule(
+        self,
+        column_expr: exp.Column,
+        rule: RequiredColumnValueRule,
+        alias_to_base: dict[str, str],
+    ) -> bool:
+        """Check whether column expression matches configured rule reference."""
+        if self._normalize_name(column_expr.name) != rule.column:
+            return False
+
+        if rule.table is None:
+            return True
+
+        column_qualifier = column_expr.table
+        if not column_qualifier:
+            return False
+
+        qualifier_norm = self._normalize_name(column_qualifier)
+        resolved_base = alias_to_base.get(qualifier_norm, qualifier_norm)
+        return resolved_base == rule.table
+
+    def _check_column_values(
+        self,
+        parsed_statements: list[exp.Expression],
+        analyses: list[QueryAnalysis],
+        query: str,
+        context: dict[str, Any],
+    ) -> EvaluatorResult | None:
+        """Check required column equality/value rules for multi-tenant filtering."""
+        if not self._required_column_values:
+            return None
+
+        for statement_index, (stmt, analysis) in enumerate(
+            zip(parsed_statements, analyses, strict=False)
+        ):
+            if not self._statement_accesses_physical_tables(analysis):
+                continue
+
+            top_level_where = self._get_top_level_where_clause(stmt)
+            if top_level_where is None:
+                return EvaluatorResult(
+                    matched=True,
+                    confidence=1.0,
+                    message=(
+                        "Table-accessing statement is missing top-level WHERE clause required "
+                        "for required_column_values"
+                    ),
+                    metadata=self._create_query_metadata(
+                        query,
+                        {
+                            "violation": "missing_top_level_where",
+                            "statement_index": statement_index,
+                        },
+                    ),
+                )
+
+            alias_to_base, base_tables = self._build_alias_to_base_table_map(stmt, analysis)
+
+            for rule in self._required_column_values:
+                if rule.context_key not in context:
+                    return EvaluatorResult(
+                        matched=True,
+                        confidence=1.0,
+                        message=(
+                            "Missing context value for required_column_values rule "
+                            f"'{rule.raw_column}'. Use selector '*' so step context is available."
+                        ),
+                        metadata=self._create_query_metadata(
+                            query,
+                            {
+                                "violation": "missing_context_value",
+                                "required_column": rule.raw_column,
+                                "context_key": rule.context_key,
+                                "statement_index": statement_index,
+                            },
+                        ),
+                    )
+
+                expected_value = context[rule.context_key]
+                if not self._is_scalar_context_value(expected_value):
+                    return EvaluatorResult(
+                        matched=True,
+                        confidence=1.0,
+                        message=(
+                            "required_column_values context value must be scalar "
+                            f"(str/int/float/bool) for key '{rule.context_key}'"
+                        ),
+                        metadata=self._create_query_metadata(
+                            query,
+                            {
+                                "violation": "invalid_context_value_type",
+                                "required_column": rule.raw_column,
+                                "context_key": rule.context_key,
+                                "context_value_type": type(expected_value).__name__,
+                                "statement_index": statement_index,
+                            },
+                        ),
+                    )
+
+                if rule.table is None and len(base_tables) > 1:
+                    return EvaluatorResult(
+                        matched=True,
+                        confidence=1.0,
+                        message=(
+                            "Table qualification is required for required_column_values "
+                            "when query references multiple tables"
+                        ),
+                        metadata=self._create_query_metadata(
+                            query,
+                            {
+                                "violation": "ambiguous_unqualified_column",
+                                "required_column": rule.raw_column,
+                                "base_tables": sorted(base_tables),
+                                "statement_index": statement_index,
+                            },
+                        ),
+                    )
+
+                found_valid_predicate = False
+                expected_literal = str(expected_value)
+                for eq_node in top_level_where.find_all(exp.EQ):
+                    if not self._is_in_node_but_not_in_subqueries(eq_node, top_level_where):
+                        continue
+                    if self._has_ancestor_of_type(eq_node, top_level_where, exp.Not):
+                        continue
+                    if self._has_ancestor_of_type(eq_node, top_level_where, exp.Or):
+                        continue
+
+                    column_and_literal = self._extract_column_literal_from_eq(eq_node)
+                    if not column_and_literal:
+                        continue
+
+                    column_expr, literal_expr = column_and_literal
+                    if not self._column_matches_rule(column_expr, rule, alias_to_base):
+                        continue
+
+                    if str(literal_expr.this) != expected_literal:
+                        continue
+
+                    found_valid_predicate = True
+                    break
+
+                if not found_valid_predicate:
+                    return EvaluatorResult(
+                        matched=True,
+                        confidence=1.0,
+                        message=(
+                            "Required equality predicate not found in top-level WHERE: "
+                            f"'{rule.raw_column}' must equal context['{rule.context_key}']"
+                        ),
+                        metadata=self._create_query_metadata(
+                            query,
+                            {
+                                "violation": "missing_or_invalid_value_predicate",
+                                "required_column": rule.raw_column,
+                                "context_key": rule.context_key,
+                                "statement_index": statement_index,
+                            },
+                        ),
+                    )
+
+        return None
+
     async def evaluate(self, data: Any) -> EvaluatorResult:
         """Evaluate SQL query against all configured controls.
 
@@ -728,11 +1034,7 @@ class SQLEvaluator(Evaluator[SQLEvaluatorConfig]):
                 message="No SQL query provided",
             )
 
-        query = (
-            data
-            if isinstance(data, str)
-            else data.get("query", "") if isinstance(data, dict) else str(data)
-        )
+        query, context = self._extract_query_and_context(data)
 
         if not query.strip():
             return EvaluatorResult(
@@ -751,6 +1053,7 @@ class SQLEvaluator(Evaluator[SQLEvaluatorConfig]):
             self._allowed_schemas,
             self._blocked_schemas,
             self._required_columns,
+            self._required_column_values,
             self.config.require_limit,
             self.config.max_limit is not None,
             self.config.max_result_window is not None,
@@ -803,6 +1106,8 @@ class SQLEvaluator(Evaluator[SQLEvaluatorConfig]):
                 metadata=self._create_query_metadata(query),
             )
 
+        parsed_statements = [stmt for stmt in parsed if stmt is not None]
+
         # 2. Check multi-statements
         if not self.config.allow_multi_statements or self.config.max_statements:
             multi_stmt_result = self._check_multi_statements(parsed, query)
@@ -811,7 +1116,7 @@ class SQLEvaluator(Evaluator[SQLEvaluatorConfig]):
 
         # 3. Analyze query structure once (single tree walk for performance)
         # This avoids multiple expensive tree traversals
-        analyses = [self._analyze_query_structure(stmt) for stmt in parsed if stmt]
+        analyses = [self._analyze_query_structure(stmt) for stmt in parsed_statements]
 
         # 4. Check operations
         if self._blocked_ops or self._allowed_ops:
@@ -835,6 +1140,17 @@ class SQLEvaluator(Evaluator[SQLEvaluatorConfig]):
             column_result = self._check_columns(analyses, query)
             if column_result:
                 return column_result
+
+        # 6.5. Check column value constraints
+        if self._required_column_values:
+            column_value_result = self._check_column_values(
+                parsed_statements=parsed_statements,
+                analyses=analyses,
+                query=query,
+                context=context,
+            )
+            if column_value_result:
+                return column_value_result
 
         # 7. Check LIMIT constraints
         if (

--- a/evaluators/builtin/tests/sql/test_sql.py
+++ b/evaluators/builtin/tests/sql/test_sql.py
@@ -1947,6 +1947,298 @@ class TestMultiTenantRLSSecurityBypass:
         assert result.matched is True
 
 
+class TestRequiredColumnValues:
+    """Tests for value-aware multi-tenant SQL enforcement."""
+
+    @pytest.mark.asyncio
+    async def test_exact_equality_match_passes(self):
+        """Required column value match in top-level WHERE should pass."""
+        config = SQLEvaluatorConfig(required_column_values={"user_id": "user_id"})
+        evaluator = SQLEvaluator(config)
+
+        result = await evaluator.evaluate(
+            {"query": "SELECT * FROM users WHERE user_id = 'u1'", "context": {"user_id": "u1"}}
+        )
+        assert result.error is None
+        assert result.matched is False
+
+    @pytest.mark.asyncio
+    async def test_full_step_payload_format_passes(self):
+        """Full step payload should provide query and context to the evaluator."""
+        config = SQLEvaluatorConfig(required_column_values={"user_id": "user_id"})
+        evaluator = SQLEvaluator(config)
+
+        result = await evaluator.evaluate(
+            {
+                "type": "tool",
+                "name": "execute_sql",
+                "input": {"query": "SELECT * FROM users WHERE user_id = 'u1'"},
+                "context": {"user_id": "u1"},
+            }
+        )
+        assert result.error is None
+        assert result.matched is False
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_column_match_passes(self):
+        """Column matching should follow case-insensitive default behavior."""
+        config = SQLEvaluatorConfig(required_column_values={"user_id": "user_id"})
+        evaluator = SQLEvaluator(config)
+
+        result = await evaluator.evaluate(
+            {"query": "SELECT * FROM users WHERE User_ID = 'u1'", "context": {"user_id": "u1"}}
+        )
+        assert result.error is None
+        assert result.matched is False
+
+    @pytest.mark.asyncio
+    async def test_numeric_literal_match_passes(self):
+        """Numeric SQL literals should match equivalent scalar context values."""
+        config = SQLEvaluatorConfig(required_column_values={"user_id": "user_id"})
+        evaluator = SQLEvaluator(config)
+
+        result = await evaluator.evaluate(
+            {"query": "SELECT * FROM users WHERE user_id = 123", "context": {"user_id": 123}}
+        )
+        assert result.error is None
+        assert result.matched is False
+
+    @pytest.mark.asyncio
+    async def test_value_mismatch_is_blocked(self):
+        """Mismatched literal value should be blocked."""
+        config = SQLEvaluatorConfig(required_column_values={"user_id": "user_id"})
+        evaluator = SQLEvaluator(config)
+
+        result = await evaluator.evaluate(
+            {"query": "SELECT * FROM users WHERE user_id = 'u2'", "context": {"user_id": "u1"}}
+        )
+        assert result.error is None
+        assert result.matched is True
+        assert result.metadata["violation"] == "missing_or_invalid_value_predicate"
+
+    @pytest.mark.asyncio
+    async def test_neq_operator_is_blocked(self):
+        """Negated comparison should not satisfy required_column_values."""
+        config = SQLEvaluatorConfig(required_column_values={"user_id": "user_id"})
+        evaluator = SQLEvaluator(config)
+
+        result = await evaluator.evaluate(
+            {"query": "SELECT * FROM users WHERE user_id != 'u1'", "context": {"user_id": "u1"}}
+        )
+        assert result.error is None
+        assert result.matched is True
+        assert result.metadata["violation"] == "missing_or_invalid_value_predicate"
+
+    @pytest.mark.asyncio
+    async def test_not_wrapper_is_blocked(self):
+        """NOT-wrapped equality should be blocked."""
+        config = SQLEvaluatorConfig(required_column_values={"user_id": "user_id"})
+        evaluator = SQLEvaluator(config)
+
+        result = await evaluator.evaluate(
+            {
+                "query": "SELECT * FROM users WHERE NOT user_id = 'u1'",
+                "context": {"user_id": "u1"},
+            }
+        )
+        assert result.error is None
+        assert result.matched is True
+        assert result.metadata["violation"] == "missing_or_invalid_value_predicate"
+
+    @pytest.mark.asyncio
+    async def test_or_bypass_is_blocked(self):
+        """OR-branch predicates should be rejected for tenant checks."""
+        config = SQLEvaluatorConfig(required_column_values={"user_id": "user_id"})
+        evaluator = SQLEvaluator(config)
+
+        result = await evaluator.evaluate(
+            {
+                "query": "SELECT * FROM users WHERE user_id = 'u1' OR 1 = 1",
+                "context": {"user_id": "u1"},
+            }
+        )
+        assert result.error is None
+        assert result.matched is True
+        assert result.metadata["violation"] == "missing_or_invalid_value_predicate"
+
+    @pytest.mark.asyncio
+    async def test_parameterized_rhs_is_blocked(self):
+        """Parameterized comparisons should fail closed."""
+        config = SQLEvaluatorConfig(required_column_values={"user_id": "user_id"})
+        evaluator = SQLEvaluator(config)
+
+        result = await evaluator.evaluate(
+            {"query": "SELECT * FROM users WHERE user_id = $1", "context": {"user_id": "u1"}}
+        )
+        assert result.error is None
+        assert result.matched is True
+        assert result.metadata["violation"] == "missing_or_invalid_value_predicate"
+
+    @pytest.mark.asyncio
+    async def test_function_rhs_is_blocked(self):
+        """Function-based RHS should fail closed."""
+        config = SQLEvaluatorConfig(required_column_values={"user_id": "user_id"})
+        evaluator = SQLEvaluator(config)
+
+        result = await evaluator.evaluate(
+            {
+                "query": "SELECT * FROM users WHERE user_id = get_user_id()",
+                "context": {"user_id": "u1"},
+            }
+        )
+        assert result.error is None
+        assert result.matched is True
+        assert result.metadata["violation"] == "missing_or_invalid_value_predicate"
+
+    @pytest.mark.asyncio
+    async def test_missing_context_key_is_blocked(self):
+        """Missing context key should fail closed."""
+        config = SQLEvaluatorConfig(required_column_values={"user_id": "user_id"})
+        evaluator = SQLEvaluator(config)
+
+        result = await evaluator.evaluate({"query": "SELECT * FROM users WHERE user_id = 'u1'"})
+        assert result.error is None
+        assert result.matched is True
+        assert result.metadata["violation"] == "missing_context_value"
+
+    @pytest.mark.asyncio
+    async def test_non_scalar_context_value_is_blocked(self):
+        """Context values must be scalar."""
+        config = SQLEvaluatorConfig(required_column_values={"user_id": "user_id"})
+        evaluator = SQLEvaluator(config)
+
+        result = await evaluator.evaluate(
+            {"query": "SELECT * FROM users WHERE user_id = 'u1'", "context": {"user_id": ["u1"]}}
+        )
+        assert result.error is None
+        assert result.matched is True
+        assert result.metadata["violation"] == "invalid_context_value_type"
+
+    @pytest.mark.asyncio
+    async def test_none_context_value_is_blocked(self):
+        """None context values must be rejected."""
+        config = SQLEvaluatorConfig(required_column_values={"user_id": "user_id"})
+        evaluator = SQLEvaluator(config)
+
+        result = await evaluator.evaluate(
+            {"query": "SELECT * FROM users WHERE user_id = 'u1'", "context": {"user_id": None}}
+        )
+        assert result.error is None
+        assert result.matched is True
+        assert result.metadata["violation"] == "invalid_context_value_type"
+
+    @pytest.mark.asyncio
+    async def test_missing_top_level_where_is_blocked(self):
+        """Table-accessing statements must have top-level WHERE."""
+        config = SQLEvaluatorConfig(required_column_values={"user_id": "user_id"})
+        evaluator = SQLEvaluator(config)
+
+        result = await evaluator.evaluate(
+            {"query": "SELECT * FROM users", "context": {"user_id": "u1"}}
+        )
+        assert result.error is None
+        assert result.matched is True
+        assert result.metadata["violation"] == "missing_top_level_where"
+
+    @pytest.mark.asyncio
+    async def test_subquery_only_predicate_is_blocked(self):
+        """Predicates only inside subqueries must not satisfy the rule."""
+        config = SQLEvaluatorConfig(required_column_values={"user_id": "user_id"})
+        evaluator = SQLEvaluator(config)
+
+        result = await evaluator.evaluate(
+            {
+                "query": (
+                    "SELECT * FROM users WHERE id IN "
+                    "(SELECT user_id FROM orders WHERE user_id = 'u1')"
+                ),
+                "context": {"user_id": "u1"},
+            }
+        )
+        assert result.error is None
+        assert result.matched is True
+        assert result.metadata["violation"] == "missing_or_invalid_value_predicate"
+
+    @pytest.mark.asyncio
+    async def test_table_qualified_rule_with_alias_resolves_to_base_table(self):
+        """Qualified rules should resolve aliases to base tables."""
+        config = SQLEvaluatorConfig(required_column_values={"users.user_id": "user_id"})
+        evaluator = SQLEvaluator(config)
+
+        result = await evaluator.evaluate(
+            {
+                "query": "SELECT * FROM users u WHERE u.user_id = 'u1'",
+                "context": {"user_id": "u1"},
+            }
+        )
+        assert result.error is None
+        assert result.matched is False
+
+    @pytest.mark.asyncio
+    async def test_table_alias_spoofing_is_blocked(self):
+        """Alias spoofing should not satisfy qualified base-table rules."""
+        config = SQLEvaluatorConfig(required_column_values={"users.user_id": "user_id"})
+        evaluator = SQLEvaluator(config)
+
+        result = await evaluator.evaluate(
+            {
+                "query": "SELECT * FROM orders AS users WHERE users.user_id = 'u1'",
+                "context": {"user_id": "u1"},
+            }
+        )
+        assert result.error is None
+        assert result.matched is True
+        assert result.metadata["violation"] == "missing_or_invalid_value_predicate"
+
+    @pytest.mark.asyncio
+    async def test_unqualified_column_with_multi_table_query_is_blocked(self):
+        """Unqualified rules should fail closed when statement has multiple tables."""
+        config = SQLEvaluatorConfig(required_column_values={"user_id": "user_id"})
+        evaluator = SQLEvaluator(config)
+
+        result = await evaluator.evaluate(
+            {
+                "query": (
+                    "SELECT * FROM users u JOIN orders o ON u.id = o.user_id "
+                    "WHERE u.user_id = 'u1'"
+                ),
+                "context": {"user_id": "u1"},
+            }
+        )
+        assert result.error is None
+        assert result.matched is True
+        assert result.metadata["violation"] == "ambiguous_unqualified_column"
+
+    @pytest.mark.asyncio
+    async def test_multi_statement_requires_each_statement_to_be_scoped(self):
+        """Each table-accessing statement must satisfy required_column_values."""
+        config = SQLEvaluatorConfig(required_column_values={"user_id": "user_id"})
+        evaluator = SQLEvaluator(config)
+
+        result = await evaluator.evaluate(
+            {
+                "query": (
+                    "SELECT * FROM users WHERE user_id = 'u1'; "
+                    "SELECT * FROM users WHERE status = 'active'"
+                ),
+                "context": {"user_id": "u1"},
+            }
+        )
+        assert result.error is None
+        assert result.matched is True
+        assert result.metadata["statement_index"] == 1
+        assert result.metadata["violation"] == "missing_or_invalid_value_predicate"
+
+    def test_required_column_values_warns_with_select_context(self):
+        """Value-based rules should warn when select context is configured."""
+        with pytest.warns(UserWarning, match="value checks only apply to WHERE"):
+            SQLEvaluatorConfig(
+                required_columns=["user_id"],
+                column_context="select",
+                required_column_values={"user_id": "user_id"},
+            )
+
+
 class TestLimitBypassSubqueries:
     """Tests for Issue #3: LIMIT checking doesn't recurse."""
 


### PR DESCRIPTION
## Summary

Closes [sc-52949](https://app.shortcut.com/galileo/story/52949)

The SQL evaluator's `required_columns` check verifies column **presence** in WHERE but doesn't validate the **operator** or **value**. This means `WHERE user_id != 'user_001'` passes validation because `user_id` is technically present - even though it negates the tenant filter.

- Adds `required_column_values` config option that maps column references to runtime context keys
- Validates strict equality (`=`) with a literal value matching the context value
- Enforces AND-only conjunctive paths (rejects OR-branch bypasses)
- Checks top-level WHERE only (subquery-only predicates rejected)
- Per-statement enforcement (multi-statement bypass blocked)
- Fail-closed on non-literals (`$1`, function calls), missing/non-scalar context, and ambiguous unqualified columns in JOINs
- Resolves table aliases back to base table names to prevent alias spoofing

## Test plan

- [x] 20 new tests in `TestRequiredColumnValues` covering all valid/blocked scenarios
- [x] Full test suite passes (151 tests, 0 failures)
- [x] Lint + typecheck pass (pre-push hooks)
- [ ] Manual verification with multi-tenant SQL agent