### PR TITLE
fix(sdk): bundle evaluators in sdk wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ build-server:
 	cd $(SERVER_DIR) && uv build
 
 build-sdk:
-	cd $(SDK_DIR) && uv build
+	uv run python scripts/build.py sdk
 
 publish: publish-models publish-server publish-sdk engine-publish
 
@@ -134,7 +134,7 @@ publish-models:
 publish-server:
 	cd $(SERVER_DIR) && uv publish
 
-publish-sdk:
+publish-sdk: build-sdk
 	cd $(SDK_DIR) && uv publish
 
 # ---------------------------

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -2,8 +2,8 @@
 """Build packages for PyPI distribution.
 
 This script builds all publishable packages. For SDK and server, it copies internal
-packages (models, engine) into the source directories before building, then cleans up
-afterward. This allows the published wheels to be self-contained.
+packages into the source directories before building, then cleans up afterward. This
+allows the published wheels to be self-contained.
 
 Usage:
     python scripts/build.py [models|evaluators|sdk|server|galileo|all]
@@ -81,7 +81,7 @@ def build_sdk() -> None:
     print(f"Building agent-control-sdk v{version}")
 
     # Clean previous builds and vendored code
-    for pkg in ["agent_control_models", "agent_control_engine"]:
+    for pkg in ["agent_control_models", "agent_control_engine", "agent_control_evaluators"]:
         target = sdk_src / pkg
         if target.exists():
             shutil.rmtree(target)
@@ -99,6 +99,10 @@ def build_sdk() -> None:
         ROOT / "engine" / "src" / "agent_control_engine",
         sdk_src / "agent_control_engine",
     )
+    shutil.copytree(
+        ROOT / "evaluators" / "builtin" / "src" / "agent_control_evaluators",
+        sdk_src / "agent_control_evaluators",
+    )
 
     # Inject bundle metadata for conflict detection
     inject_bundle_metadata(
@@ -111,6 +115,11 @@ def build_sdk() -> None:
         "agent-control-sdk",
         version,
     )
+    inject_bundle_metadata(
+        sdk_src / "agent_control_evaluators" / "__init__.py",
+        "agent-control-sdk",
+        version,
+    )
 
     # Set version
     set_package_version(sdk_dir / "pyproject.toml", version)
@@ -120,7 +129,7 @@ def build_sdk() -> None:
         print(f"  Built agent-control-sdk v{version}")
     finally:
         # Clean up vendored code (don't commit it)
-        for pkg in ["agent_control_models", "agent_control_engine"]:
+        for pkg in ["agent_control_models", "agent_control_engine", "agent_control_evaluators"]:
             target = sdk_src / pkg
             if target.exists():
                 shutil.rmtree(target)

--- a/sdks/python/Makefile
+++ b/sdks/python/Makefile
@@ -43,7 +43,8 @@ typecheck:
 	uv run mypy --config-file ../../pyproject.toml src/
 
 build:
-	uv build
+	uv run python ../../scripts/build.py sdk
 
 publish:
+	$(MAKE) build
 	uv publish

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -3,17 +3,16 @@ name = "agent-control-sdk"
 version = "6.6.0"
 description = "Python SDK for Agent Control - protect your AI agents with controls"
 requires-python = ">=3.12"
-# Note: agent-control-models and agent-control-engine are bundled at build time
-# Note: agent-control-evaluators is a runtime dependency (NOT vendored) to avoid
-#       duplicate module conflict when galileo extras are installed
+# Note: agent-control-models, agent-control-engine, and agent-control-evaluators
+# are bundled at build time for self-contained SDK wheels.
 dependencies = [
     "httpx>=0.26.0",
     "pydantic>=2.5.0",
     "pydantic-settings>=2.0.0",  # For typed configuration via environment variables
     "docstring-parser>=0.15",  # For @tool decorator schema inference
-    "google-re2>=1.1",  # For engine (bundled)
-    "jsonschema>=4.0.0",  # For models/engine (bundled)
-    "agent-control-evaluators>=3.0.0",  # NOT vendored - avoid conflict with galileo
+    "google-re2>=1.1",  # For engine/evaluators (bundled)
+    "jsonschema>=4.0.0",  # For models/engine/evaluators (bundled)
+    "sqlglot[c]>=29.0.0,<29.1.0",  # For bundled SQL evaluator
 ]
 authors = [
     {name = "Agent Control Team"}
@@ -56,8 +55,13 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-# Note: agent_control_models and agent_control_engine are copied by scripts/build.py
-packages = ["src/agent_control", "src/agent_control_models", "src/agent_control_engine"]
+# Note: vendored packages are copied by scripts/build.py before building.
+packages = [
+    "src/agent_control",
+    "src/agent_control_models",
+    "src/agent_control_engine",
+    "src/agent_control_evaluators",
+]
 
 [tool.ruff]
 line-length = 100

--- a/sdks/python/tests/test_packaging.py
+++ b/sdks/python/tests/test_packaging.py
@@ -1,0 +1,40 @@
+"""Packaging regression tests for the published SDK wheel."""
+
+from __future__ import annotations
+
+import subprocess
+import zipfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SDK_DIR = ROOT / "sdks" / "python"
+SDK_SRC = SDK_DIR / "src"
+DIST_DIR = SDK_DIR / "dist"
+
+
+def test_sdk_wheel_bundles_engine_and_evaluators() -> None:
+    """The SDK wheel should vendor engine and evaluator source packages."""
+    subprocess.run(["make", "build-sdk"], cwd=ROOT, check=True)
+
+    wheels = sorted(DIST_DIR.glob("agent_control_sdk-*.whl"))
+    assert wheels, "Expected make build-sdk to produce a wheel"
+
+    wheel_path = max(wheels, key=lambda path: path.stat().st_mtime)
+    with zipfile.ZipFile(wheel_path) as wheel:
+        names = set(wheel.namelist())
+
+        assert "agent_control_engine/__init__.py" in names
+        assert "agent_control_evaluators/__init__.py" in names
+
+        engine_init = wheel.read("agent_control_engine/__init__.py").decode()
+        evaluators_init = wheel.read("agent_control_evaluators/__init__.py").decode()
+        assert '__bundled_by__ = "agent-control-sdk"' in engine_init
+        assert '__bundled_by__ = "agent-control-sdk"' in evaluators_init
+
+        metadata_name = next(name for name in names if name.endswith(".dist-info/METADATA"))
+        metadata = wheel.read(metadata_name).decode()
+        assert "Requires-Dist: agent-control-evaluators" not in metadata
+
+    assert not (SDK_SRC / "agent_control_engine").exists()
+    assert not (SDK_SRC / "agent_control_evaluators").exists()


### PR DESCRIPTION
## Summary
- vendor `agent_control_evaluators` into the SDK wheel alongside the bundled models and engine packages
- route `make build-sdk` and `sdks/python/Makefile` builds through `scripts/build.py sdk` so the standard build path produces the vendored wheel
- remove the standalone `agent-control-evaluators` runtime dependency from the SDK package metadata and add a regression test that inspects the built wheel contents

## Validation
- `make build-sdk`
- `uv run --package agent-control-sdk pytest sdks/python/tests/test_packaging.py sdks/python/tests/test_evaluators.py -q`