### PR TITLE
fix(ci): disable npm provenance for private TS SDK release

### DIFF
--- a/.github/workflows/release-sdk-ts.yml
+++ b/.github/workflows/release-sdk-ts.yml
@@ -19,7 +19,8 @@ jobs:
       pull-requests: write
     env:
       SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
-      NPM_CONFIG_PROVENANCE: "true"
+      # npm provenance publish is rejected for private GitHub repositories (E422).
+      NPM_CONFIG_PROVENANCE: "false"
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- set `NPM_CONFIG_PROVENANCE` to `false` in `.github/workflows/release-sdk-ts.yml`
- keep semantic-release publish flow unchanged

## Why
The TypeScript SDK release job failed publishing to npm with:
- `E422 Unsupported GitHub Actions source repository visibility: "private"`

This occurs when npm provenance is enabled for a private source repo. Disabling provenance for this workflow unblocks publish.

## Failed run reference
- https://github.com/agentcontrol/agent-control/actions/runs/22650980432/job/65650042858
