### PR TITLE
feat(server): Override PG password in dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ export AGENT_CONTROL_DB_HOST_PORT=15432
 curl -L https://raw.githubusercontent.com/agentcontrol/agent-control/refs/heads/main/docker-compose.yml | docker compose -f - up -d
 ```
 
+To override the bundled PostgreSQL password, set
+`AGENT_CONTROL_POSTGRES_PASSWORD` before starting Compose. This value is used
+for both the Postgres container and the server's database connection. Example:
+
+```bash
+export AGENT_CONTROL_POSTGRES_PASSWORD=agent_control_local
+curl -L https://raw.githubusercontent.com/agentcontrol/agent-control/refs/heads/main/docker-compose.yml | docker compose -f - up -d
+```
+
 Verify it is up:
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     environment:
       POSTGRES_DB: agent_control
       POSTGRES_USER: agent_control
-      POSTGRES_PASSWORD: agent_control
+      POSTGRES_PASSWORD: "${AGENT_CONTROL_POSGTRES_PASSWORD:-agent_control}"
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
@@ -45,7 +45,7 @@ services:
     environment:
       # Database connection (uses Docker service name 'postgres')
       # Use postgresql+psycopg:// (supports both sync migrations and async app code)
-      AGENT_CONTROL_DB_URL: postgresql+psycopg://agent_control:agent_control@postgres:5432/agent_control
+      AGENT_CONTROL_DB_URL: "postgresql+psycopg://agent_control:${AGENT_CONTROL_POSGTRES_PASSWORD:-agent_control}@postgres:5432/agent_control"
       # Server configuration
       AGENT_CONTROL_HOST: 0.0.0.0
       AGENT_CONTROL_PORT: 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@
 # Quick Start:
 #   docker compose up -d
 #   AGENT_CONTROL_SERVER_HOST_PORT=18000 AGENT_CONTROL_DB_HOST_PORT=15432 docker compose up -d
+#   AGENT_CONTROL_POSTGRES_PASSWORD=agent_control_local docker compose up -d
 #
 # Services:
 #   - PostgreSQL database (port 5432)
@@ -26,7 +27,7 @@ services:
     environment:
       POSTGRES_DB: agent_control
       POSTGRES_USER: agent_control
-      POSTGRES_PASSWORD: "${AGENT_CONTROL_POSGTRES_PASSWORD:-agent_control}"
+      POSTGRES_PASSWORD: "${AGENT_CONTROL_POSTGRES_PASSWORD:-agent_control}"
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
@@ -45,7 +46,7 @@ services:
     environment:
       # Database connection (uses Docker service name 'postgres')
       # Use postgresql+psycopg:// (supports both sync migrations and async app code)
-      AGENT_CONTROL_DB_URL: "postgresql+psycopg://agent_control:${AGENT_CONTROL_POSGTRES_PASSWORD:-agent_control}@postgres:5432/agent_control"
+      AGENT_CONTROL_DB_URL: "postgresql+psycopg://agent_control:${AGENT_CONTROL_POSTGRES_PASSWORD:-agent_control}@postgres:5432/agent_control"
       # Server configuration
       AGENT_CONTROL_HOST: 0.0.0.0
       AGENT_CONTROL_PORT: 8000


### PR DESCRIPTION
## Summary
- Add a Compose-level PostgreSQL password override so users can start the bundled Postgres container with a non-default password.
- Wire the same override into the server container's `AGENT_CONTROL_DB_URL` so the bundled server uses the matching credential by default.
- Correct the env var name to `AGENT_CONTROL_POSTGRES_PASSWORD` and document it in the root quickstart README.

## Scope
- User-facing/API changes:
  - `docker-compose.yml` now supports `AGENT_CONTROL_POSTGRES_PASSWORD` for the bundled Postgres + server setup.
  - `README.md` quickstart now shows how to override the bundled PostgreSQL password.
- Internal changes:
  - Replace the hardcoded compose password with environment-variable interpolation.
  - Keep the server container DB URL in sync with the compose-managed Postgres password.
- Out of scope:
  - Rotating credentials for already-initialized Postgres data volumes.
  - Changes to `docker-compose.dev.yml` or direct server env var handling outside the bundled compose path.

## Risk and Rollout
- Risk level: low
- Rollback plan:
  - Revert this PR to restore the previous hardcoded compose password.
  - If a deployment reused an existing Postgres volume, operators may still need to recreate the volume or manually rotate the DB user's password to match the configured env var.

## Testing
- [ ] Added or updated automated tests
- [ ] Ran `make check` (or explained why not)
- [x] Manually verified behavior

Manual verification performed:
- Ran `docker compose -f docker-compose.yml config` to verify the compose file renders correctly after the env var and quoting changes.

Why automated checks were not run:
- This PR only changes compose wiring and README documentation; no Python application code or tests were modified.

## Checklist
- [ ] Linked issue/spec (if applicable)
- [x] Updated docs/examples for user-facing changes
- [x] Included any required follow-up tasks

Follow-up notes:
- Existing Postgres volumes keep their original credentials; changing `AGENT_CONTROL_POSTGRES_PASSWORD` does not retroactively rotate the database password inside an already-initialized volume.
