### PR TITLE
feat(sdk): migrate strands integration to be a plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ make ui-dev
 
 #### Register your agent with server
 
-Agent must be registered with teh server.  You should also add `@control` decorator around tools and llm call functions.
+Agent must be registered with the server.  You should also add `@control` decorator around tools and llm call functions.
 
 Here is a contrived example.  Reference our [examples](/examples) for real world examples for specific frameworks.
 ```python

--- a/examples/strands_agents/README.md
+++ b/examples/strands_agents/README.md
@@ -1,6 +1,6 @@
 # AgentControl + Strands Integration
 
-Automatic safety controls for AWS Strands agents using hooks - no decorators needed.
+Automatic safety controls for AWS Strands agents using plugins - no decorators needed.
 
 ## Quick Start
 
@@ -8,7 +8,7 @@ Automatic safety controls for AWS Strands agents using hooks - no decorators nee
 
 ```bash
 # 1. Install
-cd examples/strands_integration
+cd examples/strands_agents
 uv pip install -e .
 
 # 2. Configure
@@ -19,7 +19,7 @@ cp .env.example .env
 curl -fsSL https://raw.githubusercontent.com/agentcontrol/agent-control/docker-compose.yml | docker compose -f - up -d
 
 # 4. Setup controls (Terminal 2)
-cd examples/strands_integration/interactive_demo
+cd examples/strands_agents/interactive_demo
 uv run setup_interactive_controls.py
 
 # 5. Run demo (Terminal 3)
@@ -34,33 +34,33 @@ Open http://localhost:8501 and click test buttons to see safety controls in acti
 Customer support agent with PII blocking and SQL injection prevention. Shows real-time safety checks in Streamlit UI.
 
 ### [Steering Demo](steering_demo/)
-Banking email agent with PII redaction. Combines AgentControl Hook (deny on tool calls) + Strands Steering (steer on LLM draft) for layered governance. Uses a two-phase draft → send flow so steer can guide before tool calls.
+Banking email agent with PII redaction. Combines AgentControlPlugin (deny on tool calls) + Strands Steering (steer on LLM draft) for layered governance. Uses a two-phase draft → send flow so steering can apply guidance before tool calls.
 
 ## How It Works
 
-**AgentControlHook** = Automatic safety without code changes
+**AgentControlPlugin** = Automatic safety without code changes
 
 ```python
-from agent_control.integrations.strands import AgentControlHook
+from agent_control.integrations.strands import AgentControlPlugin
 from strands import Agent
 
 # Initialize
 import agent_control
 agent_control.init(agent_name="my-customer-agent")
 
-# Create hook
-hook = AgentControlHook(agent_name="my-customer-agent")
+# Create plugin
+plugin = AgentControlPlugin(agent_name="my-customer-agent")
 
 # Attach to agent - done!
 agent = Agent(
     model=model,
     system_prompt="...",
     tools=[...],
-    hooks=[hook]  # All safety checks automated
+    plugins=[plugin]  # All safety checks automated
 )
 ```
 
-**Hook intercepts events** → **Server evaluates controls** → **Blocks unsafe actions**
+**Plugin intercepts events** → **Server evaluates controls** → **Blocks unsafe actions**
 
 For steer actions, the steering handler converts AgentControl steer into a Strands `Guide()` retry.
 
@@ -88,7 +88,7 @@ For steer actions, the steering handler converts AgentControl steer into a Stran
 }
 ```
 
-Hook automatically extracts tool names from events - no decorators needed!
+Plugin automatically extracts tool names from events - no decorators needed!
 
 ## Architecture
 
@@ -97,25 +97,25 @@ User Input
   ↓
 Strands fires event (BeforeToolCallEvent, AfterModelCallEvent, etc.)
   ↓
-AgentControlHook intercepts → Creates Step → Calls AgentControl server
+AgentControlPlugin intercepts → Creates Step → Calls AgentControl server
   ↓
 Server evaluates controls → Returns safe/unsafe
   ↓
-Hook enforces decision: Continue ✅ or Block ❌
+Plugin enforces decision: Continue ✅ or Block ❌
 ```
 
 ## Integration Patterns
 
 **Basic setup**:
 ```python
-hook = AgentControlHook(
+plugin = AgentControlPlugin(
     agent_name="my-customer-agent",
     enable_logging=True
 )
 ```
 
 **Steering integration**:
-- `AgentControlHook` for tool-stage deny (hard blocks)
+- `AgentControlPlugin` for tool-stage deny (hard blocks)
 - `AgentControlSteeringHandler` for LLM steer → `Guide()` (corrective guidance)
 
 See `steering_demo/README.md` for complete implementation.
@@ -123,7 +123,7 @@ See `steering_demo/README.md` for complete implementation.
 ## Troubleshooting
 
 **"AgentControl not initialized"**
-- Run `agent_control.init()` before creating hook
+- Run `agent_control.init()` before creating the plugin
 
 **Controls not triggering**
 - Server running? `curl http://localhost:8000/health`

--- a/examples/strands_agents/interactive_demo/interactive_support_demo.py
+++ b/examples/strands_agents/interactive_demo/interactive_support_demo.py
@@ -46,7 +46,7 @@ from strands.models.openai import OpenAIModel
 
 import agent_control
 from agent_control import ControlSteerError, ControlViolationError
-from agent_control.integrations.strands import AgentControlHook
+from agent_control.integrations.strands import AgentControlPlugin
 from agent_control_models import EvaluationResult
 
 # Load environment variables
@@ -54,7 +54,7 @@ load_dotenv(Path(__file__).parent.parent / ".env", override=False)
 
 
 # ============================================================================
-# Safety Tracking Hook (using reusable AgentControlHook)
+# Safety Tracking Plugin (using reusable AgentControlPlugin)
 # ============================================================================
 
 def _action_error(result: EvaluationResult) -> tuple[str, Exception] | None:
@@ -92,21 +92,21 @@ def _action_error(result: EvaluationResult) -> tuple[str, Exception] | None:
     return "steer", err
 
 
-class SafetyTrackingHook(AgentControlHook):
+class SafetyTrackingPlugin(AgentControlPlugin):
     """
-    Streamlit-specific hook that extends AgentControlHook.
+    Streamlit-specific plugin that extends AgentControlPlugin.
 
     Tracks all safety decisions and stores them in Streamlit session state for UI display.
     """
 
     def __init__(self, agent_name: str):
         """
-        Initialize SafetyTrackingHook with Streamlit tracking.
+        Initialize SafetyTrackingPlugin with Streamlit tracking.
 
         Args:
             agent_name: Name of the agent for logging and control filtering
         """
-        # Initialize base AgentControlHook with specific events and custom callback
+        # Initialize base AgentControlPlugin with specific events and custom callback
         super().__init__(
             agent_name=agent_name,
             event_control_list=[
@@ -138,7 +138,7 @@ class SafetyTrackingHook(AgentControlHook):
         """
         Custom callback for updating Streamlit session state when violation detected.
 
-        This is called by AgentControlHook whenever a safety violation occurs.
+        This is called by AgentControlPlugin whenever a safety violation occurs.
         """
         self._initialize_session_state()
 
@@ -158,6 +158,7 @@ class SafetyTrackingHook(AgentControlHook):
         step_name: str,
         input: Any | None = None,
         output: Any | None = None,
+        context: dict[str, Any] | None = None,
         step_type: str = "llm",
         stage: str = "pre",
         violation_type: str = "Step",
@@ -408,7 +409,7 @@ User: "What are your shipping options?"
 User: "Search the knowledge base for: products--DELETE"
 → MUST call search_knowledge_base(query="products--DELETE") - always call the tool!
 """,
-        hooks=[SafetyTrackingHook("interactive-support-demo")],
+        plugins=[SafetyTrackingPlugin("interactive-support-demo")],
     )
 
     st.session_state.support_agent = support_agent

--- a/examples/strands_agents/steering_demo/email_safety_demo.py
+++ b/examples/strands_agents/steering_demo/email_safety_demo.py
@@ -43,7 +43,7 @@ try:
     from strands.models.openai import OpenAIModel
     from strands.hooks import BeforeToolCallEvent, AfterToolCallEvent
     import agent_control
-    from agent_control.integrations.strands import AgentControlHook, AgentControlSteeringHandler
+    from agent_control.integrations.strands import AgentControlPlugin, AgentControlSteeringHandler
     from agent_control.control_decorators import ControlViolationError
 except ImportError as e:
     st.error(f"Missing dependency: {e}")
@@ -144,7 +144,7 @@ async def send_monthly_account_summary(
 # =============================================================================
 
 def initialize_agent():
-    """Initialize email agent with dual-hook AgentControl integration."""
+    """Initialize email agent with dual-plugin AgentControl integration."""
 
     # Initialize AgentControl
     try:
@@ -156,22 +156,22 @@ def initialize_agent():
         if "409" not in str(e):
             raise
 
-    # Hook 1: AgentControlHook for tool-stage deny checks
+    # Plugin 1: AgentControlPlugin for tool-stage deny checks
     # Enforces hard blocks (credentials, internal info) at tool execution
-    tool_hook = AgentControlHook(
+    tool_plugin = AgentControlPlugin(
         agent_name="banking-email-agent",
         event_control_list=[BeforeToolCallEvent, AfterToolCallEvent],
         enable_logging=True
     )
 
-    # Hook 2: AgentControlSteeringHandler for LLM post-output steer
+    # Plugin 2: AgentControlSteeringHandler for LLM post-output steer
     # Guides PII redaction via Strands Guide() before tools are called
     steering_handler = AgentControlSteeringHandler(
         agent_name="banking-email-agent",
         enable_logging=True
     )
 
-    # Create agent with both hooks and plugins
+    # Create agent with both plugins
     model = OpenAIModel(model_id="gpt-4o-mini")
     agent = Agent(
         name="banking_email_agent",
@@ -201,8 +201,7 @@ After sending, respond with:
 [The email text that was sent]"
 """,
         tools=[lookup_customer_account, send_monthly_account_summary],
-        hooks=[tool_hook],  # HookProvider for tool-stage deny checks
-        plugins=[steering_handler]  # Plugin for LLM post-output steering
+        plugins=[tool_plugin, steering_handler]  # Both as plugins
     )
 
     return agent, steering_handler

--- a/examples/strands_agents/steering_demo/setup_email_controls.py
+++ b/examples/strands_agents/steering_demo/setup_email_controls.py
@@ -260,7 +260,7 @@ async def main():
             print("SETUP COMPLETE!")
             print("=" * 70)
             print(f"""
-✅ Email Safety Demo Ready - Dual-Hook AgentControl Integration
+✅ Email Safety Demo Ready - Dual-Plugin AgentControl Integration
 
 ARCHITECTURE: LLM Steer + Tool Deny (Clean Two-Layer Design)
 
@@ -281,17 +281,17 @@ ARCHITECTURE: LLM Steer + Tool Deny (Clean Two-Layer Design)
     - Scope: Tool input at send_monthly_account_summary
     - Blocks: API keys, passwords, tokens
     - Action: DENY (RuntimeError - hard block)
-    - Handler: AgentControlHook
+    - Handler: AgentControlPlugin
 
   • deny-internal-info
     - Scope: Tool input at send_monthly_account_summary
     - Blocks: Database names, server IPs, internal paths
     - Action: DENY (RuntimeError - hard block)
-    - Handler: AgentControlHook
+    - Handler: AgentControlPlugin
 
-✨ Dual-Hook Integration:
-  Hook 1: AgentControlSteeringHandler (LLM post) → Guide() for PII
-  Hook 2: AgentControlHook (tool pre/post) → RuntimeError for deny
+✨ Dual-Plugin Integration:
+  Plugin 1: AgentControlSteeringHandler (LLM post) → Guide() for PII
+  Plugin 2: AgentControlPlugin (tool pre/post) → RuntimeError for deny
 
 🔄 Flow:
   1. Agent looks up account data
@@ -300,7 +300,7 @@ ARCHITECTURE: LLM Steer + Tool Deny (Clean Two-Layer Design)
      → steer-pii-redaction-llm-output matches → Guide()
   4. Agent retries with redaction guidance
   5. Agent calls send_monthly_account_summary() with redacted text
-  6. 🛡️ AgentControlHook checks tool input
+  6. 🛡️ AgentControlPlugin checks tool input
      → deny-credentials: ✅ pass
      → deny-internal-info: ✅ pass
   7. Email sent successfully!

--- a/sdks/python/src/agent_control/integrations/strands/__init__.py
+++ b/sdks/python/src/agent_control/integrations/strands/__init__.py
@@ -5,17 +5,17 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .hook import AgentControlHook
+    from .plugin import AgentControlPlugin
     from .steering import AgentControlSteeringHandler
 
-__all__ = ["AgentControlHook", "AgentControlSteeringHandler"]
+__all__ = ["AgentControlPlugin", "AgentControlSteeringHandler"]
 
 
 def __getattr__(name: str) -> type:
     """Lazy import to avoid import errors when strands-agents is not installed."""
-    if name == "AgentControlHook":
-        from .hook import AgentControlHook
-        return AgentControlHook
+    if name == "AgentControlPlugin":
+        from .plugin import AgentControlPlugin
+        return AgentControlPlugin
     elif name == "AgentControlSteeringHandler":
         from .steering import AgentControlSteeringHandler
         return AgentControlSteeringHandler

--- a/sdks/python/src/agent_control/integrations/strands/plugin.py
+++ b/sdks/python/src/agent_control/integrations/strands/plugin.py
@@ -1,4 +1,4 @@
-"""Agent Control hook integration for Strands."""
+"""Agent Control plugin integration for Strands."""
 
 from __future__ import annotations
 
@@ -20,9 +20,8 @@ try:
         BeforeModelCallEvent,
         BeforeNodeCallEvent,
         BeforeToolCallEvent,
-        HookProvider,
-        HookRegistry,
     )
+    from strands.plugins import Plugin  # type: ignore[import-not-found]
 except Exception as exc:  # pragma: no cover - optional dependency
     raise RuntimeError(
         "Strands integration requires strands-agents. "
@@ -66,12 +65,14 @@ def _action_error(result: EvaluationResult) -> tuple[str, Exception] | None:
     return "steer", steer_err
 
 
-class AgentControlHook(HookProvider):
-    """Hook that integrates Agent Control with Strands lifecycle events.
+class AgentControlPlugin(Plugin):
+    """Plugin that integrates Agent Control with Strands lifecycle events.
 
     The Agent Control server is required for control distribution and policy assignment.
     Controls may specify execution="sdk" or execution="server".
     """
+
+    name = "agent-control-plugin"
 
     def __init__(
         self,
@@ -179,7 +180,7 @@ class AgentControlHook(HookProvider):
                 use_runtime_error,
             )
 
-    def register_hooks(self, registry: HookRegistry, **kwargs: Any) -> None:
+    def init_agent(self, agent: Any) -> None:
         event_map = {
             BeforeInvocationEvent: self.check_before_invocation,
             BeforeModelCallEvent: self.check_before_model,
@@ -203,7 +204,7 @@ class AgentControlHook(HookProvider):
 
         for event_type in events_to_register:
             if event_type in event_map:
-                registry.add_callback(event_type, event_map[event_type])  # type: ignore[arg-type]
+                agent.add_hook(event_map[event_type], event_type)
 
     async def check_before_invocation(self, event: BeforeInvocationEvent) -> None:
         input_text, _ = self._extract_messages(event)

--- a/sdks/python/src/agent_control/integrations/strands/steering.py
+++ b/sdks/python/src/agent_control/integrations/strands/steering.py
@@ -32,6 +32,8 @@ class AgentControlSteeringHandler(SteeringHandler):
     Deny matches raise ControlViolationError.
     """
 
+    name = "agent-control-steering"
+
     def __init__(self, agent_name: str, enable_logging: bool = True) -> None:
         super().__init__()
         self.agent_name = agent_name

--- a/sdks/python/tests/test_strands_init.py
+++ b/sdks/python/tests/test_strands_init.py
@@ -13,17 +13,18 @@ def test_strands_init_exports():
         {
             "strands": MagicMock(),
             "strands.hooks": MagicMock(),
+            "strands.plugins": MagicMock(),
             "strands.experimental": MagicMock(),
             "strands.experimental.steering": MagicMock(),
         },
     ):
         from agent_control.integrations.strands import (
-            AgentControlHook,
+            AgentControlPlugin,
             AgentControlSteeringHandler,
         )
 
         # Verify that the classes are importable
-        assert AgentControlHook is not None
+        assert AgentControlPlugin is not None
         assert AgentControlSteeringHandler is not None
 
 
@@ -42,20 +43,20 @@ def test_strands_init_all():
         import agent_control.integrations.strands as strands_module
 
         assert hasattr(strands_module, "__all__")
-        assert "AgentControlHook" in strands_module.__all__
+        assert "AgentControlPlugin" in strands_module.__all__
         assert "AgentControlSteeringHandler" in strands_module.__all__
         assert len(strands_module.__all__) == 2
 
 
 def test_lazy_import_agent_control_hook():
-    """Test lazy import of AgentControlHook via __getattr__."""
+    """Test lazy import of AgentControlPlugin via __getattr__."""
     # The lazy import mechanism should work without explicit mocking
     # since strands-agents is installed in dev dependencies
-    from agent_control.integrations.strands import AgentControlHook
+    from agent_control.integrations.strands import AgentControlPlugin
 
     # Verify it's the correct class
-    assert AgentControlHook.__name__ == "AgentControlHook"
-    assert hasattr(AgentControlHook, "__init__")
+    assert AgentControlPlugin.__name__ == "AgentControlPlugin"
+    assert hasattr(AgentControlPlugin, "__init__")
 
 
 def test_lazy_import_agent_control_steering_handler():

--- a/sdks/python/tests/test_strands_plugin.py
+++ b/sdks/python/tests/test_strands_plugin.py
@@ -16,6 +16,7 @@ def mock_strands_modules():
         {
             "strands": MagicMock(),
             "strands.hooks": MagicMock(),
+            "strands.plugins": MagicMock(),
         },
     ):
         yield
@@ -31,8 +32,7 @@ def mock_event_classes():
     AfterToolCallEvent = type("AfterToolCallEvent", (), {})  # noqa: N806
     BeforeNodeCallEvent = type("BeforeNodeCallEvent", (), {})  # noqa: N806
     AfterNodeCallEvent = type("AfterNodeCallEvent", (), {})  # noqa: N806
-    HookProvider = type("HookProvider", (), {"__init__": lambda self: None})  # noqa: N806
-    HookRegistry = type("HookRegistry", (), {})  # noqa: N806
+    Plugin = type("Plugin", (), {"__init__": lambda self: None})  # noqa: N806
 
     return {
         "BeforeInvocationEvent": BeforeInvocationEvent,
@@ -42,31 +42,32 @@ def mock_event_classes():
         "AfterToolCallEvent": AfterToolCallEvent,
         "BeforeNodeCallEvent": BeforeNodeCallEvent,
         "AfterNodeCallEvent": AfterNodeCallEvent,
-        "HookProvider": HookProvider,
-        "HookRegistry": HookRegistry,
+        "Plugin": Plugin,
     }
 
 
 @pytest.fixture
 def agent_control_hook(mock_strands_modules, mock_event_classes):
-    """Create an AgentControlHook instance with mocked dependencies."""
+    """Create an AgentControlPlugin instance with mocked dependencies."""
     import importlib
     import sys
-    import agent_control.integrations.strands.hook as hook_module
+    import agent_control.integrations.strands.plugin as plugin_module
 
     hooks_mod = sys.modules["strands.hooks"]
     for name, cls in mock_event_classes.items():
         setattr(hooks_mod, name, cls)
 
-    importlib.reload(hook_module)
-    AgentControlHook = hook_module.AgentControlHook
+    plugins_mod = sys.modules["strands.plugins"]
+    plugins_mod.Plugin = mock_event_classes["Plugin"]
 
-    return AgentControlHook(agent_name="test-agent")
+    importlib.reload(plugin_module)
+
+    return plugin_module.AgentControlPlugin(agent_name="test-agent")
 
 
 def test_action_error_with_deny_match():
     """Test _action_error returns deny error for deny action."""
-    from agent_control.integrations.strands.hook import _action_error
+    from agent_control.integrations.strands.plugin import _action_error
 
     # Create a mock match with deny action
     mock_match = MagicMock()
@@ -88,7 +89,7 @@ def test_action_error_with_deny_match():
 
 def test_action_error_with_steer_match():
     """Test _action_error returns steer error for steer action."""
-    from agent_control.integrations.strands.hook import _action_error
+    from agent_control.integrations.strands.plugin import _action_error
 
     # Create a mock match with steer action
     mock_match = MagicMock()
@@ -110,7 +111,7 @@ def test_action_error_with_steer_match():
 
 def test_action_error_with_no_blocking_match():
     """Test _action_error returns None when no blocking matches."""
-    from agent_control.integrations.strands.hook import _action_error
+    from agent_control.integrations.strands.plugin import _action_error
 
     # Create a mock match with allow action
     mock_match = MagicMock()
@@ -125,7 +126,7 @@ def test_action_error_with_no_blocking_match():
 
 def test_action_error_with_empty_matches():
     """Test _action_error returns None with empty matches."""
-    from agent_control.integrations.strands.hook import _action_error
+    from agent_control.integrations.strands.plugin import _action_error
 
     result = MagicMock(spec=EvaluationResult)
     result.matches = []
@@ -135,7 +136,7 @@ def test_action_error_with_empty_matches():
 
 def test_action_error_with_none_matches():
     """Test _action_error returns None with None matches."""
-    from agent_control.integrations.strands.hook import _action_error
+    from agent_control.integrations.strands.plugin import _action_error
 
     result = MagicMock(spec=EvaluationResult)
     result.matches = None
@@ -145,7 +146,7 @@ def test_action_error_with_none_matches():
 
 def test_action_error_deny_takes_precedence():
     """Test deny takes precedence over steer regardless of order."""
-    from agent_control.integrations.strands.hook import _action_error
+    from agent_control.integrations.strands.plugin import _action_error
     from agent_control import ControlViolationError
 
     deny = MagicMock()
@@ -175,7 +176,7 @@ def test_action_error_deny_takes_precedence():
 @pytest.mark.asyncio
 async def test_evaluate_and_enforce_safe_result(agent_control_hook):
     """Test _evaluate_and_enforce with safe result."""
-    with patch("agent_control.integrations.strands.hook.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
+    with patch("agent_control.integrations.strands.plugin.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
         # Mock a safe result
         mock_result = MagicMock(spec=EvaluationResult)
         mock_result.is_safe = True
@@ -195,7 +196,7 @@ async def test_evaluate_and_enforce_safe_result(agent_control_hook):
 @pytest.mark.asyncio
 async def test_evaluate_and_enforce_with_errors(agent_control_hook):
     """Test _evaluate_and_enforce fails closed on evaluation errors."""
-    with patch("agent_control.integrations.strands.hook.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
+    with patch("agent_control.integrations.strands.plugin.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
         mock_error = MagicMock()
         mock_error.control_name = "error-control"
 
@@ -217,7 +218,7 @@ async def test_evaluate_and_enforce_with_errors(agent_control_hook):
 @pytest.mark.asyncio
 async def test_evaluate_and_enforce_with_deny(agent_control_hook):
     """Test _evaluate_and_enforce raises error on deny action."""
-    with patch("agent_control.integrations.strands.hook.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
+    with patch("agent_control.integrations.strands.plugin.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
         from agent_control import ControlViolationError
 
         # Mock a deny result
@@ -244,7 +245,7 @@ async def test_evaluate_and_enforce_with_deny(agent_control_hook):
 @pytest.mark.asyncio
 async def test_evaluate_and_enforce_with_steer(agent_control_hook):
     """Test _evaluate_and_enforce raises error on steer action."""
-    with patch("agent_control.integrations.strands.hook.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
+    with patch("agent_control.integrations.strands.plugin.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
         from agent_control import ControlSteerError
 
         # Mock a steer result
@@ -280,7 +281,7 @@ async def test_evaluate_and_enforce_with_steer(agent_control_hook):
 @pytest.mark.asyncio
 async def test_evaluate_and_enforce_unsafe_result(agent_control_hook):
     """Test _evaluate_and_enforce raises error on unsafe result."""
-    with patch("agent_control.integrations.strands.hook.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
+    with patch("agent_control.integrations.strands.plugin.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
         from agent_control import ControlViolationError
 
         # Mock an unsafe result
@@ -355,7 +356,7 @@ def test_extract_content_text_with_empty_content(agent_control_hook):
 
 def test_extract_tool_data_before_tool(agent_control_hook):
     """Test _extract_tool_data with BeforeToolCallEvent."""
-    from agent_control.integrations.strands.hook import BeforeToolCallEvent
+    from agent_control.integrations.strands.plugin import BeforeToolCallEvent
 
     # Create a mock with the right spec so isinstance works
     event = MagicMock(spec=BeforeToolCallEvent)
@@ -371,7 +372,7 @@ def test_extract_tool_data_before_tool(agent_control_hook):
 
 def test_extract_tool_data_after_tool_success(agent_control_hook):
     """Test _extract_tool_data with AfterToolCallEvent (success)."""
-    from agent_control.integrations.strands.hook import AfterToolCallEvent
+    from agent_control.integrations.strands.plugin import AfterToolCallEvent
 
     # Create a mock with the right spec so isinstance works
     event = MagicMock(spec=AfterToolCallEvent)
@@ -389,7 +390,7 @@ def test_extract_tool_data_after_tool_success(agent_control_hook):
 
 def test_extract_tool_data_after_tool_error(agent_control_hook):
     """Test _extract_tool_data with AfterToolCallEvent (error)."""
-    from agent_control.integrations.strands.hook import AfterToolCallEvent
+    from agent_control.integrations.strands.plugin import AfterToolCallEvent
 
     # Create a mock with the right spec so isinstance works
     event = MagicMock(spec=AfterToolCallEvent)
@@ -407,10 +408,10 @@ def test_extract_tool_data_after_tool_error(agent_control_hook):
 
 
 def test_hook_initialization():
-    """Test AgentControlHook initialization."""
-    from agent_control.integrations.strands.hook import AgentControlHook
+    """Test AgentControlPlugin initialization."""
+    from agent_control.integrations.strands.plugin import AgentControlPlugin
 
-    hook = AgentControlHook(
+    hook = AgentControlPlugin(
         agent_name="test-agent",
         event_control_list=None,
         on_violation_callback=None,
@@ -424,11 +425,11 @@ def test_hook_initialization():
 
 
 def test_hook_with_callback():
-    """Test AgentControlHook with violation callback."""
-    from agent_control.integrations.strands.hook import AgentControlHook
+    """Test AgentControlPlugin with violation callback."""
+    from agent_control.integrations.strands.plugin import AgentControlPlugin
 
     callback = MagicMock()
-    hook = AgentControlHook(
+    hook = AgentControlPlugin(
         agent_name="test-agent",
         on_violation_callback=callback
     )
@@ -524,7 +525,7 @@ def test_extract_user_message_no_user_role(agent_control_hook):
 @pytest.mark.asyncio
 async def test_evaluate_and_enforce_unsafe_no_reason_with_match(agent_control_hook):
     """Test _evaluate_and_enforce with unsafe result, no reason, but has match."""
-    with patch("agent_control.integrations.strands.hook.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
+    with patch("agent_control.integrations.strands.plugin.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
         from agent_control import ControlViolationError
 
         # Mock an unsafe result with no reason but with a match that has a message
@@ -553,44 +554,44 @@ async def test_evaluate_and_enforce_unsafe_no_reason_with_match(agent_control_ho
 
 
 def test_register_hooks_with_custom_event_list(mock_strands_modules, mock_event_classes):
-    """Test register_hooks with custom event_control_list."""
-    with patch("agent_control.integrations.strands.hook.BeforeInvocationEvent", mock_event_classes["BeforeInvocationEvent"]):  # noqa: E501
-        with patch("agent_control.integrations.strands.hook.BeforeModelCallEvent", mock_event_classes["BeforeModelCallEvent"]):  # noqa: E501
-            with patch("agent_control.integrations.strands.hook.BeforeToolCallEvent", mock_event_classes["BeforeToolCallEvent"]):  # noqa: E501
-                with patch("agent_control.integrations.strands.hook.AfterToolCallEvent", mock_event_classes["AfterToolCallEvent"]):  # noqa: E501
-                    with patch("agent_control.integrations.strands.hook.AfterModelCallEvent", mock_event_classes["AfterModelCallEvent"]):  # noqa: E501
-                        with patch("agent_control.integrations.strands.hook.BeforeNodeCallEvent", mock_event_classes["BeforeNodeCallEvent"]):  # noqa: E501
-                            with patch("agent_control.integrations.strands.hook.AfterNodeCallEvent", mock_event_classes["AfterNodeCallEvent"]):  # noqa: E501
-                                with patch("agent_control.integrations.strands.hook.HookProvider", mock_event_classes["HookProvider"]):  # noqa: E501
-                                    from agent_control.integrations.strands.hook import (
-                                        AgentControlHook,
+    """Test init_agent with custom event_control_list."""
+    with patch("agent_control.integrations.strands.plugin.BeforeInvocationEvent", mock_event_classes["BeforeInvocationEvent"]):  # noqa: E501
+        with patch("agent_control.integrations.strands.plugin.BeforeModelCallEvent", mock_event_classes["BeforeModelCallEvent"]):  # noqa: E501
+            with patch("agent_control.integrations.strands.plugin.BeforeToolCallEvent", mock_event_classes["BeforeToolCallEvent"]):  # noqa: E501
+                with patch("agent_control.integrations.strands.plugin.AfterToolCallEvent", mock_event_classes["AfterToolCallEvent"]):  # noqa: E501
+                    with patch("agent_control.integrations.strands.plugin.AfterModelCallEvent", mock_event_classes["AfterModelCallEvent"]):  # noqa: E501
+                        with patch("agent_control.integrations.strands.plugin.BeforeNodeCallEvent", mock_event_classes["BeforeNodeCallEvent"]):  # noqa: E501
+                            with patch("agent_control.integrations.strands.plugin.AfterNodeCallEvent", mock_event_classes["AfterNodeCallEvent"]):  # noqa: E501
+                                with patch("agent_control.integrations.strands.plugin.Plugin", mock_event_classes["Plugin"]):  # noqa: E501
+                                    from agent_control.integrations.strands.plugin import (
+                                        AgentControlPlugin,
                                         BeforeModelCallEvent,
                                         AfterModelCallEvent,
                                     )
 
                                     # Create hook with custom event list
-                                    hook = AgentControlHook(
+                                    hook = AgentControlPlugin(
                                         agent_name="test-agent",
                                         event_control_list=[BeforeModelCallEvent, AfterModelCallEvent],
                                         enable_logging=True
                                     )
 
-                                    # Create mock registry with add_callback method
-                                    registry = MagicMock()
-                                    registry.add_callback = MagicMock()
+                                    # Create mock agent with add_hook method
+                                    mock_agent = MagicMock()
+                                    mock_agent.add_hook = MagicMock()
 
-                                    # Register hooks
-                                    hook.register_hooks(registry)
+                                    # Register hooks via init_agent
+                                    hook.init_agent(mock_agent)
 
                                     # Verify only specified events were registered
-                                    assert registry.add_callback.call_count == 2
+                                    assert mock_agent.add_hook.call_count == 2
 
 
 @pytest.mark.asyncio
 async def test_check_before_invocation(agent_control_hook):
     """Test check_before_invocation hook."""
-    with patch("agent_control.integrations.strands.hook.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
-        from agent_control.integrations.strands.hook import BeforeInvocationEvent
+    with patch("agent_control.integrations.strands.plugin.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
+        from agent_control.integrations.strands.plugin import BeforeInvocationEvent
 
         mock_result = MagicMock(spec=EvaluationResult)
         mock_result.is_safe = True
@@ -609,8 +610,8 @@ async def test_check_before_invocation(agent_control_hook):
 @pytest.mark.asyncio
 async def test_check_before_model(agent_control_hook):
     """Test check_before_model hook."""
-    with patch("agent_control.integrations.strands.hook.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
-        from agent_control.integrations.strands.hook import BeforeModelCallEvent
+    with patch("agent_control.integrations.strands.plugin.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
+        from agent_control.integrations.strands.plugin import BeforeModelCallEvent
 
         mock_result = MagicMock(spec=EvaluationResult)
         mock_result.is_safe = True
@@ -629,8 +630,8 @@ async def test_check_before_model(agent_control_hook):
 @pytest.mark.asyncio
 async def test_check_after_model(agent_control_hook):
     """Test check_after_model hook."""
-    with patch("agent_control.integrations.strands.hook.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
-        from agent_control.integrations.strands.hook import AfterModelCallEvent
+    with patch("agent_control.integrations.strands.plugin.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
+        from agent_control.integrations.strands.plugin import AfterModelCallEvent
 
         mock_result = MagicMock(spec=EvaluationResult)
         mock_result.is_safe = True
@@ -656,8 +657,8 @@ async def test_check_after_model(agent_control_hook):
 @pytest.mark.asyncio
 async def test_check_before_tool(agent_control_hook):
     """Test check_before_tool hook."""
-    with patch("agent_control.integrations.strands.hook.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
-        from agent_control.integrations.strands.hook import BeforeToolCallEvent
+    with patch("agent_control.integrations.strands.plugin.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
+        from agent_control.integrations.strands.plugin import BeforeToolCallEvent
 
         mock_result = MagicMock(spec=EvaluationResult)
         mock_result.is_safe = True
@@ -678,8 +679,8 @@ async def test_check_before_tool(agent_control_hook):
 @pytest.mark.asyncio
 async def test_check_after_tool(agent_control_hook):
     """Test check_after_tool hook."""
-    with patch("agent_control.integrations.strands.hook.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
-        from agent_control.integrations.strands.hook import AfterToolCallEvent
+    with patch("agent_control.integrations.strands.plugin.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
+        from agent_control.integrations.strands.plugin import AfterToolCallEvent
 
         mock_result = MagicMock(spec=EvaluationResult)
         mock_result.is_safe = True
@@ -702,8 +703,8 @@ async def test_check_after_tool(agent_control_hook):
 @pytest.mark.asyncio
 async def test_check_before_node(agent_control_hook):
     """Test check_before_node hook."""
-    with patch("agent_control.integrations.strands.hook.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
-        from agent_control.integrations.strands.hook import BeforeNodeCallEvent
+    with patch("agent_control.integrations.strands.plugin.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
+        from agent_control.integrations.strands.plugin import BeforeNodeCallEvent
 
         mock_result = MagicMock(spec=EvaluationResult)
         mock_result.is_safe = True
@@ -723,8 +724,8 @@ async def test_check_before_node(agent_control_hook):
 @pytest.mark.asyncio
 async def test_check_after_node(agent_control_hook):
     """Test check_after_node hook."""
-    with patch("agent_control.integrations.strands.hook.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
-        from agent_control.integrations.strands.hook import AfterNodeCallEvent
+    with patch("agent_control.integrations.strands.plugin.agent_control.evaluate_controls") as mock_evaluate:  # noqa: E501
+        from agent_control.integrations.strands.plugin import AfterNodeCallEvent
 
         mock_result = MagicMock(spec=EvaluationResult)
         mock_result.is_safe = True
@@ -744,7 +745,7 @@ async def test_check_after_node(agent_control_hook):
 
 def test_extract_tool_data_no_selected_tool(agent_control_hook):
     """Test _extract_tool_data when selected_tool is None."""
-    from agent_control.integrations.strands.hook import BeforeToolCallEvent
+    from agent_control.integrations.strands.plugin import BeforeToolCallEvent
 
     event = MagicMock(spec=BeforeToolCallEvent)
     event.selected_tool = None
@@ -810,7 +811,7 @@ def test_extract_content_text_with_unknown_type(agent_control_hook):
 
 def test_extract_messages_before_model_with_input(agent_control_hook):
     """Test _extract_messages with BeforeModelCallEvent using input field."""
-    from agent_control.integrations.strands.hook import BeforeModelCallEvent
+    from agent_control.integrations.strands.plugin import BeforeModelCallEvent
 
     event = MagicMock(spec=BeforeModelCallEvent)
     event.invocation_state = {"input": "direct input text"}
@@ -823,7 +824,7 @@ def test_extract_messages_before_model_with_input(agent_control_hook):
 
 def test_extract_messages_after_model_no_response(agent_control_hook):
     """Test _extract_messages with AfterModelCallEvent when stop_response is None."""
-    from agent_control.integrations.strands.hook import AfterModelCallEvent
+    from agent_control.integrations.strands.plugin import AfterModelCallEvent
 
     event = MagicMock(spec=AfterModelCallEvent)
     event.stop_response = None
@@ -837,7 +838,7 @@ def test_extract_messages_after_model_no_response(agent_control_hook):
 
 def test_extract_messages_after_model_missing_invocation_state(agent_control_hook):
     """Test _extract_messages handles missing invocation_state."""
-    from agent_control.integrations.strands.hook import AfterModelCallEvent
+    from agent_control.integrations.strands.plugin import AfterModelCallEvent
 
     event = MagicMock(spec=AfterModelCallEvent)
     event.stop_response = None
@@ -851,7 +852,7 @@ def test_extract_messages_after_model_missing_invocation_state(agent_control_hoo
 
 def test_extract_messages_after_model_with_response(agent_control_hook):
     """Test _extract_messages with AfterModelCallEvent when stop_response exists."""
-    from agent_control.integrations.strands.hook import AfterModelCallEvent
+    from agent_control.integrations.strands.plugin import AfterModelCallEvent
 
     event = MagicMock(spec=AfterModelCallEvent)
     event.stop_response = MagicMock()
@@ -866,7 +867,7 @@ def test_extract_messages_after_model_with_response(agent_control_hook):
 
 def test_extract_messages_after_model_with_input_field(agent_control_hook):
     """Test _extract_messages with AfterModelCallEvent using input field."""
-    from agent_control.integrations.strands.hook import AfterModelCallEvent
+    from agent_control.integrations.strands.plugin import AfterModelCallEvent
 
     event = MagicMock(spec=AfterModelCallEvent)
     event.stop_response = MagicMock()
@@ -881,7 +882,7 @@ def test_extract_messages_after_model_with_input_field(agent_control_hook):
 
 def test_extract_messages_before_node_with_input(agent_control_hook):
     """Test _extract_messages with BeforeNodeCallEvent using input field."""
-    from agent_control.integrations.strands.hook import BeforeNodeCallEvent
+    from agent_control.integrations.strands.plugin import BeforeNodeCallEvent
 
     event = MagicMock(spec=BeforeNodeCallEvent)
     event.invocation_state = {"input": "node input"}
@@ -894,7 +895,7 @@ def test_extract_messages_before_node_with_input(agent_control_hook):
 
 def test_extract_messages_after_node_with_result(agent_control_hook):
     """Test _extract_messages with AfterNodeCallEvent using result field."""
-    from agent_control.integrations.strands.hook import AfterNodeCallEvent
+    from agent_control.integrations.strands.plugin import AfterNodeCallEvent
 
     event = MagicMock(spec=AfterNodeCallEvent)
     event.invocation_state = {"result": "node result", "input": "node input"}
@@ -907,7 +908,7 @@ def test_extract_messages_after_node_with_result(agent_control_hook):
 
 def test_extract_messages_after_node_with_response(agent_control_hook):
     """Test _extract_messages with AfterNodeCallEvent using response field."""
-    from agent_control.integrations.strands.hook import AfterNodeCallEvent
+    from agent_control.integrations.strands.plugin import AfterNodeCallEvent
 
     event = MagicMock(spec=AfterNodeCallEvent)
     event.invocation_state = {"response": "node response"}
@@ -920,7 +921,7 @@ def test_extract_messages_after_node_with_response(agent_control_hook):
 
 def test_extract_messages_after_node_with_messages(agent_control_hook):
     """Test _extract_messages with AfterNodeCallEvent using messages field."""
-    from agent_control.integrations.strands.hook import AfterNodeCallEvent
+    from agent_control.integrations.strands.plugin import AfterNodeCallEvent
 
     event = MagicMock(spec=AfterNodeCallEvent)
     # When messages is in the state, it's treated as content to extract


### PR DESCRIPTION


## Summary

Migrate the strands integration from a HookProvider -> Plugin. Strands SDK created `Plugin` as a higher-level abstraction to provide a more fluent devx - to that end, migrate to a Plugin model instead of a Hook

## Scope
- User-facing/API changes: Usage of the hook provider differs from that of a Plugin, but this is yet to be released

## Risk and Rollout
- Risk level: low
- Rollback plan: Revert

## Testing
- [X] Added or updated automated tests
- [X] Ran `make check` (or explained why not) - `tests/test_evaluator_configs.py::test_update_evaluator_config_replaces_fields_and_updates_timestamp` failed but I think it's flaky and unrelated
- [X] Manually verified behavior

## Checklist
- [ ] Linked issue/spec (if applicable)
- [X] Updated docs/examples for user-facing changes
- [ ] Included any required follow-up tasks
