### PR TITLE
fix(server): reject empty string list evaluator values

### DIFF
--- a/evaluators/builtin/src/agent_control_evaluators/list/config.py
+++ b/evaluators/builtin/src/agent_control_evaluators/list/config.py
@@ -28,7 +28,7 @@ class ListEvaluatorConfig(EvaluatorConfig):
     @field_validator("values")
     @classmethod
     def validate_values(cls, values: list[str | int | float]) -> list[str | int | float]:
-        """Reject empty-string entries that would compile into a match-all regex."""
-        if any(isinstance(value, str) and value == "" for value in values):
-            raise ValueError("values must not contain empty strings")
+        """Reject blank string entries that would compile into pathological regexes."""
+        if any(isinstance(value, str) and value.strip() == "" for value in values):
+            raise ValueError("values must not contain empty or whitespace-only strings")
         return values

--- a/evaluators/builtin/src/agent_control_evaluators/list/evaluator.py
+++ b/evaluators/builtin/src/agent_control_evaluators/list/evaluator.py
@@ -35,9 +35,9 @@ class ListEvaluator(Evaluator[ListEvaluatorConfig]):
 
     def __init__(self, config: ListEvaluatorConfig) -> None:
         super().__init__(config)
-        # Defensive filtering keeps legacy invalid configs from compiling into match-all regexes.
+        # Defensive filtering keeps legacy invalid configs from compiling into pathological regexes.
         normalized_values = [str(v) for v in config.values]
-        self._values = [value for value in normalized_values if value != ""]
+        self._values = [value for value in normalized_values if value.strip() != ""]
         self._regex: Any = self._build_regex()
 
     def _build_regex(self) -> Any:

--- a/evaluators/builtin/tests/list/test_list.py
+++ b/evaluators/builtin/tests/list/test_list.py
@@ -13,8 +13,20 @@ class TestListEvaluatorConfig:
         """Test that empty-string list entries are rejected at config validation time."""
         # Given: a list evaluator config with an empty-string value
         # When: constructing the config model
-        with pytest.raises(ValidationError, match="values must not contain empty strings"):
+        with pytest.raises(
+            ValidationError, match="values must not contain empty or whitespace-only strings"
+        ):
             ListEvaluatorConfig(values=[""])
+        # Then: validation rejects the config (asserted by pytest)
+
+    def test_whitespace_only_value_rejected(self) -> None:
+        """Test that whitespace-only list entries are rejected at config validation time."""
+        # Given: a list evaluator config with a whitespace-only value
+        # When: constructing the config model
+        with pytest.raises(
+            ValidationError, match="values must not contain empty or whitespace-only strings"
+        ):
+            ListEvaluatorConfig(values=[" "])
         # Then: validation rejects the config (asserted by pytest)
 
 
@@ -38,5 +50,45 @@ class TestListEvaluator:
         result = await evaluator.evaluate("Tell me a joke")
 
         # Then: the evaluator ignores the empty control values
+        assert result.matched is False
+        assert result.message == "Empty control values - control ignored"
+
+    @pytest.mark.asyncio
+    async def test_legacy_whitespace_only_value_is_ignored_defensively(self) -> None:
+        """Test that legacy whitespace-only configs do not compile into pathological regexes."""
+        # Given: a legacy invalid config with a whitespace-only value
+        config = ListEvaluatorConfig.model_construct(
+            values=[" "],
+            logic="any",
+            match_on="match",
+            match_mode="contains",
+            case_sensitive=False,
+        )
+        evaluator = ListEvaluator(config)
+
+        # When: evaluating normal text against the legacy config
+        result = await evaluator.evaluate("Tell me a joke")
+
+        # Then: the evaluator ignores the empty control values
+        assert result.matched is False
+        assert result.message == "Empty control values - control ignored"
+
+    @pytest.mark.asyncio
+    async def test_legacy_empty_string_allowlist_does_not_block_all(self) -> None:
+        """Test that legacy invalid allowlist configs do not block all inputs."""
+        # Given: a legacy invalid allowlist config constructed without validation
+        config = ListEvaluatorConfig.model_construct(
+            values=[""],
+            logic="any",
+            match_on="no_match",
+            match_mode="contains",
+            case_sensitive=False,
+        )
+        evaluator = ListEvaluator(config)
+
+        # When: evaluating normal text against the legacy config
+        result = await evaluator.evaluate("legitimate_value")
+
+        # Then: the evaluator ignores the empty control values instead of blocking all input
         assert result.matched is False
         assert result.message == "Empty control values - control ignored"

--- a/server/tests/test_controls_validation.py
+++ b/server/tests/test_controls_validation.py
@@ -86,15 +86,15 @@ def test_validation_regex_flags_list(client: TestClient):
     assert any("flags" in str(e.get("field", "")) for e in errors)
 
 
-def test_validation_list_values_reject_empty_strings(client: TestClient):
-    """Test that list evaluator config rejects empty-string entries."""
-    # Given: a control and a list evaluator payload with an empty-string value
+def test_validation_list_values_reject_blank_strings(client: TestClient):
+    """Test that list evaluator config rejects empty and whitespace-only entries."""
+    # Given: a control and a list evaluator payload with a whitespace-only value
     control_id = create_control(client)
     payload = VALID_CONTROL_PAYLOAD.copy()
     payload["evaluator"] = {
         "name": "list",
         "config": {
-            "values": [""],
+            "values": [" "],
             "logic": "any",
             "match_on": "match",
             "match_mode": "contains",
@@ -109,7 +109,7 @@ def test_validation_list_values_reject_empty_strings(client: TestClient):
     response_data = resp.json()
     errors = response_data.get("errors", [])
     assert any("values" in str(e.get("field", "")) for e in errors)
-    assert any("empty strings" in e.get("message", "") for e in errors)
+    assert any("empty or whitespace-only strings" in e.get("message", "") for e in errors)
 
 
 def test_validation_invalid_regex_pattern(client: TestClient):

--- a/server/tests/test_evaluator_configs.py
+++ b/server/tests/test_evaluator_configs.py
@@ -142,13 +142,13 @@ def test_create_evaluator_config_invalid_config_422(client: TestClient) -> None:
     assert any("config" in str(err.get("field", "")) for err in data.get("errors", []))
 
 
-def test_create_evaluator_config_rejects_empty_list_values(client: TestClient) -> None:
-    # Given: a payload with an empty-string entry for the list evaluator
+def test_create_evaluator_config_rejects_blank_list_values(client: TestClient) -> None:
+    # Given: a payload with a whitespace-only entry for the list evaluator
     name = f"config-{uuid.uuid4().hex}"
     payload = _create_config_payload(
         name=name,
         evaluator="list",
-        config={"values": [""], "logic": "any", "match_on": "match", "match_mode": "contains"},
+        config={"values": [" "], "logic": "any", "match_on": "match", "match_mode": "contains"},
     )
 
     # When: creating the evaluator config
@@ -159,7 +159,10 @@ def test_create_evaluator_config_rejects_empty_list_values(client: TestClient) -
     data = resp.json()
     assert data["error_code"] == "INVALID_CONFIG"
     assert any("config.values" in str(err.get("field", "")) for err in data.get("errors", []))
-    assert any("empty strings" in err.get("message", "") for err in data.get("errors", []))
+    assert any(
+        "empty or whitespace-only strings" in err.get("message", "")
+        for err in data.get("errors", [])
+    )
 
 
 def test_create_evaluator_config_invalid_parameters_type_error_422(


### PR DESCRIPTION
## Summary
- reject empty-string list entries at list evaluator config validation time
- defensively filter exact empty strings in the evaluator so legacy invalid configs do not compile into a match-all regex
- add evaluator and server regression tests for both validation paths

## Testing
- make evaluators-test
- make server-test
- make lint
- make typecheck

Fixes https://github.com/agentcontrol/agent-control/issues/120
