### PR TITLE
chore(sdk-ts): make semantic-release workflow manual-only

### DIFF
--- a/.github/workflows/release-sdk-ts.yml
+++ b/.github/workflows/release-sdk-ts.yml
@@ -1,8 +1,6 @@
 name: Release TypeScript SDK
 
 on:
-  push:
-    branches: [ main ]
   workflow_dispatch:
     inputs:
       dry_run:
@@ -86,6 +84,11 @@ jobs:
             echo "Running semantic-release dry-run."
             pnpm run release:dry-run
             exit 0
+          fi
+
+          if [[ "${{ github.ref_name }}" != "main" ]]; then
+            echo "Publish runs must be dispatched from main. Current ref: ${{ github.ref_name }}"
+            exit 1
           fi
 
           if [[ -z "${NPM_TOKEN}" ]]; then

--- a/sdks/typescript/RELEASING.md
+++ b/sdks/typescript/RELEASING.md
@@ -46,9 +46,8 @@ This previews the next semantic version and release notes without publishing.
 
 Workflow: `.github/workflows/release-sdk-ts.yml`
 
-- Automatic publish: runs on `push` to `main`.
 - Manual preview: `workflow_dispatch` with `dry_run=true`.
-- Manual publish: `workflow_dispatch` with `dry_run=false`.
+- Manual publish: `workflow_dispatch` with `dry_run=false` from `main`.
 
 Release job performs:
 - `make sdk-ts-release-check`


### PR DESCRIPTION
## Summary
- Makes the TypeScript SDK release workflow manual-only (Python-style trigger behavior).
- Keeps semantic-release in place, but requires explicit `workflow_dispatch` for both preview and publish.
- Adds a publish safety gate so non-dry runs can only execute from `main`.

## Scope
- User-facing/API changes:
  - No SDK runtime/API behavior changes.
- Internal changes:
  - Updated `.github/workflows/release-sdk-ts.yml`:
    - removed `push` trigger
    - retained `workflow_dispatch` with `dry_run`
    - added guard: `dry_run=false` requires `ref == main`
  - Updated `sdks/typescript/RELEASING.md` to match manual-only behavior.
- Out of scope:
  - semantic-release rules/tag format/package versioning strategy
  - Python release workflow changes

## Risk and Rollout
- Risk level: low
- Rollout plan:
  - Merge PR.
  - Run manual dry-run on `main` (`dry_run=true`).
  - Run manual publish on `main` (`dry_run=false`).
- Rollback plan:
  - Revert this PR to restore push-triggered behavior.

## Testing
- [ ] Added or updated automated tests
- [ ] Ran `make check` (or explained why not)
- [x] Manually verified behavior

Notes:
- No new tests added; change is workflow + runbook only.
- Verified workflow path on branch with existing semantic-release runs:
  - https://github.com/agentcontrol/agent-control/actions/runs/22649229718
  - https://github.com/agentcontrol/agent-control/actions/runs/22649269871

## Checklist
- [x] Linked issue/spec (if applicable)
- [x] Updated docs/examples for user-facing changes
- [x] Included any required follow-up tasks

Links:
- Parent story: https://app.shortcut.com/galileo/story/55974/define-typescript-sdk-semver-policy-and-release-alignment
- Implementation subtask: https://app.shortcut.com/galileo/story/57429/implement-independent-commitdriven-semanticrelease-for-typescript-sdk
