### PR TITLE
feat(sdk): forward target_type and target_id on evaluation calls (5/7)

### DIFF
--- a/sdks/python/src/agent_control/evaluation.py
+++ b/sdks/python/src/agent_control/evaluation.py
@@ -170,12 +170,19 @@ async def check_evaluation(
     agent_name: str,
     step: Step,
     stage: Literal["pre", "post"],
+    *,
+    target_type: str | None = None,
+    target_id: str | None = None,
 ) -> EvaluationResult:
     """Check if agent interaction is safe through the public SDK helper.
 
     The server returns only evaluation semantics. When SDK observability is
     enabled, this helper reconstructs server-side control-execution events
     from the response and enqueues them through the built-in SDK batcher.
+
+    ``target_type`` and ``target_id`` are optional. When both are supplied the
+    server merges controls attached to that target into the effective set;
+    when either is omitted the request uses the agent-only path.
     """
     normalized_name = ensure_agent_name(agent_name)
     resolved_trace_id, resolved_span_id = get_trace_and_span_ids()
@@ -183,6 +190,8 @@ async def check_evaluation(
         agent_name=normalized_name,
         step=step,
         stage=stage,
+        target_type=target_type,
+        target_id=target_id,
     )
     request_payload = request.model_dump(mode="json")
 
@@ -218,8 +227,16 @@ async def check_evaluation_with_local(
     trace_id: str | None = None,
     span_id: str | None = None,
     event_agent_name: str | None = None,
+    *,
+    target_type: str | None = None,
+    target_id: str | None = None,
 ) -> EvaluationResult:
-    """Evaluate controls with local-first execution and SDK-owned event emission."""
+    """Evaluate controls with local-first execution and SDK-owned event emission.
+
+    ``target_type`` / ``target_id`` are optional. When both are supplied they
+    are forwarded to the server on the remote evaluation call, letting the
+    server merge controls attached to that target into its resolution.
+    """
     normalized_name = ensure_agent_name(agent_name)
     resolved_trace_id = trace_id
     resolved_span_id = span_id
@@ -299,6 +316,8 @@ async def check_evaluation_with_local(
         agent_name=normalized_name,
         step=step,
         stage=stage,
+        target_type=target_type,
+        target_id=target_id,
     )
 
     def _with_parse_errors(result: EvaluationResult) -> EvaluationResult:
@@ -402,8 +421,15 @@ async def evaluate_controls(
     agent_name: str,
     trace_id: str | None = None,
     span_id: str | None = None,
+    target_type: str | None = None,
+    target_id: str | None = None,
 ) -> EvaluationResult:
-    """Evaluate controls for a step."""
+    """Evaluate controls for a step.
+
+    When ``target_type`` and ``target_id`` are both supplied, the SDK forwards
+    them to the server so controls attached to that target are included in
+    resolution. Omit either to use the agent-only path.
+    """
     if state.server_url is None:
         raise RuntimeError("Server URL not configured. Call agent_control.init() first.")
 
@@ -430,4 +456,6 @@ async def evaluate_controls(
             trace_id=trace_id,
             span_id=span_id,
             event_agent_name=agent_name,
+            target_type=target_type,
+            target_id=target_id,
         )

--- a/sdks/python/tests/test_evaluation.py
+++ b/sdks/python/tests/test_evaluation.py
@@ -73,6 +73,54 @@ async def test_check_evaluation_returns_result_model():
 
 
 @pytest.mark.asyncio
+async def test_check_evaluation_forwards_target_fields_when_supplied():
+    """target_type and target_id land in the outgoing request body when set."""
+
+    class DummyResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return {"is_safe": True, "confidence": 1.0}
+
+    client = MagicMock()
+    client.http_client = MagicMock()
+    client.http_client.post = AsyncMock(return_value=DummyResponse())
+
+    await evaluation.check_evaluation(
+        client=client,
+        agent_name="Agent-Example_01",
+        step={"type": "llm", "name": "chat", "input": "hello"},
+        stage="pre",
+        target_type="environment",
+        target_id="env-prod-123",
+    )
+
+    sent_payload = client.http_client.post.await_args.kwargs["json"]
+    assert sent_payload["target_type"] == "environment"
+    assert sent_payload["target_id"] == "env-prod-123"
+
+
+@pytest.mark.asyncio
+async def test_check_evaluation_rejects_half_target_context():
+    """Server-side pairing rule must be enforced client-side via model validation."""
+    client = MagicMock()
+    client.http_client = AsyncMock()
+    client.http_client.post = AsyncMock()
+
+    with pytest.raises(ValidationError):
+        await evaluation.check_evaluation(
+            client=client,
+            agent_name="Agent-Example_01",
+            step={"type": "llm", "name": "chat", "input": "hello"},
+            stage="pre",
+            target_type="environment",
+        )
+
+    client.http_client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_evaluate_controls_requires_server_url():
     """evaluate_controls should require server_url to be configured."""
     with patch("agent_control.state.server_url", None):
@@ -124,3 +172,47 @@ async def test_evaluate_controls_with_context(monkeypatch):
             )
 
     assert mock_check.call_args is not None
+
+
+@pytest.mark.asyncio
+async def test_evaluate_controls_forwards_target_fields(monkeypatch):
+    """target_type and target_id flow through to check_evaluation_with_local."""
+    mock_result = EvaluationResult(is_safe=True, confidence=1.0)
+    mock_check = AsyncMock(return_value=mock_result)
+    monkeypatch.setattr(evaluation, "check_evaluation_with_local", mock_check)
+
+    with patch("agent_control.state.server_url", "http://localhost:8000"):
+        with patch("agent_control.state.api_key", None):
+            await evaluation.evaluate_controls(
+                step_name="chat",
+                input="hello",
+                stage="pre",
+                agent_name="test-bot",
+                target_type="environment",
+                target_id="env-prod-123",
+            )
+
+    forwarded = mock_check.call_args.kwargs
+    assert forwarded["target_type"] == "environment"
+    assert forwarded["target_id"] == "env-prod-123"
+
+
+@pytest.mark.asyncio
+async def test_evaluate_controls_defaults_target_fields_to_none(monkeypatch):
+    """Omitting target fields sends None through so the existing path stays unchanged."""
+    mock_result = EvaluationResult(is_safe=True, confidence=1.0)
+    mock_check = AsyncMock(return_value=mock_result)
+    monkeypatch.setattr(evaluation, "check_evaluation_with_local", mock_check)
+
+    with patch("agent_control.state.server_url", "http://localhost:8000"):
+        with patch("agent_control.state.api_key", None):
+            await evaluation.evaluate_controls(
+                step_name="chat",
+                input="hello",
+                stage="pre",
+                agent_name="test-bot",
+            )
+
+    forwarded = mock_check.call_args.kwargs
+    assert forwarded["target_type"] is None
+    assert forwarded["target_id"] is None


### PR DESCRIPTION
Stacked on top of #182. Kept in draft until the full stack is validated.

## Summary
- Threads optional \`target_type\` and \`target_id\` through \`check_evaluation\`, \`check_evaluation_with_local\`, and the top-level \`evaluate_controls\` helper.
- Fields default to \`None\` so every existing call site works unchanged.
- Model-level pairing validation is inherited from \`EvaluationRequest\`: supplying only one of the two raises before the network call.

## Test plan
- [x] \`make check\` clean locally (503 SDK tests including 4 new)
- [x] New SDK coverage:
  - \`check_evaluation\` forwards both fields into the request body when supplied
  - \`check_evaluation\` raises \`ValidationError\` before any server call when only one of the two fields is set
  - \`evaluate_controls\` forwards both fields through to \`check_evaluation_with_local\`
  - \`evaluate_controls\` defaults both fields to \`None\` when omitted, matching prior behavior
- [x] Validated on integration branch with PR1-PR5 merged