### PR TITLE
docs(docs): add performance benchmarks to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ Traditional guardrails embedded inside your agent code have critical limitations
 
 ## Performance
 
-Benchmarks were run locally on a MacBook (Apple M5, 16 GB RAM) using Docker Compose (`postgres:16` + `agent-control`).
-
 | Endpoint | Scenario | RPS | p50 | p99 |
 |----------|----------|-----|-----|-----|
 | Agent init | Agent with 3 tool steps | 509 | 19 ms | 54 ms |
@@ -50,13 +48,12 @@ Benchmarks were run locally on a MacBook (Apple M5, 16 GB RAM) using Docker Comp
 | Evaluation | 50 controls, 500-char content | 199 | 63 ms | 91 ms |
 | Controls refresh | 5-50 controls per agent | 273-392 | 20-27 ms | 27-61 ms |
 
-- Run profile: 2 minutes per scenario, 5 concurrent users for latency (p50, p99), 10-20 concurrent users for throughput (RPS).
-- RPS = completed requests per second (server throughput).
-- All scenarios completed with 0% errors.
-- Agent create and update paths perform identically (upsert).
+- Agent init handles both create and update identically (upsert).
 - All four built-in evaluators (regex, list, JSON, SQL) perform within 40-46 ms p50 at 1 control.
 - Moving from 1 to 50 controls increased evaluation p50 by about 27 ms.
 - Local laptop benchmarks are directional and intended for developer reference. They are not production sizing guidance.
+
+_Benchmarked on Apple M5 (16 GB RAM), Docker Compose (`postgres:16` + `agent-control`). 2 minutes per scenario, 5 concurrent users for latency (p50, p99), 10-20 for throughput (RPS). RPS = completed requests per second. All scenarios completed with 0% errors._
 
 ### Examples
 


### PR DESCRIPTION
## Summary

Add a Performance section to the README with local benchmark numbers (Docker Compose on MacBook M5).

Covers evaluation (by control count and evaluator type), agent init, and controls refresh - with measured RPS and latency.