### PR TITLE
fix(server): fix alembic migrations

### DIFF
--- a/server/alembic/versions/58920e6807fe_name_native_agent_identity_hard_cut.py
+++ b/server/alembic/versions/58920e6807fe_name_native_agent_identity_hard_cut.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '58920e6807fe'
-down_revision = 'd2f4a6b8c9d0'
+down_revision = '53d8427083e2'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
https://github.com/agentcontrol/agent-control/commit/7277e2730c16e717ad5ba8248b946252b22e69cb merged alembic migrations into one, so when i merged  https://github.com/agentcontrol/agent-control/commit/ee322c93eb91f69a04895685176e4977bac21c15 it had wrong down revision