### PR TITLE
feat(ui): add full control JSON editing and create-from-JSON

### DIFF
--- a/ui/src/core/page-components/agent-detail/modals/add-new-control/index.tsx
+++ b/ui/src/core/page-components/agent-detail/modals/add-new-control/index.tsx
@@ -51,6 +51,33 @@ function getDefaultConfigForEvaluator(
   return DEFAULT_EVALUATOR_CONFIGS[evaluatorId] ?? {};
 }
 
+function buildJsonDraftControl(agentName: string) {
+  return {
+    id: 0,
+    name: `json-control-for-${sanitizeControlNamePart(agentName)}`,
+    control: {
+      description: '',
+      enabled: true,
+      execution: 'server' as const,
+      scope: {
+        step_types: ['llm'],
+        stages: ['post'] as ('post' | 'pre')[],
+      },
+      condition: {
+        selector: {
+          path: '*',
+        },
+        evaluator: {
+          name: 'regex',
+          config: getDefaultConfigForEvaluator('regex'),
+        },
+      },
+      action: { decision: 'deny' as const },
+      tags: [],
+    },
+  };
+}
+
 type AddNewControlModalProps = {
   opened: boolean;
   onClose: () => void;
@@ -90,6 +117,12 @@ export function AddNewControlModal({
     });
   };
 
+  const handleFromJsonClick = () => {
+    openModal(MODAL_NAMES.CONTROL_STORE, {
+      submodal: SUBMODAL_NAMES.CREATE,
+    });
+  };
+
   const handleEditModalClose = () => {
     closeSubmodal();
   };
@@ -110,31 +143,34 @@ export function AddNewControlModal({
   }, [evaluatorsData]);
 
   const draftControl = useMemo(() => {
-    if (!selectedEvaluator) return null;
-    const name = `${sanitizeControlNamePart(selectedEvaluator.name)}-control-for-${sanitizeControlNamePart(agentName)}`;
-    return {
-      id: 0,
-      name,
-      control: {
-        description: selectedEvaluator.description,
-        enabled: true,
-        execution: 'server' as const,
-        scope: {
-          step_types: ['llm'],
-          stages: ['post'] as ('post' | 'pre')[],
-        },
-        condition: {
-          selector: {
-            path: '*',
+    if (selectedEvaluator) {
+      const name = `${sanitizeControlNamePart(selectedEvaluator.name)}-control-for-${sanitizeControlNamePart(agentName)}`;
+      return {
+        id: 0,
+        name,
+        control: {
+          description: selectedEvaluator.description,
+          enabled: true,
+          execution: 'server' as const,
+          scope: {
+            step_types: ['llm'],
+            stages: ['post'] as ('post' | 'pre')[],
           },
-          evaluator: {
-            name: selectedEvaluator.id,
-            config: getDefaultConfigForEvaluator(selectedEvaluator.id),
+          condition: {
+            selector: {
+              path: '*',
+            },
+            evaluator: {
+              name: selectedEvaluator.id,
+              config: getDefaultConfigForEvaluator(selectedEvaluator.id),
+            },
           },
+          action: { decision: 'deny' as const },
         },
-        action: { decision: 'deny' as const },
-      },
-    };
+      };
+    }
+
+    return buildJsonDraftControl(agentName);
   }, [selectedEvaluator, agentName]);
 
   const columns: ColumnDef<EvaluatorInfo & { id: string }>[] = [
@@ -219,7 +255,7 @@ export function AddNewControlModal({
             </Button>
           </Group>
           <Text size="sm" c="dimmed">
-            Select an evaluator to create a new control
+            Select an evaluator to create a new control or start from JSON
           </Text>
         </Box>
         <Divider />
@@ -240,20 +276,30 @@ export function AddNewControlModal({
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
               />
-              <Text size="sm" c="dimmed">
-                Learn here on how to add new type of evaluator.{' '}
-                <Text
-                  component="a"
-                  href="https://github.com/agentcontrol/agent-control/blob/main/README.md"
-                  c="blue"
+              <Group gap="md" wrap="nowrap">
+                <Button
+                  variant="outline"
                   size="sm"
-                  td="none"
-                  target="_blank"
-                  rel="noreferrer"
+                  data-testid="from-json-button"
+                  onClick={handleFromJsonClick}
                 >
-                  Docs ↗
+                  From JSON
+                </Button>
+                <Text size="sm" c="dimmed">
+                  Learn here on how to add new type of evaluator.{' '}
+                  <Text
+                    component="a"
+                    href="https://github.com/agentcontrol/agent-control/blob/main/README.md"
+                    c="blue"
+                    size="sm"
+                    td="none"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Docs ↗
+                  </Text>
                 </Text>
-              </Text>
+              </Group>
             </Group>
 
             {/* Table or Empty State */}
@@ -307,6 +353,7 @@ export function AddNewControlModal({
               control={draftControl}
               agentId={agentId}
               mode="create"
+              initialEditorMode={selectedEvaluator ? 'form' : 'json'}
               onClose={handleEditModalClose}
               onSuccess={handleEditModalSuccess}
             />

--- a/ui/src/core/page-components/agent-detail/modals/edit-control/control-condition.ts
+++ b/ui/src/core/page-components/agent-detail/modals/edit-control/control-condition.ts
@@ -2,9 +2,6 @@ import type { ControlDefinition } from '@/core/api/types';
 import type { AnyEvaluatorDefinition } from '@/core/evaluators';
 import { getEvaluator } from '@/core/evaluators';
 
-const COMPOSITE_CONDITION_EDITING_MESSAGE =
-  'This control uses a composite condition tree. This PR keeps the old single-condition UI, so saving will preserve the existing tree without editing it.';
-
 export type LeafConditionDetails = {
   selectorPath: string;
   evaluatorName: string;
@@ -16,7 +13,6 @@ export type ControlConditionState = {
   evaluatorId: string;
   evaluator: AnyEvaluatorDefinition | undefined;
   canEditLeafCondition: boolean;
-  conditionEditingMessage: string | null;
 };
 
 function getLeafConditionDetails(
@@ -46,9 +42,6 @@ export function getControlConditionState(
     evaluatorId,
     evaluator,
     canEditLeafCondition: Boolean(leafCondition),
-    conditionEditingMessage: leafCondition
-      ? null
-      : COMPOSITE_CONDITION_EDITING_MESSAGE,
   };
 }
 

--- a/ui/src/core/page-components/agent-detail/modals/edit-control/edit-control-content.tsx
+++ b/ui/src/core/page-components/agent-detail/modals/edit-control/edit-control-content.tsx
@@ -4,6 +4,9 @@ import {
   Divider,
   Grid,
   Group,
+  Paper,
+  SegmentedControl,
+  Stack,
   Text,
   TextInput,
 } from '@mantine/core';
@@ -32,11 +35,18 @@ import {
 } from './control-condition';
 import { ControlDefinitionForm } from './control-definition-form';
 import { EvaluatorConfigSection } from './evaluator-config-section';
-import type { ControlDefinitionFormValues, EditControlMode } from './types';
+import { JsonEditorView } from './json-editor-view';
+import type {
+  ControlDefinitionFormValues,
+  ControlEditorMode,
+  EditControlMode,
+} from './types';
 import { useEvaluatorConfigState } from './use-evaluator-config-state';
 import { applyApiErrorsToForms } from './utils';
 
 const EVALUATOR_CONFIG_HEIGHT = 450;
+const JSON_EDITOR_HEIGHT = 520;
+type ValidationStatus = 'idle' | 'validating' | 'valid' | 'invalid';
 
 export type EditControlContentProps = {
   /** The control to edit/create template */
@@ -49,6 +59,8 @@ export type EditControlContentProps = {
   onClose: () => void;
   /** Callback when save succeeds */
   onSuccess?: () => void;
+  /** Initial editor mode */
+  initialEditorMode?: ControlEditorMode;
 };
 
 export const EditControlContent = ({
@@ -57,14 +69,28 @@ export const EditControlContent = ({
   mode = 'edit',
   onClose,
   onSuccess,
+  initialEditorMode = 'form',
 }: EditControlContentProps) => {
   const { data: agentResponse } = useAgent(agentId);
   const steps = agentResponse?.steps ?? [];
 
+  const [workingDefinition, setWorkingDefinition] = useState<ControlDefinition>(
+    control.control
+  );
+  const [editorMode, setEditorMode] =
+    useState<ControlEditorMode>(initialEditorMode);
   const [apiError, setApiError] = useState<ProblemDetail | null>(null);
   const [unmappedErrors, setUnmappedErrors] = useState<
     Array<{ field: string | null; message: string }>
   >([]);
+  const [definitionJsonText, setDefinitionJsonText] = useState('');
+  const [definitionJsonError, setDefinitionJsonError] = useState<string | null>(
+    null
+  );
+  const [definitionValidationError, setDefinitionValidationError] =
+    useState<ProblemDetail | null>(null);
+  const [definitionValidationStatus, setDefinitionValidationStatus] =
+    useState<ValidationStatus>('idle');
 
   const updateControl = useUpdateControl();
   const updateControlMetadata = useUpdateControlMetadata();
@@ -76,16 +102,11 @@ export const EditControlContent = ({
     : updateControl.isPending || updateControlMetadata.isPending;
 
   const formInitializedForEvaluator = useRef<string>('');
-  const {
-    leafCondition,
-    evaluatorId,
-    evaluator,
-    canEditLeafCondition,
-    conditionEditingMessage,
-  } = useMemo(
-    () => getControlConditionState(control.control),
-    [control.control]
-  );
+  const { leafCondition, evaluatorId, evaluator, canEditLeafCondition } =
+    useMemo(
+      () => getControlConditionState(workingDefinition),
+      [workingDefinition]
+    );
 
   const definitionForm = useForm<ControlDefinitionFormValues>({
     initialValues: {
@@ -105,7 +126,7 @@ export const EditControlContent = ({
     validate: {
       name: (value) => (!value?.trim() ? 'Control name is required' : null),
       selector_path: (value) => {
-        if (!canEditLeafCondition) {
+        if (editorMode === 'json' || !canEditLeafCondition) {
           return null;
         }
         if (!value?.trim()) {
@@ -148,25 +169,25 @@ export const EditControlContent = ({
     [evaluator, evaluatorForm]
   );
 
-  const buildCondition = useCallback(
+  const buildLeafCondition = useCallback(
     (
       values: ControlDefinitionFormValues,
       finalConfig: Record<string, unknown>
     ): ControlDefinition['condition'] => {
       return buildEditableCondition(
-        control.control,
+        workingDefinition,
         leafCondition,
         values.selector_path.trim(),
         finalConfig
       );
     },
-    [control.control, leafCondition]
+    [leafCondition, workingDefinition]
   );
 
   const buildControlDefinition = useCallback(
     (
       values: ControlDefinitionFormValues,
-      finalConfig: Record<string, unknown>
+      condition: ControlDefinition['condition']
     ): ControlDefinition => {
       const stepTypes = values.step_types
         .map((value) => value.trim())
@@ -189,7 +210,7 @@ export const EditControlContent = ({
         enabled: values.enabled,
         execution: values.execution,
         scope: Object.keys(scope).length > 0 ? scope : undefined,
-        condition: buildCondition(values, finalConfig),
+        condition,
         action: {
           decision: values.action_decision,
           ...(values.action_decision === 'steer' &&
@@ -201,18 +222,10 @@ export const EditControlContent = ({
               }
             : {}),
         },
-        tags: control.control.tags,
+        tags: workingDefinition.tags,
       };
     },
-    [buildCondition, control.control.tags]
-  );
-
-  const buildDefinitionForValidation = useCallback(
-    (finalConfig: Record<string, unknown>): ControlDefinition => ({
-      ...control.control,
-      condition: buildCondition(definitionForm.values, finalConfig),
-    }),
-    [buildCondition, control.control, definitionForm.values]
+    [workingDefinition.tags]
   );
 
   const validateEvaluatorConfig = useCallback(
@@ -220,12 +233,18 @@ export const EditControlContent = ({
       config: Record<string, unknown>,
       options?: { signal?: AbortSignal }
     ) => {
+      const condition = buildLeafCondition(definitionForm.values, config);
       await validateControlDataAsync({
-        definition: buildDefinitionForValidation(config),
+        definition: buildControlDefinition(definitionForm.values, condition),
         signal: options?.signal,
       });
     },
-    [buildDefinitionForValidation, validateControlDataAsync]
+    [
+      buildControlDefinition,
+      buildLeafCondition,
+      definitionForm.values,
+      validateControlDataAsync,
+    ]
   );
 
   const evaluatorConfig = useEvaluatorConfigState({
@@ -236,6 +255,133 @@ export const EditControlContent = ({
 
   const { reset } = evaluatorConfig;
 
+  const getDefinitionFromFormState =
+    useCallback((): ControlDefinition | null => {
+      let condition: ControlDefinition['condition'];
+
+      if (canEditLeafCondition) {
+        let finalConfig: Record<string, unknown> =
+          leafCondition?.evaluatorConfig ?? {};
+
+        if (evaluatorConfig.configViewMode === 'json') {
+          const jsonConfig = evaluatorConfig.getJsonConfig();
+          if (!jsonConfig) return null;
+          finalConfig = jsonConfig;
+        } else {
+          finalConfig = getEvaluatorConfig();
+        }
+
+        condition = buildLeafCondition(definitionForm.values, finalConfig);
+      } else {
+        condition = workingDefinition.condition;
+      }
+
+      return buildControlDefinition(definitionForm.values, condition);
+    }, [
+      buildControlDefinition,
+      buildLeafCondition,
+      canEditLeafCondition,
+      definitionForm.values,
+      evaluatorConfig,
+      getEvaluatorConfig,
+      leafCondition?.evaluatorConfig,
+      workingDefinition.condition,
+    ]);
+
+  const handleDefinitionJsonChange = useCallback((value: string) => {
+    setDefinitionJsonText(value);
+    setDefinitionJsonError(null);
+    setDefinitionValidationError(null);
+  }, []);
+
+  const getJsonDefinition = useCallback((): ControlDefinition | null => {
+    if (!definitionJsonText.trim()) {
+      setDefinitionJsonError(
+        'Control JSON is required. Please add a control definition.'
+      );
+      setDefinitionValidationError(null);
+      return null;
+    }
+
+    try {
+      setDefinitionJsonError(null);
+      return JSON.parse(definitionJsonText) as ControlDefinition;
+    } catch {
+      setDefinitionJsonError('Invalid JSON. Please fix before saving.');
+      setDefinitionValidationError(null);
+      return null;
+    }
+  }, [definitionJsonText]);
+
+  const validateDefinitionJson = useCallback(
+    async (
+      definition: Record<string, unknown>,
+      options?: { signal?: AbortSignal }
+    ) => {
+      await validateControlDataAsync({
+        definition: definition as ControlDefinition,
+        signal: options?.signal,
+      });
+    },
+    [validateControlDataAsync]
+  );
+
+  const handleEditorModeChange = useCallback(
+    async (value: string) => {
+      const nextMode = value as ControlEditorMode;
+
+      if (nextMode === editorMode) {
+        return;
+      }
+
+      if (nextMode === 'json') {
+        const definition = getDefinitionFromFormState();
+        if (!definition) {
+          return;
+        }
+
+        setDefinitionJsonText(JSON.stringify(definition, null, 2));
+        setDefinitionJsonError(null);
+        setDefinitionValidationError(null);
+        setDefinitionValidationStatus('idle');
+        setEditorMode('json');
+        return;
+      }
+
+      const parsedDefinition = getJsonDefinition();
+      if (!parsedDefinition) {
+        return;
+      }
+
+      try {
+        await validateControlDataAsync({ definition: parsedDefinition });
+      } catch (error) {
+        if (isApiError(error)) {
+          setDefinitionValidationError(error.problemDetail);
+          setDefinitionJsonError(null);
+          setDefinitionValidationStatus('invalid');
+        } else {
+          setDefinitionJsonError('Validation failed.');
+          setDefinitionValidationError(null);
+          setDefinitionValidationStatus('invalid');
+        }
+        return;
+      }
+
+      setWorkingDefinition(parsedDefinition);
+      setDefinitionJsonError(null);
+      setDefinitionValidationError(null);
+      setDefinitionValidationStatus('idle');
+      setEditorMode('form');
+    },
+    [
+      editorMode,
+      getDefinitionFromFormState,
+      getJsonDefinition,
+      validateControlDataAsync,
+    ]
+  );
+
   useEffect(() => {
     if (definitionForm.values.action_decision !== 'steer') {
       definitionForm.setFieldValue('action_steering_context', '');
@@ -244,34 +390,47 @@ export const EditControlContent = ({
   }, [definitionForm.values.action_decision]);
 
   useEffect(() => {
+    setWorkingDefinition(control.control);
+    setEditorMode(initialEditorMode);
+    setDefinitionJsonText(
+      initialEditorMode === 'json'
+        ? JSON.stringify(control.control, null, 2)
+        : ''
+    );
+    setDefinitionJsonError(null);
+    setDefinitionValidationError(null);
+    setDefinitionValidationStatus('idle');
+  }, [control.control, initialEditorMode]);
+
+  useEffect(() => {
     reset();
     setApiError(null);
     setUnmappedErrors([]);
     formInitializedForEvaluator.current = '';
-  }, [reset, evaluatorId, control.id]);
+  }, [reset, evaluatorId, control.id, workingDefinition]);
 
   useEffect(() => {
-    const scope = control.control.scope ?? {};
+    const scope = workingDefinition.scope ?? {};
     const stepNamesValue = (scope.step_names ?? []).join(', ');
     const stepRegexValue = scope.step_name_regex ?? '';
     const stepNameMode = stepRegexValue && !stepNamesValue ? 'regex' : 'names';
 
     definitionForm.setValues({
       name: control.name,
-      description: control.control.description ?? '',
-      enabled: control.control.enabled,
+      description: workingDefinition.description ?? '',
+      enabled: workingDefinition.enabled,
       step_types: scope.step_types ?? [],
       stages: scope.stages ?? [],
       step_names: stepNamesValue,
       step_name_regex: stepRegexValue,
       step_name_mode: stepNameMode,
       selector_path: leafCondition?.selectorPath ?? '*',
-      action_decision: control.control.action.decision,
+      action_decision: workingDefinition.action.decision,
       action_steering_context:
-        control.control.action.decision === 'steer'
-          ? (control.control.action.steering_context?.message ?? '')
+        workingDefinition.action.decision === 'steer'
+          ? (workingDefinition.action.steering_context?.message ?? '')
           : '',
-      execution: control.control.execution ?? 'server',
+      execution: workingDefinition.execution ?? 'server',
     });
 
     if (leafCondition && evaluator) {
@@ -281,7 +440,7 @@ export const EditControlContent = ({
       formInitializedForEvaluator.current = evaluatorId;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [control, evaluator, evaluatorId, leafCondition]);
+  }, [control.name, evaluator, evaluatorId, leafCondition, workingDefinition]);
 
   const handleSubmit = async (values: ControlDefinitionFormValues) => {
     setApiError(null);
@@ -290,6 +449,7 @@ export const EditControlContent = ({
     evaluatorForm.clearErrors();
 
     if (
+      editorMode === 'form' &&
       values.action_decision === 'steer' &&
       !leafCondition &&
       !values.action_steering_context?.trim()
@@ -301,25 +461,30 @@ export const EditControlContent = ({
       return;
     }
 
-    let finalConfig: Record<string, unknown> =
-      leafCondition?.evaluatorConfig ?? {};
+    let definition: ControlDefinition | null = null;
 
-    if (canEditLeafCondition) {
-      if (evaluatorConfig.configViewMode === 'json') {
-        const jsonConfig = evaluatorConfig.getJsonConfig();
-        if (!jsonConfig) return;
-        finalConfig = jsonConfig;
-      } else {
+    if (editorMode === 'json') {
+      definition = getJsonDefinition();
+      if (!definition) {
+        return;
+      }
+    } else {
+      if (canEditLeafCondition && evaluatorConfig.configViewMode === 'form') {
         const validation = evaluatorForm.validate();
         if (validation.hasErrors) return;
-        finalConfig = getEvaluatorConfig();
+      }
+
+      definition = getDefinitionFromFormState();
+      if (!definition) {
+        return;
       }
     }
 
-    const definition = buildControlDefinition(values, finalConfig);
-
     const runSave = async () => {
       try {
+        if (!definition) {
+          return;
+        }
         await validateControlDataAsync({ definition });
 
         if (isCreating) {
@@ -431,7 +596,14 @@ export const EditControlContent = ({
           setApiError(problemDetail);
 
           if (problemDetail.errors) {
-            if (evaluatorConfig.configViewMode === 'form') {
+            if (editorMode === 'json') {
+              setUnmappedErrors(
+                problemDetail.errors.map((e) => ({
+                  field: e.field,
+                  message: e.message,
+                }))
+              );
+            } else if (evaluatorConfig.configViewMode === 'form') {
               const unmapped = applyApiErrorsToForms(
                 problemDetail.errors,
                 definitionForm,
@@ -482,60 +654,124 @@ export const EditControlContent = ({
   };
 
   const formComponent = evaluator?.FormComponent;
+  const definitionStatusLabel = (() => {
+    if (editorMode !== 'json') return null;
+    if (definitionValidationStatus === 'validating')
+      return 'JSON validating...';
+    if (definitionValidationStatus === 'valid') return 'JSON valid';
+    if (definitionValidationStatus === 'invalid') return 'JSON invalid';
+    return null;
+  })();
+  const definitionStatusColor =
+    definitionValidationStatus === 'valid'
+      ? 'green'
+      : definitionValidationStatus === 'invalid'
+        ? 'red'
+        : 'dimmed';
+  const isDefinitionJsonInvalid =
+    editorMode === 'json' &&
+    (definitionJsonError !== null || definitionValidationError !== null);
 
   return (
     <Box>
       <form onSubmit={definitionForm.onSubmit(handleSubmit)}>
-        <Grid gutter="xl" mb="lg">
-          <Grid.Col span={6}>
-            <TextInput
-              label="Control name"
-              placeholder="Enter control name"
-              size="sm"
-              required
-              {...definitionForm.getInputProps('name')}
-            />
-          </Grid.Col>
-          <Grid.Col span={6}>
+        <Stack gap="md" mb="lg">
+          <Group justify="space-between" align="flex-end" wrap="nowrap">
+            <Box
+              style={{
+                flex: 1,
+                maxWidth: editorMode === 'json' ? 420 : undefined,
+              }}
+            >
+              <TextInput
+                label="Control name"
+                placeholder="Enter control name"
+                size="sm"
+                required
+                {...definitionForm.getInputProps('name')}
+              />
+            </Box>
+            <Group gap="xs" align="center">
+              {definitionStatusLabel ? (
+                <Text size="xs" c={definitionStatusColor}>
+                  {definitionStatusLabel}
+                </Text>
+              ) : null}
+              <SegmentedControl
+                value={editorMode}
+                onChange={handleEditorModeChange}
+                disabled={isDefinitionJsonInvalid}
+                data={[
+                  { value: 'form', label: 'Form' },
+                  { value: 'json', label: 'Full JSON' },
+                ]}
+                size="xs"
+              />
+            </Group>
+          </Group>
+
+          {editorMode === 'json' ? (
+            <Text size="sm" c="dimmed">
+              Edit the full control definition below. Control name stays
+              separate.
+            </Text>
+          ) : (
             <TextInput
               label="Description"
               placeholder="Optional description of what this control does"
               size="sm"
               {...definitionForm.getInputProps('description')}
             />
-          </Grid.Col>
-        </Grid>
+          )}
+        </Stack>
 
-        <Grid gutter="xl">
-          <Grid.Col span={4}>
-            <ControlDefinitionForm
-              form={definitionForm}
-              steps={steps}
-              disableSelectorPath={!canEditLeafCondition}
+        {editorMode === 'json' ? (
+          <Paper withBorder radius="sm" p={16}>
+            <JsonEditorView
+              jsonText={definitionJsonText}
+              handleJsonChange={handleDefinitionJsonChange}
+              jsonError={definitionJsonError}
+              setJsonError={setDefinitionJsonError}
+              validationError={definitionValidationError}
+              setValidationError={setDefinitionValidationError}
+              onValidateConfig={validateDefinitionJson}
+              onValidationStatusChange={setDefinitionValidationStatus}
+              height={JSON_EDITOR_HEIGHT}
+              label="Control definition (JSON)"
+              tooltip="Edit the raw control definition as JSON. Control name remains outside this editor."
+              helperText="Enter the raw control definition only. Do not wrap it in data, name, id, or control objects."
+              testId="control-json-textarea"
             />
-          </Grid.Col>
-
-          <Grid.Col span={8}>
-            {canEditLeafCondition ? (
-              <EvaluatorConfigSection
-                config={evaluatorConfig}
-                evaluatorForm={evaluatorForm}
-                formComponent={formComponent}
-                height={EVALUATOR_CONFIG_HEIGHT}
-                onConfigChange={syncJsonToForm}
-                onValidateConfig={validateEvaluatorConfig}
+          </Paper>
+        ) : (
+          <Grid gutter="xl">
+            <Grid.Col span={4}>
+              <ControlDefinitionForm
+                form={definitionForm}
+                steps={steps}
+                disableSelectorPath={!canEditLeafCondition}
               />
-            ) : (
-              <Alert
-                color="blue"
-                variant="light"
-                title="Condition editing unavailable"
-              >
-                {conditionEditingMessage}
-              </Alert>
-            )}
-          </Grid.Col>
-        </Grid>
+            </Grid.Col>
+
+            <Grid.Col span={8}>
+              {canEditLeafCondition ? (
+                <EvaluatorConfigSection
+                  config={evaluatorConfig}
+                  evaluatorForm={evaluatorForm}
+                  formComponent={formComponent}
+                  height={EVALUATOR_CONFIG_HEIGHT}
+                  onConfigChange={syncJsonToForm}
+                  onValidateConfig={validateEvaluatorConfig}
+                />
+              ) : (
+                <Alert color="blue" variant="light" title="Composite condition">
+                  This control uses a composite boolean condition tree. Switch
+                  to Full JSON mode to edit the condition.
+                </Alert>
+              )}
+            </Grid.Col>
+          </Grid>
+        )}
 
         {apiError ? (
           <>

--- a/ui/src/core/page-components/agent-detail/modals/edit-control/evaluator-config-section.tsx
+++ b/ui/src/core/page-components/agent-detail/modals/edit-control/evaluator-config-section.tsx
@@ -13,7 +13,7 @@ import { useState } from 'react';
 
 import type { ProblemDetail } from '@/core/api/types';
 
-import { EvaluatorJsonView } from './evaluator-json-view';
+import { JsonEditorView } from './json-editor-view';
 import type { ConfigViewMode } from './types';
 
 const DEFAULT_HEIGHT = 450;
@@ -124,10 +124,13 @@ export function EvaluatorConfigSection({
               </Text>
             )
           ) : (
-            <EvaluatorJsonView
+            <JsonEditorView
               onValidateConfig={onValidateConfig}
               onValidationStatusChange={setValidationStatus}
               height={height}
+              label="Configuration (JSON)"
+              tooltip="Raw evaluator configuration in JSON format"
+              testId="raw-json-textarea"
               {...jsonViewProps}
             />
           )}

--- a/ui/src/core/page-components/agent-detail/modals/edit-control/json-editor-view.tsx
+++ b/ui/src/core/page-components/agent-detail/modals/edit-control/json-editor-view.tsx
@@ -1,4 +1,4 @@
-import { Box, Textarea } from '@mantine/core';
+import { Box, Text, Textarea } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { useEffect, useRef } from 'react';
 
@@ -9,12 +9,15 @@ import {
 } from '@/core/components/label-with-tooltip';
 
 import { ApiErrorAlert } from './api-error-alert';
-import type { EvaluatorJsonViewProps } from './types';
+import type { JsonEditorViewProps } from './types';
 
 const DEFAULT_HEIGHT = 400;
 const DEFAULT_VALIDATE_DEBOUNCE_MS = 500;
+const DEFAULT_LABEL = 'Configuration (JSON)';
+const DEFAULT_TOOLTIP = 'Raw JSON configuration';
+const DEFAULT_TEST_ID = 'raw-json-textarea';
 
-export const EvaluatorJsonView = ({
+export const JsonEditorView = ({
   jsonText,
   handleJsonChange,
   jsonError,
@@ -25,7 +28,11 @@ export const EvaluatorJsonView = ({
   onValidationStatusChange,
   validateDebounceMs = DEFAULT_VALIDATE_DEBOUNCE_MS,
   height = DEFAULT_HEIGHT,
-}: EvaluatorJsonViewProps) => {
+  label = DEFAULT_LABEL,
+  tooltip = DEFAULT_TOOLTIP,
+  helperText,
+  testId = DEFAULT_TEST_ID,
+}: JsonEditorViewProps) => {
   const [debouncedJsonText] = useDebouncedValue(jsonText, validateDebounceMs);
   const abortControllerRef = useRef<AbortController | null>(null);
 
@@ -40,7 +47,7 @@ export const EvaluatorJsonView = ({
 
     let parsed: Record<string, unknown>;
     try {
-      parsed = JSON.parse(debouncedJsonText);
+      parsed = JSON.parse(debouncedJsonText) as Record<string, unknown>;
     } catch {
       setJsonError?.('Invalid JSON');
       setValidationError?.(null);
@@ -74,21 +81,16 @@ export const EvaluatorJsonView = ({
     return () => controller.abort();
   }, [
     debouncedJsonText,
-    setJsonError,
     onValidateConfig,
-    setValidationError,
     onValidationStatusChange,
+    setJsonError,
+    setValidationError,
   ]);
 
   return (
     <Box>
       <Textarea
-        label={
-          <LabelWithTooltip
-            label="Configuration (JSON)"
-            tooltip="Raw evaluator configuration in JSON format"
-          />
-        }
+        label={<LabelWithTooltip label={label} tooltip={tooltip} />}
         labelProps={labelPropsInline}
         value={jsonText}
         onChange={(e) => handleJsonChange(e.currentTarget.value)}
@@ -101,8 +103,13 @@ export const EvaluatorJsonView = ({
           },
         }}
         error={jsonError}
-        data-testid="raw-json-textarea"
+        data-testid={testId}
       />
+      {helperText ? (
+        <Text size="xs" c="dimmed" mt="xs">
+          {helperText}
+        </Text>
+      ) : null}
       {validationError ? (
         <Box mt="sm">
           <ApiErrorAlert error={validationError} unmappedErrors={[]} />

--- a/ui/src/core/page-components/agent-detail/modals/edit-control/types.ts
+++ b/ui/src/core/page-components/agent-detail/modals/edit-control/types.ts
@@ -1,4 +1,5 @@
 import type { UseFormReturnType } from '@mantine/form';
+import type { ReactNode } from 'react';
 
 import type {
   Control,
@@ -20,6 +21,7 @@ export type { RegexFormValues } from '@/core/evaluators/regex/types';
 export type { SqlFormValues } from '@/core/evaluators/sql/types';
 
 export type ConfigViewMode = 'form' | 'json';
+export type ControlEditorMode = 'form' | 'json';
 
 // Form values type for control definition
 // Uses snake_case to match API field names directly
@@ -56,7 +58,7 @@ export type EditControlProps = {
   onSuccess?: () => void;
 };
 
-export type EvaluatorJsonViewProps = {
+export type JsonEditorViewProps = {
   /** Current JSON text shown in the editor */
   jsonText: string;
   /** Update handler when JSON text changes */
@@ -76,6 +78,14 @@ export type EvaluatorJsonViewProps = {
   validateDebounceMs?: number;
   /** Optional height for the editor area */
   height?: number;
+  /** Optional label for the JSON editor */
+  label?: string;
+  /** Optional tooltip for the JSON editor label */
+  tooltip?: string;
+  /** Optional helper text shown below the editor */
+  helperText?: ReactNode;
+  /** Optional test id for the textarea */
+  testId?: string;
 };
 
 export type ControlDefinitionFormProps = {

--- a/ui/tests/agent-detail.spec.ts
+++ b/ui/tests/agent-detail.spec.ts
@@ -624,6 +624,145 @@ test.describe('Agent Detail Page', () => {
     ).not.toBeVisible();
   });
 
+  test('controls can be edited through the full JSON editor', async ({
+    mockedPage,
+  }) => {
+    const compositeControl: Control = {
+      id: 77,
+      name: 'Risk Escalation Guard',
+      control: {
+        description: 'Escalates high-risk interactions',
+        enabled: true,
+        execution: 'server',
+        scope: { step_types: ['llm'], stages: ['post'] },
+        condition: {
+          and: [
+            {
+              selector: { path: 'context.risk_level' },
+              evaluator: {
+                name: 'list',
+                config: {
+                  values: ['high', 'critical'],
+                  logic: 'any',
+                  match_on: 'match',
+                },
+              },
+            },
+            {
+              not: {
+                selector: { path: 'context.user_role' },
+                evaluator: {
+                  name: 'list',
+                  config: {
+                    values: ['admin'],
+                    logic: 'any',
+                    match_on: 'match',
+                  },
+                },
+              },
+            },
+          ],
+        },
+        action: { decision: 'deny' },
+        tags: ['risk'],
+      },
+    };
+    const compositeControls: AgentControlsResponse = {
+      controls: [compositeControl],
+    };
+    const updatedCondition = {
+      or: [
+        {
+          selector: { path: 'context.risk_level' },
+          evaluator: {
+            name: 'list',
+            config: {
+              values: ['critical'],
+              logic: 'any',
+              match_on: 'match',
+            },
+          },
+        },
+        {
+          selector: { path: 'output' },
+          evaluator: {
+            name: 'regex',
+            config: { pattern: 'urgent' },
+          },
+        },
+      ],
+    };
+
+    let updateRequestBody: Record<string, unknown> | null = null;
+
+    await mockRoutes.agent(mockedPage, {
+      controls: { data: compositeControls },
+    });
+    await mockedPage.route(
+      '**/api/v1/controls/77/data',
+      async (route, request) => {
+        if (request.method() === 'GET') {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ data: compositeControl.control }),
+          });
+          return;
+        }
+
+        if (request.method() === 'PUT') {
+          updateRequestBody = (await request.postDataJSON()) as Record<
+            string,
+            unknown
+          >;
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ success: true }),
+          });
+          return;
+        }
+
+        await route.continue();
+      }
+    );
+
+    await mockedPage.goto(
+      getAgentControlsUrl({ modal: 'edit', controlId: 77 })
+    );
+
+    const modal = mockedPage.getByRole('dialog', { name: 'Edit Control' });
+    await expect(modal).toBeVisible();
+    await modal.getByText('Full JSON', { exact: true }).click();
+    await expect(modal.getByTestId('control-json-textarea')).toBeVisible();
+
+    await modal.getByTestId('control-json-textarea').fill(
+      JSON.stringify(
+        {
+          ...compositeControl.control,
+          description: 'Updated in full JSON mode',
+          condition: updatedCondition,
+        },
+        null,
+        2
+      )
+    );
+
+    await modal.getByRole('button', { name: /Save/i }).click();
+    await mockedPage.getByRole('button', { name: /Confirm/i }).click({
+      force: true,
+    });
+
+    await expect.poll(() => updateRequestBody).not.toBeNull();
+
+    expect(updateRequestBody).toMatchObject({
+      data: {
+        description: 'Updated in full JSON mode',
+        condition: updatedCondition,
+      },
+    });
+  });
+
   test('disables Form switch when JSON is invalid', async ({ mockedPage }) => {
     await mockedPage.goto(agentUrl);
 
@@ -657,7 +796,9 @@ test.describe('Agent Detail Page', () => {
     await jsonInput.fill('{');
 
     // Form option should be disabled when JSON is invalid (validation is debounced ~500ms)
-    await expect(modal.getByRole('radio', { name: 'Form' })).toBeDisabled({
+    await expect(
+      modal.getByRole('radio', { name: 'Form' }).last()
+    ).toBeDisabled({
       timeout: 2000,
     });
   });

--- a/ui/tests/control-store.spec.ts
+++ b/ui/tests/control-store.spec.ts
@@ -513,6 +513,100 @@ test.describe('Modal Routing', () => {
     await expect(createModal).toBeVisible();
   });
 
+  test('can create a control from full JSON', async ({ mockedPage }) => {
+    const addNewModal = await openAddNewControlModal(mockedPage);
+    await addNewModal.getByTestId('from-json-button').click();
+
+    await expect(mockedPage).toHaveURL(
+      getAgentControlsUrl({
+        modal: 'control-store',
+        submodal: 'create',
+      })
+    );
+
+    const createModal = mockedPage.getByRole('dialog', {
+      name: 'Create Control',
+    });
+    await expect(createModal).toBeVisible();
+    await expect(
+      createModal.getByTestId('control-json-textarea')
+    ).toBeVisible();
+
+    let createRequestBody: Record<string, unknown> | null = null;
+
+    await mockedPage.route('**/api/v1/controls', async (route, request) => {
+      if (request.method() === 'PUT') {
+        createRequestBody = (await request.postDataJSON()) as Record<
+          string,
+          unknown
+        >;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ control_id: 100 }),
+        });
+      } else {
+        await route.continue();
+      }
+    });
+
+    await mockedPage.route(
+      '**/api/v1/agents/*/controls/*',
+      async (route, request) => {
+        if (request.method() === 'POST') {
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ success: true }),
+          });
+        } else {
+          await route.continue();
+        }
+      }
+    );
+
+    const jsonDefinition = {
+      description: 'Created from JSON',
+      enabled: true,
+      execution: 'server',
+      scope: { step_types: ['tool'], stages: ['pre'] },
+      condition: {
+        selector: { path: 'input.query' },
+        evaluator: {
+          name: 'sql',
+          config: { mode: 'strict' },
+        },
+      },
+      action: { decision: 'deny' },
+      tags: ['json'],
+    };
+
+    await createModal
+      .getByPlaceholder('Enter control name')
+      .fill('json-created-control');
+    await createModal
+      .getByTestId('control-json-textarea')
+      .fill(JSON.stringify(jsonDefinition, null, 2));
+
+    await createModal.getByRole('button', { name: /Save|Create/i }).click();
+
+    const confirmButton = mockedPage.locator("button:has-text('Confirm')");
+    await expect(confirmButton).toBeVisible({ timeout: 5000 });
+
+    const responsePromise = mockedPage.waitForResponse(
+      '**/api/v1/agents/*/controls/*',
+      { timeout: 10000 }
+    );
+    await confirmButton.click();
+    await responsePromise;
+
+    await expect.poll(() => createRequestBody).not.toBeNull();
+    expect(createRequestBody).toMatchObject({
+      name: 'json-created-control',
+      data: jsonDefinition,
+    });
+  });
+
   test('closes all modals when control is successfully created', async ({
     mockedPage,
   }) => {


### PR DESCRIPTION
## Summary
- add `Full JSON` mode for editing the entire control definition from the control modal
- add `From JSON` in the create-control flow so a control can be created directly from JSON without picking an evaluator first
- reuse a shared JSON editor for both full control definitions and evaluator config JSON
- add helper text clarifying that the control JSON editor expects the raw control definition, not `data` / `name` / `id` wrapper objects
- add Playwright coverage for the JSON create/edit flows

## Testing
- `make ui-typecheck`
- `make ui-lint` *(passes; existing `no-img-element` warnings remain in `ui/src/core/layouts/app-layout.tsx`)*

## Screenshots

New control UI now has `From JSON` button`
<img width="841" height="613" alt="image" src="https://github.com/user-attachments/assets/0db00e89-5fd0-4cca-bbee-ff2378a1fb87" />

When you click on it you get this
<img width="794" height="916" alt="Screenshot 2026-03-24 at 9 11 12 PM" src="https://github.com/user-attachments/assets/f487e36a-b635-4fbf-b528-e83cb1404f9c" />

you can also edit full json in control now
<img width="802" height="917" alt="Screenshot 2026-03-24 at 9 11 38 PM" src="https://github.com/user-attachments/assets/7207ce13-ec49-4137-9928-7bcdcd27eb64" />

