### PR TITLE
chore(docs): update docs URLs from v2docs to docs.galileo.ai

### DIFF
--- a/evaluators/contrib/galileo/src/agent_control_evaluator_galileo/luna2/__init__.py
+++ b/evaluators/contrib/galileo/src/agent_control_evaluator_galileo/luna2/__init__.py
@@ -11,8 +11,8 @@ Environment Variables:
     GALILEO_CONSOLE_URL: Optional, for custom deployments
 
 Documentation:
-    https://v2docs.galileo.ai/concepts/protect/overview
-    https://v2docs.galileo.ai/sdk-api/python/reference/protect
+    https://docs.galileo.ai/concepts/protect/overview
+    https://docs.galileo.ai/sdk-api/python/reference/protect
 """
 
 from agent_control_evaluator_galileo.luna2.config import (

--- a/evaluators/contrib/galileo/src/agent_control_evaluator_galileo/luna2/client.py
+++ b/evaluators/contrib/galileo/src/agent_control_evaluator_galileo/luna2/client.py
@@ -3,7 +3,7 @@
 This module provides a lightweight HTTP client that calls the Galileo Protect API
 directly, without requiring the full galileo-sdk package.
 
-Reference: https://v2docs.galileo.ai/sdk-api/python/reference/protect
+Reference: https://docs.galileo.ai/sdk-api/python/reference/protect
 """
 
 import logging


### PR DESCRIPTION
Updates all `v2docs.galileo.ai` links to `docs.galileo.ai` following the migration of v2 docs to the docs subdomain.