### PR TITLE
fix(infra): fix docker compose to make ui work

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -101,7 +101,7 @@ jobs:
         with:
           context: ui
           file: ui/Dockerfile
-          platforms: linux/amd64  # Build only for Intel to keep UI image CI fast
+          platforms: linux/amd64,linux/arm64  # Build for both Intel and Apple Silicon
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,6 @@ services:
 
   ui:
     image: galileoai/agent-control-ui:latest
-    platform: linux/amd64
     container_name: agent_control_ui
     ports:
       - "4000:4000"


### PR DESCRIPTION
## Summary
- What changed and why.
   Docker compose was pulling ui from local. Updated to use the image from docker repository

## Scope
- User-facing/API changes:
- Internal changes:
- Out of scope:

## Risk and Rollout
- Risk level: low / medium / high
- Rollback plan:

## Testing
- [ ] Added or updated automated tests
- [ ] Ran `make check` (or explained why not)
- [ ] Manually verified behavior

## Checklist
- [ ] Linked issue/spec (if applicable)
- [ ] Updated docs/examples for user-facing changes
- [ ] Included any required follow-up tasks
