### PR TITLE
feat(docs): simplify README for faster quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.12+-blue.svg" alt="Python 3.12+" /></a>
   <a href="https://pypi.org/project/agent-control-sdk/"><img src="https://img.shields.io/pypi/v/agent-control-sdk.svg" alt="PyPI version" /></a>
   <a href="https://www.npmjs.com/package/agent-control"><img src="https://img.shields.io/npm/v/agent-control.svg" alt="npm version" /></a>
+  <a href="https://github.com/agentcontrol/agent-control/actions/workflows/ci.yml"><img src="https://github.com/agentcontrol/agent-control/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="https://codecov.io/gh/agentcontrol/agent-control"><img src="https://codecov.io/gh/agentcontrol/agent-control/branch/main/graph/badge.svg" alt="codecov" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- Restructure README so users reach working code in the first scroll
- Add quick-link navigation bar (Docs, Quickstart, Examples, Slack)
- Condense marketing sections (Why, Key Features, Performance) into 4 concise bullets - detailed content remains in docs
- Trim code example to essentials, note alternative integration paths (callbacks, direct SDK, TypeScript)
- Replace categorized examples list with compact table
- ~300 lines down to ~100 lines

## Test plan
- [ ] Verify README renders correctly on GitHub (links, table, badges, images)
- [ ] Confirm all example links resolve
- [ ] Check quick-link URLs work (docs site, Slack invite)