### PR TITLE
fix(ui): improve edit control ux, no layout shift, consistent spacing

### DIFF
--- a/ui/src/core/page-components/agent-detail/modals/edit-control/evaluator-config-section.tsx
+++ b/ui/src/core/page-components/agent-detail/modals/edit-control/evaluator-config-section.tsx
@@ -113,11 +113,7 @@ export function EvaluatorConfigSection({
         </Group>
       </Group>
       <Paper withBorder radius="sm" p={16}>
-        <ScrollArea
-          h={contentHeight}
-          type="always"
-          offsetScrollbars="y"
-        >
+        <ScrollArea h={contentHeight} type="always" offsetScrollbars="y">
           {configViewMode === 'form' ? (
             FormComponent ? (
               <FormComponent form={evaluatorForm} />

--- a/ui/src/core/page-components/agent-detail/modals/edit-control/evaluator-config-section.tsx
+++ b/ui/src/core/page-components/agent-detail/modals/edit-control/evaluator-config-section.tsx
@@ -1,5 +1,6 @@
 import {
   Anchor,
+  Box,
   Group,
   Paper,
   ScrollArea,
@@ -17,6 +18,7 @@ import { EvaluatorJsonView } from './evaluator-json-view';
 import type { ConfigViewMode } from './types';
 
 const DEFAULT_HEIGHT = 450;
+const CONTENT_MIN_HEIGHT_EXTRA = 60;
 type ValidationStatus = 'idle' | 'validating' | 'valid' | 'invalid';
 
 type EvaluatorConfigSectionProps = {
@@ -91,45 +93,48 @@ export function EvaluatorConfigSection({
             </Group>
           </Anchor>
         </Group>
-        <SegmentedControl
-          value={configViewMode}
-          onChange={handleConfigViewModeChange}
-          disabled={configViewMode === 'json' && !!jsonError}
-          data={[
-            { value: 'form', label: 'Form' },
-            { value: 'json', label: 'JSON' },
-          ]}
-          size="xs"
-        />
-      </Group>
-      {statusLabel ? (
-        <Text size="xs" c={statusColor}>
-          {statusLabel}
-        </Text>
-      ) : null}
-
-      <Paper withBorder radius="sm" p={16}>
-        {configViewMode === 'form' && (
-          <ScrollArea h={height} type="auto">
-            {FormComponent ? (
-              <FormComponent form={evaluatorForm} />
-            ) : (
-              <Text c="dimmed" ta="center" py="xl">
-                No form available for this evaluator. Use JSON view to
-                configure.
-              </Text>
-            )}
-          </ScrollArea>
-        )}
-
-        {configViewMode === 'json' && (
-          <EvaluatorJsonView
-            onValidateConfig={onValidateConfig}
-            onValidationStatusChange={setValidationStatus}
-            height={height}
-            {...jsonViewProps}
+        <Group gap="xs" align="center">
+          {statusLabel ? (
+            <Text size="xs" c={statusColor}>
+              {statusLabel}
+            </Text>
+          ) : null}
+          <SegmentedControl
+            value={configViewMode}
+            onChange={handleConfigViewModeChange}
+            disabled={configViewMode === 'json' && !!jsonError}
+            data={[
+              { value: 'form', label: 'Form' },
+              { value: 'json', label: 'JSON' },
+            ]}
+            size="xs"
           />
-        )}
+        </Group>
+      </Group>
+      <Paper withBorder radius="sm" p={16}>
+        <Box style={{ minHeight: height + CONTENT_MIN_HEIGHT_EXTRA }}>
+          {configViewMode === 'form' && (
+            <ScrollArea h={height} type="auto">
+              {FormComponent ? (
+                <FormComponent form={evaluatorForm} />
+              ) : (
+                <Text c="dimmed" ta="center" py="xl">
+                  No form available for this evaluator. Use JSON view to
+                  configure.
+                </Text>
+              )}
+            </ScrollArea>
+          )}
+
+          {configViewMode === 'json' && (
+            <EvaluatorJsonView
+              onValidateConfig={onValidateConfig}
+              onValidationStatusChange={setValidationStatus}
+              height={height}
+              {...jsonViewProps}
+            />
+          )}
+        </Box>
       </Paper>
     </Stack>
   );

--- a/ui/src/core/page-components/agent-detail/modals/edit-control/evaluator-config-section.tsx
+++ b/ui/src/core/page-components/agent-detail/modals/edit-control/evaluator-config-section.tsx
@@ -1,6 +1,5 @@
 import {
   Anchor,
-  Box,
   Group,
   Paper,
   ScrollArea,
@@ -74,6 +73,8 @@ export function EvaluatorConfigSection({
         ? 'red'
         : 'dimmed';
 
+  const contentHeight = height + CONTENT_MIN_HEIGHT_EXTRA;
+
   return (
     <Stack gap="md">
       <Group justify="space-between" align="center">
@@ -112,21 +113,21 @@ export function EvaluatorConfigSection({
         </Group>
       </Group>
       <Paper withBorder radius="sm" p={16}>
-        <Box style={{ minHeight: height + CONTENT_MIN_HEIGHT_EXTRA }}>
-          {configViewMode === 'form' && (
-            <ScrollArea h={height} type="auto">
-              {FormComponent ? (
-                <FormComponent form={evaluatorForm} />
-              ) : (
-                <Text c="dimmed" ta="center" py="xl">
-                  No form available for this evaluator. Use JSON view to
-                  configure.
-                </Text>
-              )}
-            </ScrollArea>
-          )}
-
-          {configViewMode === 'json' && (
+        <ScrollArea
+          h={contentHeight}
+          type="always"
+          offsetScrollbars="y"
+        >
+          {configViewMode === 'form' ? (
+            FormComponent ? (
+              <FormComponent form={evaluatorForm} />
+            ) : (
+              <Text c="dimmed" ta="center" py="xl">
+                No form available for this evaluator. Use JSON view to
+                configure.
+              </Text>
+            )
+          ) : (
             <EvaluatorJsonView
               onValidateConfig={onValidateConfig}
               onValidationStatusChange={setValidationStatus}
@@ -134,7 +135,7 @@ export function EvaluatorConfigSection({
               {...jsonViewProps}
             />
           )}
-        </Box>
+        </ScrollArea>
       </Paper>
     </Stack>
   );

--- a/ui/src/core/page-components/agent-detail/modals/edit-control/evaluator-json-view.tsx
+++ b/ui/src/core/page-components/agent-detail/modals/edit-control/evaluator-json-view.tsx
@@ -3,6 +3,10 @@ import { useDebouncedValue } from '@mantine/hooks';
 import { useEffect, useRef } from 'react';
 
 import { isApiError } from '@/core/api/errors';
+import {
+  labelPropsInline,
+  LabelWithTooltip,
+} from '@/core/components/label-with-tooltip';
 
 import { ApiErrorAlert } from './api-error-alert';
 import type { EvaluatorJsonViewProps } from './types';
@@ -79,6 +83,13 @@ export const EvaluatorJsonView = ({
   return (
     <Box>
       <Textarea
+        label={
+          <LabelWithTooltip
+            label="Configuration (JSON)"
+            tooltip="Raw evaluator configuration in JSON format"
+          />
+        }
+        labelProps={labelPropsInline}
         value={jsonText}
         onChange={(e) => handleJsonChange(e.currentTarget.value)}
         styles={{

--- a/ui/src/core/page-components/agent-detail/modals/edit-control/step-name-input.tsx
+++ b/ui/src/core/page-components/agent-detail/modals/edit-control/step-name-input.tsx
@@ -99,7 +99,7 @@ export function StepNameInput({ form, steps = [] }: StepNameInputProps) {
 
   return (
     <Box>
-      <Group gap="xs" mb={4} wrap="nowrap">
+      <Group gap="xs" mb={8} wrap="nowrap">
         <Group gap={4}>
           <Text size="sm" fw={500}>
             Step name

--- a/ui/src/pages/_app.tsx
+++ b/ui/src/pages/_app.tsx
@@ -12,8 +12,6 @@ import '@rungalileo/icons/styles.css';
 import '@/styles/globals.css';
 
 import { MantineProvider } from '@mantine/core';
-
-import { appTheme } from '@/theme';
 import { DatesProvider } from '@mantine/dates';
 import { ModalsProvider } from '@mantine/modals';
 import { Notifications } from '@mantine/notifications';
@@ -26,6 +24,7 @@ import { LoginModal } from '@/core/components/login-modal';
 import { AuthProvider, useAuth } from '@/core/providers/auth-provider';
 import { QueryProvider } from '@/core/providers/query-provider';
 import type { NextPageWithLayout } from '@/core/types/page';
+import { appTheme } from '@/theme';
 
 type AppPropsWithLayout = AppProps & {
   Component: NextPageWithLayout;

--- a/ui/src/pages/_app.tsx
+++ b/ui/src/pages/_app.tsx
@@ -12,6 +12,8 @@ import '@rungalileo/icons/styles.css';
 import '@/styles/globals.css';
 
 import { MantineProvider } from '@mantine/core';
+
+import { appTheme } from '@/theme';
 import { DatesProvider } from '@mantine/dates';
 import { ModalsProvider } from '@mantine/modals';
 import { Notifications } from '@mantine/notifications';
@@ -125,7 +127,7 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
 
       <ErrorBoundary variant="page">
         <QueryProvider>
-          <MantineProvider defaultColorScheme="auto">
+          <MantineProvider theme={appTheme} defaultColorScheme="auto">
             <Notifications />
             <DatesProvider settings={{ firstDayOfWeek: 0 }}>
               <JupiterThemeProvider>

--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -1,0 +1,49 @@
+import {
+  Autocomplete,
+  createTheme,
+  MultiSelect,
+  NumberInput,
+  Select,
+  TagsInput,
+  Textarea,
+  TextInput,
+} from '@mantine/core';
+
+/** Default vertical gap between label and input for form controls. */
+const LABEL_INPUT_GAP = 8;
+
+const formInputLabelStyles = {
+  label: {
+    marginBottom: LABEL_INPUT_GAP,
+  },
+};
+
+/**
+ * App theme. Defines default styles for form inputs (label spacing) in one place
+ * so all labels have consistent spacing without repeating styles per component.
+ */
+export const appTheme = createTheme({
+  components: {
+    TextInput: TextInput.extend({
+      styles: formInputLabelStyles,
+    }),
+    Textarea: Textarea.extend({
+      styles: formInputLabelStyles,
+    }),
+    Select: Select.extend({
+      styles: formInputLabelStyles,
+    }),
+    MultiSelect: MultiSelect.extend({
+      styles: formInputLabelStyles,
+    }),
+    Autocomplete: Autocomplete.extend({
+      styles: formInputLabelStyles,
+    }),
+    TagsInput: TagsInput.extend({
+      styles: formInputLabelStyles,
+    }),
+    NumberInput: NumberInput.extend({
+      styles: formInputLabelStyles,
+    }),
+  },
+});

--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -9,7 +9,6 @@ import {
   TextInput,
 } from '@mantine/core';
 
-/** Default vertical gap between label and input for form controls. */
 const LABEL_INPUT_GAP = 8;
 
 const formInputLabelStyles = {
@@ -18,10 +17,6 @@ const formInputLabelStyles = {
   },
 };
 
-/**
- * App theme. Defines default styles for form inputs (label spacing) in one place
- * so all labels have consistent spacing without repeating styles per component.
- */
 export const appTheme = createTheme({
   components: {
     TextInput: TextInput.extend({


### PR DESCRIPTION
## Summary
- ensured consistent spacing, prevent layout shift, basic `theme.ts` config
- stabilized evaluator panel scrolling/layout (Form vs JSON toggles, including JSON validation status)

## Scope
- User-facing/API changes: Edit/Add Control modal only: improved spacing and no layout shift when toggling Form/JSON or when validation state appears.
- Internal changes: New `ui/src/theme.ts` with default form-input label styles;
- Out of scope:

## Risk and Rollout
- Risk level: low 
- Rollback plan: revert

## Testing
- [ ] Added or updated automated tests
- [x] Ran `make check` (or explained why not)
- [x] Manually verified behavior

## Checklist
- [ ] Linked issue/spec (if applicable)
- [ ] Updated docs/examples for user-facing changes
- [ ] Included any required follow-up tasks

### Before
<img width="809" height="806" alt="Screenshot 2026-03-18 at 22 17 50" src="https://github.com/user-attachments/assets/febe9717-5b74-43eb-9552-d989b7d55ad1" />

https://github.com/user-attachments/assets/f6f2aa22-adfe-4cba-979c-8f40bc8708e2


### After
<img width="800" height="876" alt="Screenshot 2026-03-18 at 22 34 03" src="https://github.com/user-attachments/assets/4d4317a7-1939-4d20-913e-85580ba12121" />

https://github.com/user-attachments/assets/55eb953f-e502-4644-a073-58e3de30e108