### PR TITLE
feat(server): Align condition and template depth limits

### DIFF
--- a/models/src/agent_control_models/controls.py
+++ b/models/src/agent_control_models/controls.py
@@ -281,8 +281,9 @@ class SteeringContext(BaseModel):
 type TemplateValue = str | bool | list[str]
 type JsonValue = JSONValue
 
+MAX_CONDITION_DEPTH = 12
 _TEMPLATE_PARAMETER_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
-MAX_TEMPLATE_DEFINITION_DEPTH = 12
+MAX_TEMPLATE_DEFINITION_DEPTH = MAX_CONDITION_DEPTH
 MAX_TEMPLATE_DEFINITION_NODES = 1000
 
 
@@ -522,9 +523,6 @@ class ControlAction(BaseModel):
     @classmethod
     def normalize_decision(cls, value: str) -> ActionDecision:
         return normalize_action(value)
-
-
-MAX_CONDITION_DEPTH = 6
 
 
 def _validate_common_control_constraints(

--- a/models/tests/test_controls.py
+++ b/models/tests/test_controls.py
@@ -164,13 +164,28 @@ def test_condition_iter_leaves_preserves_left_to_right_order() -> None:
 
 def test_condition_depth_limit_is_enforced() -> None:
     # Given: a condition tree nested deeper than the allowed maximum
+    allowed_depth = _leaf("input")
+    for _ in range(11):
+        allowed_depth = {"not": allowed_depth}
+
+    control = ControlDefinition.model_validate(
+        {
+            "execution": "server",
+            "scope": {"step_types": ["llm"], "stages": ["pre"]},
+            "condition": allowed_depth,
+            "action": {"decision": "deny"},
+        }
+    )
+
+    assert control.condition.max_depth() == 12
+
     too_deep = _leaf("input")
-    for _ in range(6):
+    for _ in range(12):
         too_deep = {"not": too_deep}
 
     with pytest.raises(
         ValidationError,
-        match="Condition nesting depth exceeds maximum of 6",
+        match="Condition nesting depth exceeds maximum of 12",
     ):
         # When: validating the deep condition tree
         ControlDefinition.model_validate(


### PR DESCRIPTION
## Summary
- increase the shared condition nesting depth limit from 6 to 12
- make `MAX_TEMPLATE_DEFINITION_DEPTH` derive from `MAX_CONDITION_DEPTH` so both limits stay aligned
- expand the condition-depth model test to verify depth 12 succeeds and depth 13 still fails

## Why
The condition-tree limit had been raised independently, but the template definition depth used a separate constant value. Referencing the shared constant removes drift and keeps template-backed controls aligned with the same supported nesting depth.

## Impact
Template-backed and non-template control validation now share one source of truth for depth limits. Future changes to the condition limit will automatically apply to template definition depth as well.

## Validation
- `make test TEST= models/tests/test_controls.py` (this invoked the repo's full default `make test` chain and passed across models, telemetry, server, engine, Python SDK, and builtin evaluators)
- `make models-test`
