### PR TITLE
fix(sdk-ts): export npm token for semantic-release npm auth

### DIFF
--- a/.github/workflows/release-sdk-ts.yml
+++ b/.github/workflows/release-sdk-ts.yml
@@ -77,6 +77,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GALILEO_AUTOMATION_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary
- Fix TS release workflow auth wiring so npm auth uses the same secret for `NPM_TOKEN` and `NODE_AUTH_TOKEN`.
- This matches `.npmrc` generated by `setup-node` (`_authToken=${NODE_AUTH_TOKEN}`).

## Why
The failed main release run showed `EINVALIDNPMTOKEN` from `npm whoami` in `@semantic-release/npm`:
- https://github.com/agentcontrol/agent-control/actions/runs/22650104589/job/65647353783

Workflow exported `NPM_TOKEN` but not `NODE_AUTH_TOKEN`, so npm auth in generated `.npmrc` could not reliably use the provided secret.

## Change
- `.github/workflows/release-sdk-ts.yml`
  - add `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` in the semantic-release step env

## Validation
- Analyzed failing run logs: https://github.com/agentcontrol/agent-control/actions/runs/22650104589/job/65647353783
- Branch diff vs `main` is one-line workflow fix.
