### PR TITLE
fix(docs): add explicit shutdown to quickstart example

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,14 @@ async def main():
         print(await chat("test"))  # ❌ Blocked
     except ControlViolationError as e:
         print(f"❌ Blocked: {e.control_name}")
+    finally:
+        await agent_control.ashutdown()
 
-asyncio.run(main())
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
+
+Use `agent_control.shutdown()` or `await agent_control.ashutdown()` before process exit so short-lived scripts flush pending observability events cleanly.
 
 Next, create a control in Step 4, then run the setup and agent scripts in
 order to see blocking in action.


### PR DESCRIPTION
## Summary
- update the README quickstart async example to call `agent_control.ashutdown()` in a `finally` block
- wrap the snippet with an `if __name__ == "__main__":` guard
- add a short note explaining that short-lived scripts should explicitly shut down so observability events flush before exit

## Testing
- make check
- git push -u origin abhi/quickstart-explicit-shutdown (pre-push hook: lint, typecheck, contrib evaluator checks)
