### PR TITLE
chore(evaluators): pin sqlglotc

### DIFF
--- a/evaluators/builtin/pyproject.toml
+++ b/evaluators/builtin/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "google-re2>=1.1",
     "jsonschema>=4.0.0",
     "sqlglot[c]>=29.0.0,<29.1.0",
+    "sqlglotc>=29.0.0,<29.1.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- What changed and why.

Seems like we were wrong version which would generate this error in ci:

```

make -C server test
make[1]: Entering directory '/home/runner/work/agent-control/agent-control/server'
DB_DATABASE=agent_control_test uv run --package agent-control-server pytest --cov=src --cov-report=xml:../coverage-server.xml -q
ImportError while loading conftest '/home/runner/work/agent-control/agent-control/server/tests/conftest.py'.
tests/conftest.py:6: in <module>
    from agent_control_engine import discover_evaluators
../engine/src/agent_control_engine/__init__.py:10: in <module>
    from agent_control_evaluators import (
../evaluators/builtin/src/agent_control_evaluators/__init__.py:50: in <module>
    from agent_control_evaluators.sql import SQLEvaluator, SQLEvaluatorConfig
../evaluators/builtin/src/agent_control_evaluators/sql/__init__.py:4: in <module>
    from agent_control_evaluators.sql.evaluator import SQLEvaluator
../evaluators/builtin/src/agent_control_evaluators/sql/evaluator.py:12: in <module>
    import sqlglot
../.venv/lib/python3.12/site-packages/sqlglot/__init__.py:14: in <module>
    from sqlglot.dialects.dialect import Dialect as Dialect, Dialects as Dialects
../.venv/lib/python3.12/site-packages/sqlglot/dialects/dialect.py:26: in <module>
    from sqlglot.parser import Parser
/project/sqlglot/parser.py:959: in <module>
    ???
E   AttributeError: module 'sqlglot.expressions' has no attribute 'Expr'
make[1]: *** [Makefile:66: test] Error 4
make[1]: Leaving directory '/home/runner/work/agent-control/agent-control/server'
make: *** [Makefile:217: server-test] Error 2
```

## Scope
- User-facing/API changes:
- Internal changes:
- Out of scope:

## Risk and Rollout
- Risk level: low / medium / high
- Rollback plan:

## Testing
- [ ] Added or updated automated tests
- [ ] Ran `make check` (or explained why not)
- [ ] Manually verified behavior

## Checklist
- [ ] Linked issue/spec (if applicable)
- [ ] Updated docs/examples for user-facing changes
- [ ] Included any required follow-up tasks
