### PR TITLE
fix(ci): correct galileo contrib path in release build script

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -206,7 +206,7 @@ def build_evaluators() -> None:
 def build_evaluator_galileo() -> None:
     """Build agent-control-evaluator-galileo (standalone, no vendoring needed)."""
     version = get_global_version()
-    galileo_dir = ROOT / "evaluators" / "extra" / "galileo"
+    galileo_dir = ROOT / "evaluators" / "contrib" / "galileo"
 
     print(f"Building agent-control-evaluator-galileo v{version}")
 


### PR DESCRIPTION
## Summary
- update `scripts/build.py` to use the current Galileo evaluator path: `evaluators/contrib/galileo`
- fix release workflow failure in Build Packages step caused by stale `evaluators/extra/galileo` path

## Validation
- `uv run python scripts/build.py galileo`
- `uv sync && uv run python scripts/build.py all`

## Context
- failing run: https://github.com/agentcontrol/agent-control/actions/runs/22648712942/job/65642854999#step:8:62