### PR TITLE
feat(server): tenant-aware write paths and pluggable tenant resolver (4/7)

### DIFF
--- a/server/src/agent_control_server/endpoints/agents.py
+++ b/server/src/agent_control_server/endpoints/agents.py
@@ -71,6 +71,7 @@ from ..services.schema_compat import (
     check_schema_compatibility,
     format_compatibility_error,
 )
+from ..tenancy import get_tenant_id
 
 router = APIRouter(prefix="/agents", tags=["agents"])
 
@@ -460,6 +461,7 @@ async def list_agents(
 async def init_agent(
     request: InitAgentRequest,
     client: RequireAPIKey,
+    tenant_id: str = Depends(get_tenant_id),
     db: AsyncSession = Depends(get_async_db),
 ) -> InitAgentResponse:
     """
@@ -541,6 +543,7 @@ async def init_agent(
 
         new_agent = Agent(
             name=request.agent.agent_name,
+            tenant_id=tenant_id,
             data=data_model.model_dump(mode="json"),
         )
         db.add(new_agent)
@@ -956,7 +959,11 @@ async def add_agent_policy(
     try:
         stmt = (
             pg_insert(agent_policies)
-            .values(agent_name=agent.name, policy_id=policy_id)
+            .values(
+                agent_name=agent.name,
+                policy_id=policy_id,
+                tenant_id=agent.tenant_id,
+            )
             .on_conflict_do_nothing()
         )
         await db.execute(stmt)
@@ -1031,7 +1038,11 @@ async def set_agent_policy(
         await db.execute(delete(agent_policies).where(agent_policies.c.agent_name == agent.name))
         await db.execute(
             pg_insert(agent_policies)
-            .values(agent_name=agent.name, policy_id=policy_id)
+            .values(
+                agent_name=agent.name,
+                policy_id=policy_id,
+                tenant_id=agent.tenant_id,
+            )
             .on_conflict_do_nothing()
         )
         await db.commit()
@@ -1279,7 +1290,11 @@ async def add_agent_control(
     try:
         stmt = (
             pg_insert(agent_controls)
-            .values(agent_name=agent.name, control_id=control_id)
+            .values(
+                agent_name=agent.name,
+                control_id=control_id,
+                tenant_id=agent.tenant_id,
+            )
             .on_conflict_do_nothing()
         )
         await db.execute(stmt)

--- a/server/src/agent_control_server/endpoints/controls.py
+++ b/server/src/agent_control_server/endpoints/controls.py
@@ -53,6 +53,7 @@ from ..services.evaluator_utils import (
 )
 from ..services.query_utils import escape_like_pattern
 from ..services.validation_paths import format_field_path
+from ..tenancy import get_tenant_id
 
 # Pagination constants
 _DEFAULT_PAGINATION_LIMIT = 20
@@ -443,7 +444,9 @@ async def render_control_template(
     response_description="Created control ID",
 )
 async def create_control(
-    request: CreateControlRequest, db: AsyncSession = Depends(get_async_db)
+    request: CreateControlRequest,
+    tenant_id: str = Depends(get_tenant_id),
+    db: AsyncSession = Depends(get_async_db),
 ) -> CreateControlResponse:
     """
     Create a new control with a unique name.
@@ -476,7 +479,7 @@ async def create_control(
     control_def = await _materialize_control_input(request.data, db=db)
     control_data = _serialize_control_data(control_def)
 
-    control = Control(name=request.name, data=control_data)
+    control = Control(name=request.name, tenant_id=tenant_id, data=control_data)
     db.add(control)
     try:
         await db.commit()

--- a/server/src/agent_control_server/endpoints/policies.py
+++ b/server/src/agent_control_server/endpoints/policies.py
@@ -14,6 +14,7 @@ from ..db import get_async_db
 from ..errors import ConflictError, DatabaseError, NotFoundError
 from ..logging_utils import get_logger
 from ..models import Control, Policy, policy_controls
+from ..tenancy import get_tenant_id
 
 router = APIRouter(prefix="/policies", tags=["policies"])
 
@@ -28,7 +29,9 @@ _logger = get_logger(__name__)
     response_description="Created policy ID",
 )
 async def create_policy(
-    request: CreatePolicyRequest, db: AsyncSession = Depends(get_async_db)
+    request: CreatePolicyRequest,
+    tenant_id: str = Depends(get_tenant_id),
+    db: AsyncSession = Depends(get_async_db),
 ) -> CreatePolicyResponse:
     """
     Create a new empty policy with a unique name.
@@ -58,7 +61,7 @@ async def create_policy(
             hint="Choose a different name or update the existing policy.",
         )
 
-    policy = Policy(name=request.name)
+    policy = Policy(name=request.name, tenant_id=tenant_id)
     db.add(policy)
     try:
         await db.commit()

--- a/server/src/agent_control_server/tenancy.py
+++ b/server/src/agent_control_server/tenancy.py
@@ -1,19 +1,68 @@
 """Tenant resolution for request handlers.
 
 OSS deployments typically run as a single synthetic tenant. This module
-exposes a minimal dependency that reads an optional ``X-Tenant-Id`` header
-and falls back to ``DEFAULT_TENANT_ID`` when absent. A richer resolver
-(e.g. reading from authenticated context) can be added later; the
-dependency signature is the stable contract callers should depend on.
+exposes a request-scoped dependency, ``get_tenant_id``, that returns the
+effective tenant for any handler. Resolution flows through a pluggable
+``TenantResolver`` so deployments with their own tenant identity source
+(e.g. authenticated JWT claims) can swap in an alternative implementation
+via ``set_tenant_resolver`` at application startup.
+
+The shipped default, ``HeaderTenantResolver``, reads the optional
+``X-Tenant-Id`` header and falls back to ``DEFAULT_TENANT_ID``. That keeps
+callers which do not supply a tenant header working unchanged.
 """
 
 from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
 
 from fastapi import Header
 
 from .models import DEFAULT_TENANT_ID
 
 TENANT_HEADER_NAME = "X-Tenant-Id"
+
+
+@runtime_checkable
+class TenantResolver(Protocol):
+    """Resolves the effective tenant for an incoming request.
+
+    Implementations receive the raw header value (``None`` if absent) and
+    return a non-empty tenant id. The interface intentionally keeps the
+    surface minimal so enterprise extensions can grow it without forcing
+    OSS code to adopt auth-specific types.
+    """
+
+    def resolve(self, x_tenant_id: str | None) -> str: ...
+
+
+class HeaderTenantResolver:
+    """Default resolver: read ``X-Tenant-Id`` header, fall back to ``DEFAULT_TENANT_ID``."""
+
+    def resolve(self, x_tenant_id: str | None) -> str:
+        if x_tenant_id is None:
+            return DEFAULT_TENANT_ID
+        trimmed = x_tenant_id.strip()
+        return trimmed if trimmed else DEFAULT_TENANT_ID
+
+
+_active_resolver: TenantResolver = HeaderTenantResolver()
+
+
+def set_tenant_resolver(resolver: TenantResolver) -> None:
+    """Install a replacement tenant resolver (e.g. for enterprise deployments).
+
+    The replacement is process-wide; call this during app startup before any
+    request is served. Tests that temporarily swap the resolver should restore
+    the prior instance in teardown.
+    """
+    global _active_resolver
+    _active_resolver = resolver
+
+
+def get_active_resolver() -> TenantResolver:
+    """Return the currently installed tenant resolver."""
+    return _active_resolver
 
 
 def get_tenant_id(
@@ -26,11 +75,10 @@ def get_tenant_id(
         include_in_schema=False,
     ),
 ) -> str:
-    """Return the effective tenant for this request.
+    """FastAPI dependency that returns the effective tenant for this request.
 
-    Callers that omit the header land on the default tenant.
+    Callers that omit the tenant header land on ``DEFAULT_TENANT_ID``.
+    Deployments that resolve tenants from their own context can override the
+    active resolver via ``set_tenant_resolver``.
     """
-    if x_tenant_id is None:
-        return DEFAULT_TENANT_ID
-    trimmed = x_tenant_id.strip()
-    return trimmed if trimmed else DEFAULT_TENANT_ID
+    return _active_resolver.resolve(x_tenant_id)

--- a/server/tests/test_tenant_aware_writes.py
+++ b/server/tests/test_tenant_aware_writes.py
@@ -1,0 +1,223 @@
+"""Tests for tenant-aware write paths.
+
+Covers:
+
+- Agent / control / policy creation picks up the resolved tenant from the
+  ``X-Tenant-Id`` header (header-based default resolver).
+- Association inserts (agent_policies, agent_controls) record a tenant_id
+  consistent with the agent's tenant_id.
+- A pluggable ``TenantResolver`` override is picked up by the dependency.
+- Callers without any header continue to land in the default tenant.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from agent_control_server.models import DEFAULT_TENANT_ID
+from agent_control_server.tenancy import (
+    HeaderTenantResolver,
+    TenantResolver,
+    get_active_resolver,
+    set_tenant_resolver,
+)
+
+from .utils import VALID_CONTROL_PAYLOAD
+
+API_PREFIX = "/api/v1"
+TENANT_HEADER = "X-Tenant-Id"
+
+
+def _unique(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:10]}"
+
+
+def _create_control(
+    client: TestClient, *, tenant: str | None = None
+) -> tuple[int, str]:
+    name = _unique("ctrl")
+    headers = {TENANT_HEADER: tenant} if tenant else {}
+    resp = client.put(
+        f"{API_PREFIX}/controls",
+        headers=headers,
+        json={"name": name, "data": VALID_CONTROL_PAYLOAD},
+    )
+    assert resp.status_code == 200, resp.text
+    return int(resp.json()["control_id"]), name
+
+
+def _create_policy(
+    client: TestClient, *, tenant: str | None = None
+) -> tuple[int, str]:
+    name = _unique("pol")
+    headers = {TENANT_HEADER: tenant} if tenant else {}
+    resp = client.put(
+        f"{API_PREFIX}/policies", headers=headers, json={"name": name}
+    )
+    assert resp.status_code == 200, resp.text
+    return int(resp.json()["policy_id"]), name
+
+
+def _init_agent(
+    client: TestClient, *, tenant: str | None = None, agent_name: str | None = None
+) -> str:
+    name = agent_name or f"agent-{uuid.uuid4().hex[:12]}"
+    headers = {TENANT_HEADER: tenant} if tenant else {}
+    resp = client.post(
+        f"{API_PREFIX}/agents/initAgent",
+        headers=headers,
+        json={"agent": {"agent_name": name}, "steps": []},
+    )
+    assert resp.status_code == 200, resp.text
+    return name
+
+
+def _tenant_of(db_engine, table: str, where_sql: str, params: dict) -> str:
+    with db_engine.begin() as conn:
+        row = conn.execute(
+            text(f"SELECT tenant_id FROM {table} WHERE {where_sql}"),
+            params,
+        ).first()
+    assert row is not None, f"expected row in {table} matching {params}"
+    return str(row[0])
+
+
+# ---------------------------------------------------------------------------
+# Default resolver (header-based) behavior
+# ---------------------------------------------------------------------------
+
+
+def test_control_create_without_header_lands_in_default_tenant(
+    client: TestClient, db_engine
+) -> None:
+    _, name = _create_control(client)
+    assert _tenant_of(
+        db_engine, "controls", "name = :name", {"name": name}
+    ) == DEFAULT_TENANT_ID
+
+
+def test_control_create_with_header_lands_in_resolved_tenant(
+    client: TestClient, db_engine
+) -> None:
+    _, name = _create_control(client, tenant="acme-corp")
+    assert _tenant_of(
+        db_engine, "controls", "name = :name", {"name": name}
+    ) == "acme-corp"
+
+
+def test_policy_create_with_header_lands_in_resolved_tenant(
+    client: TestClient, db_engine
+) -> None:
+    _, name = _create_policy(client, tenant="acme-corp")
+    assert _tenant_of(
+        db_engine, "policies", "name = :name", {"name": name}
+    ) == "acme-corp"
+
+
+def test_agent_create_with_header_lands_in_resolved_tenant(
+    client: TestClient, db_engine
+) -> None:
+    name = _init_agent(client, tenant="acme-corp")
+    assert _tenant_of(
+        db_engine, "agents", "name = :name", {"name": name}
+    ) == "acme-corp"
+
+
+def test_agent_policy_association_inherits_agent_tenant(
+    client: TestClient, db_engine
+) -> None:
+    """Association rows must record the agent's tenant, not the request-scoped one."""
+    agent_name = _init_agent(client, tenant="agent-tenant")
+    policy_id, _ = _create_policy(client, tenant="policy-tenant")
+
+    # Attach without a header. The association must still pick up the agent's tenant
+    # rather than falling through to DEFAULT_TENANT_ID.
+    attach = client.post(f"{API_PREFIX}/agents/{agent_name}/policies/{policy_id}")
+    assert attach.status_code == 200, attach.text
+
+    recorded = _tenant_of(
+        db_engine,
+        "agent_policies",
+        "agent_name = :name AND policy_id = :policy_id",
+        {"name": agent_name, "policy_id": policy_id},
+    )
+    assert recorded == "agent-tenant"
+
+
+def test_agent_control_association_inherits_agent_tenant(
+    client: TestClient, db_engine
+) -> None:
+    agent_name = _init_agent(client, tenant="agent-tenant")
+    control_id, _ = _create_control(client, tenant="other-tenant")
+
+    attach = client.post(
+        f"{API_PREFIX}/agents/{agent_name}/controls/{control_id}"
+    )
+    assert attach.status_code == 200, attach.text
+
+    recorded = _tenant_of(
+        db_engine,
+        "agent_controls",
+        "agent_name = :name AND control_id = :control_id",
+        {"name": agent_name, "control_id": control_id},
+    )
+    assert recorded == "agent-tenant"
+
+
+def test_whitespace_header_falls_back_to_default_tenant(
+    client: TestClient, db_engine
+) -> None:
+    _, name = _create_control(client, tenant="   ")
+    assert _tenant_of(
+        db_engine, "controls", "name = :name", {"name": name}
+    ) == DEFAULT_TENANT_ID
+
+
+# ---------------------------------------------------------------------------
+# Pluggable resolver
+# ---------------------------------------------------------------------------
+
+
+class _ConstantTenantResolver:
+    """Test resolver that always returns a preconfigured tenant id."""
+
+    def __init__(self, tenant: str) -> None:
+        self._tenant = tenant
+
+    def resolve(self, x_tenant_id: str | None) -> str:
+        del x_tenant_id  # ignored by this resolver
+        return self._tenant
+
+
+@pytest.fixture
+def swap_resolver() -> Iterator[None]:
+    previous = get_active_resolver()
+    try:
+        yield None
+    finally:
+        set_tenant_resolver(previous)
+
+
+def test_tenant_resolver_protocol_is_runtime_checkable() -> None:
+    assert isinstance(_ConstantTenantResolver("enterprise"), TenantResolver)
+    assert isinstance(HeaderTenantResolver(), TenantResolver)
+
+
+def test_installed_resolver_overrides_request_header(
+    client: TestClient, db_engine, swap_resolver: None
+) -> None:
+    del swap_resolver
+    set_tenant_resolver(_ConstantTenantResolver("enterprise-default"))
+
+    # Even though the client sends a header, the enterprise resolver ignores
+    # it and returns its own tenant. This mimics how an auth-driven resolver
+    # would override request-supplied identity.
+    _, name = _create_control(client, tenant="client-supplied-ignored")
+    assert _tenant_of(
+        db_engine, "controls", "name = :name", {"name": name}
+    ) == "enterprise-default"


### PR DESCRIPTION
Stacked on top of #181. Kept in draft until the full stack has been validated end-to-end.

## Summary
- Introduces `TenantResolver` Protocol and `HeaderTenantResolver` default implementation in `tenancy.py`.
- `set_tenant_resolver(...)` lets deployments with their own tenant identity source (e.g. auth claims) swap in an alternative resolver at startup.
- Agent (`initAgent`), control (`create_control`), and policy (`create_policy`) creation now persist the resolved tenant explicitly instead of relying solely on the DB default.
- Association inserts into `agent_policies` and `agent_controls` record the owning agent's `tenant_id`, not the request-scoped one. This keeps association rows consistent with the parent agent under all tenant mechanisms.
- Read paths remain unscoped (matches the stance from the bottom of the stack).

## Design notes
- The resolver seam is intentionally small: one method, `resolve(x_tenant_id)`. This keeps the OSS code free of auth-specific types and lets extensions grow without forcing OSS code to adopt them.
- The process-wide resolver is installed once at startup. Tests that swap it via a fixture restore the prior resolver in teardown.
- Default behavior is unchanged: no header -> `default-tenant`.

## Intentional non-goals (deferred)
- Tenant-scoped reads on agent/control/policy endpoints. Still out of scope because it would require changing primary keys or adding tenant predicates to many existing queries.
- Removing global uniqueness on `Agent.name`, `Control.name`, `Policy.name`. Cross-tenant name collisions still apply. Tests use distinct names per tenant rather than depending on tenant-scoped uniqueness.
- Specific auth-driven resolver implementations.

## Test plan
- [x] `make check` clean locally (562 server tests including 9 new)
- [x] New coverage:
  - Writes without a header land in default-tenant for agent/control/policy
  - Writes with `X-Tenant-Id` land in the resolved tenant
  - `agent_policies` / `agent_controls` rows inherit the agent's `tenant_id`
  - Whitespace header normalizes to default-tenant
  - `TenantResolver` Protocol is runtime-checkable
  - Installed resolver override is honored by the dependency
- [x] All existing tests pass unmodified (behavior preservation)
- [x] Validated on integration branch with PR1-PR4 merged