### PR TITLE
fix(server): escape ILIKE pattern in evaluator-configs list endpoint

### DIFF
--- a/server/src/agent_control_server/endpoints/evaluator_configs.py
+++ b/server/src/agent_control_server/endpoints/evaluator_configs.py
@@ -24,6 +24,7 @@ from ..errors import APIValidationError, ConflictError, DatabaseError, NotFoundE
 from ..logging_utils import get_logger
 from ..models import EvaluatorConfigDB
 from ..services.evaluator_utils import is_agent_scoped
+from ..services.query_utils import escape_like_pattern
 
 _logger = get_logger(__name__)
 
@@ -224,7 +225,9 @@ async def list_evaluator_configs(
         query = query.where(EvaluatorConfigDB.id < cursor)
 
     if name is not None:
-        query = query.where(EvaluatorConfigDB.name.ilike(f"%{name}%"))
+        query = query.where(
+            EvaluatorConfigDB.name.ilike(f"%{escape_like_pattern(name)}%", escape="\\")
+        )
 
     if evaluator is not None:
         query = query.where(EvaluatorConfigDB.evaluator == evaluator)
@@ -235,7 +238,9 @@ async def list_evaluator_configs(
 
     total_query = select(func.count()).select_from(EvaluatorConfigDB)
     if name is not None:
-        total_query = total_query.where(EvaluatorConfigDB.name.ilike(f"%{name}%"))
+        total_query = total_query.where(
+            EvaluatorConfigDB.name.ilike(f"%{escape_like_pattern(name)}%", escape="\\")
+        )
     if evaluator is not None:
         total_query = total_query.where(EvaluatorConfigDB.evaluator == evaluator)
     total_result = await db.execute(total_query)

--- a/server/tests/test_evaluator_configs.py
+++ b/server/tests/test_evaluator_configs.py
@@ -638,3 +638,22 @@ def test_create_evaluator_config_empty_config_allowed(client: TestClient) -> Non
     assert resp.status_code == 201
     data = resp.json()
     assert data["config"] == {}
+
+
+def test_list_evaluator_configs_name_filter_escapes_like_wildcards(
+    client: TestClient,
+) -> None:
+    # Given: configs where one name contains a literal underscore
+    base = f"config-{uuid.uuid4().hex}"
+    _create_config(client, name=f"{base}_special")
+    _create_config(client, name=f"{base}Xnomatch")
+
+    # When: searching with "_" which is a LIKE wildcard for "any single character"
+    resp = client.get("/api/v1/evaluator-configs", params={"name": f"{base}_"})
+
+    # Then: only the config with a literal underscore matches, not the one with "X"
+    assert resp.status_code == 200
+    data = resp.json()
+    names = [cfg["name"] for cfg in data["evaluator_configs"]]
+    assert f"{base}_special" in names
+    assert f"{base}Xnomatch" not in names


### PR DESCRIPTION
The name filter in list_evaluator_configs used raw user input in the
ILIKE pattern, causing SQL wildcards (% and _) in search terms to be
interpreted as pattern characters instead of literals. This is
inconsistent with the agents and controls list endpoints which both
use escape_like_pattern().

Apply the same escaping already used by the other two endpoints.

## Summary
- Escape SQL LIKE wildcards (% and _) in the evaluator-configs list
  endpoint name filter, matching the existing behavior in agents and
  controls list endpoints.

## Scope
- User-facing/API changes: `GET /api/v1/evaluator-configs?name=...`
  now treats `%` and `_` as literal characters instead of SQL wildcards.
- Internal changes: Added `escape_like_pattern` import and applied it
  to both the results query and the total count query in
  `evaluator_configs.py`.
- Out of scope: No changes to agents or controls endpoints (already
  correct).

## Risk and Rollout
- Risk level: low
- Rollback plan: Revert the single commit.

## Testing
- [x] Added or updated automated tests
- [x] Ran `make check` (or explained why not)
- [x] Manually verified behavior

## Checklist
- [ ] Linked issue/spec (if applicable)
- [x] Updated docs/examples for user-facing changes
- [x] Included any required follow-up tasks