### PR TITLE
fix(sdk-ts): add conventional commits preset dependency

### DIFF
--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -66,6 +66,7 @@
     "@semantic-release/github": "^11.0.6",
     "@semantic-release/npm": "^12.0.2",
     "@semantic-release/release-notes-generator": "^14.1.0",
+    "conventional-changelog-conventionalcommits": "^9.2.0",
     "eslint": "^8.57.1",
     "semantic-release": "^25.0.2",
     "tsup": "^8.3.6",

--- a/sdks/typescript/pnpm-lock.yaml
+++ b/sdks/typescript/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.30.1
         version: 8.56.0(eslint@8.57.1)(typescript@5.9.3)
+      conventional-changelog-conventionalcommits:
+        specifier: ^9.2.0
+        version: 9.2.0
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -852,6 +855,10 @@ packages:
 
   conventional-changelog-angular@8.2.0:
     resolution: {integrity: sha512-4YB1zEXqB17oBI8yRsAs1T+ZhbdsOgJqkl6Trz+GXt/eKf1e4jnA0oW+sOd9BEENzEViuNW0DNoFFjSf3CeC5Q==}
+    engines: {node: '>=18'}
+
+  conventional-changelog-conventionalcommits@9.2.0:
+    resolution: {integrity: sha512-fCf+ODjseueTV09wVBoC0HXLi3OyuBJ+HfE3L63Khxqnr99f9nUcnQh3a15lCWHlGLihyZShW/mVVkBagr9JvQ==}
     engines: {node: '>=18'}
 
   conventional-changelog-writer@8.3.0:
@@ -3200,6 +3207,10 @@ snapshots:
   consola@3.4.2: {}
 
   conventional-changelog-angular@8.2.0:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-changelog-conventionalcommits@9.2.0:
     dependencies:
       compare-func: 2.0.0
 


### PR DESCRIPTION
## Summary
- Fixes TypeScript semantic-release failure by adding the missing `conventional-changelog-conventionalcommits` package.
- Keeps existing release behavior unchanged; this only satisfies the configured preset dependency.

## Root Cause
Release run failed in `Run semantic-release` with:
- `Cannot find module 'conventional-changelog-conventionalcommits'`
- failure run: https://github.com/agentcontrol/agent-control/actions/runs/22650721414/job/65649257696

`sdks/typescript/release.config.cjs` uses `preset: "conventionalcommits"` for both commit analyzer and release-notes generator, which requires this package to be installed.

## Changes
- `sdks/typescript/package.json`
  - add devDependency: `conventional-changelog-conventionalcommits@^9.2.0`
- `sdks/typescript/pnpm-lock.yaml`
  - lockfile update

## Validation
- `make sdk-ts-build`
- Module import check with Node 22.14:
  - `import('conventional-changelog-conventionalcommits')` => success

## Risk
- Low. Dependency-only change for release tooling.
