### PR TITLE
docs(examples): add Google ADK examples to README index

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Explore real-world integrations with popular agent frameworks, or jump to [Quick
 - **[Galileo Luna-2 Integration](examples/galileo/)** — Toxicity detection and content moderation with Galileo Protect
 
 ### Framework integrations
+- **[Google ADK Callbacks](examples/google_adk_callbacks/)** — Model and tool guardrails via ADK's native callback hooks
+- **[Google ADK Decorator](examples/google_adk_decorator/)** — `@control()` decorator pattern for ADK tool protection
 - **[LangChain](examples/langchain/)** — Protect a SQL agent from dangerous queries with server-side controls
 - **[CrewAI](examples/crewai/)** — Combine Agent Control security controls with CrewAI guardrails for customer support
 - **[AWS Strands](examples/strands_agents/)** — Guardrails for AWS Strands agent workflows and tool calls

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,6 +8,8 @@ This directory contains runnable examples for Agent Control. Each example has it
 |:--------|:--------|:-----|
 | Agent Control Demo | End-to-end workflow: create controls, run a controlled agent, update controls dynamically. | https://docs.agentcontrol.dev/examples/agent-control-demo |
 | CrewAI | Combine Agent Control security controls with CrewAI guardrails for customer support. | https://docs.agentcontrol.dev/examples/crewai |
+| Google ADK Callbacks | Model and tool guardrails via ADK's native callback hooks. | https://docs.agentcontrol.dev/examples/google-adk-callbacks |
+| Google ADK Decorator | `@control()` decorator pattern for ADK tool protection. | https://docs.agentcontrol.dev/examples/google-adk-decorator |
 | Customer Support Agent | Enterprise scenario with PII protection, prompt-injection defense, and multiple tools. | https://docs.agentcontrol.dev/examples/customer-support |
 | DeepEval | Build a custom evaluator using DeepEval GEval metrics. | https://docs.agentcontrol.dev/examples/deepeval |
 | Galileo Luna-2 | Toxicity detection and content moderation with Galileo Protect. | https://docs.agentcontrol.dev/examples/galileo-luna2 |

--- a/examples/google_adk_callbacks/README.md
+++ b/examples/google_adk_callbacks/README.md
@@ -1,0 +1,24 @@
+# Google ADK Callbacks
+
+Model and tool guardrails via ADK's native callback hooks.
+
+## What this example shows
+
+- Pre-model prompt injection blocking
+- Pre-tool and post-tool output filtering
+- Fail-closed behavior on server errors
+
+## Quick run
+
+```bash
+# From repo root
+make server-run
+export GOOGLE_API_KEY="your-key-here"
+
+cd examples/google_adk_callbacks
+uv pip install -e . --upgrade
+uv run python setup_controls.py
+uv run adk run my_agent
+```
+
+Full walkthrough: https://docs.agentcontrol.dev/examples/google-adk-callbacks

--- a/examples/google_adk_decorator/README.md
+++ b/examples/google_adk_decorator/README.md
@@ -1,0 +1,24 @@
+# Google ADK Decorator
+
+`@control()` decorator pattern for tool protection inside a Google ADK app.
+
+## What this example shows
+
+- `@control()` on ADK tool functions
+- Automatic step registration from decorators
+- Optional sdk-local execution mode
+
+## Quick run
+
+```bash
+# From repo root
+make server-run
+export GOOGLE_API_KEY="your-key-here"
+
+cd examples/google_adk_decorator
+uv pip install -e . --upgrade
+uv run python setup_controls.py
+uv run adk run my_agent
+```
+
+Full walkthrough: https://docs.agentcontrol.dev/examples/google-adk-decorator


### PR DESCRIPTION
## Summary

- Add trimmed READMEs for `google_adk_callbacks/` and `google_adk_decorator/` matching the minimal format from #66
- Add table rows in `examples/README.md`
- Add entries under "Framework integrations" in root `README.md`

Depends on #69 (already merged to main) for the example directories.

## Test plan

- [ ] Verify links resolve after #66 merges to main (which includes #69's directories)
- [ ] Confirm docs URLs are created on docs.agentcontrol.dev