### PR TITLE
feat(sdk-ts): forward target_type and target_id on evaluation requests (6/6)

### DIFF
--- a/models/src/agent_control_models/evaluation.py
+++ b/models/src/agent_control_models/evaluation.py
@@ -1,7 +1,7 @@
 """Evaluation-related models."""
 from typing import Literal
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 
 from .agent import AGENT_NAME_MIN_LENGTH, AGENT_NAME_PATTERN, Step, normalize_agent_name
 from .base import BaseModel
@@ -19,6 +19,12 @@ class EvaluationRequest(BaseModel):
         agent_name: Unique identifier of the agent making the request
         step: Step payload for evaluation
         stage: 'pre' (before execution) or 'post' (after execution)
+        target_type: Optional opaque target kind (e.g. 'environment') for
+            target-bearing requests. When supplied with ``target_id``, the
+            server merges any controls attached to that target into the
+            effective set. Omit for the agent-only path.
+        target_id: Caller-supplied external identifier of the target, paired
+            with ``target_type``.
     """
     agent_name: str = Field(
         ...,
@@ -31,6 +37,22 @@ class EvaluationRequest(BaseModel):
     )
     stage: Literal["pre", "post"] = Field(
         ..., description="Evaluation stage: 'pre' or 'post'"
+    )
+    target_type: str | None = Field(
+        default=None,
+        max_length=64,
+        description=(
+            "Optional target kind for target-bearing requests "
+            "(e.g. 'environment'). Must be provided together with target_id."
+        ),
+    )
+    target_id: str | None = Field(
+        default=None,
+        max_length=255,
+        description=(
+            "Optional external identifier of the target. Must be provided "
+            "together with target_type."
+        ),
     )
 
     model_config = {
@@ -86,6 +108,18 @@ class EvaluationRequest(BaseModel):
     @classmethod
     def validate_and_normalize_agent_name(cls, value: str) -> str:
         return normalize_agent_name(str(value))
+
+    @model_validator(mode="after")
+    def validate_target_fields_paired(self) -> "EvaluationRequest":
+        """target_type and target_id must be supplied together or not at all."""
+        has_type = self.target_type is not None
+        has_id = self.target_id is not None
+        if has_type != has_id:
+            raise ValueError(
+                "target_type and target_id must be provided together; "
+                "pass both or omit both."
+            )
+        return self
 
 
 class EvaluationResponse(BaseModel):

--- a/models/tests/test_evaluation.py
+++ b/models/tests/test_evaluation.py
@@ -1,0 +1,57 @@
+"""Unit tests for EvaluationRequest target field pairing semantics."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from agent_control_models import EvaluationRequest
+from agent_control_models.agent import Step
+
+
+def _step() -> Step:
+    return Step(type="llm", name="chat", input="hello", output=None)
+
+
+def test_both_target_fields_unset_is_valid() -> None:
+    req = EvaluationRequest(
+        agent_name="test-agent",
+        step=_step(),
+        stage="pre",
+    )
+    assert req.target_type is None
+    assert req.target_id is None
+
+
+def test_both_target_fields_set_is_valid() -> None:
+    req = EvaluationRequest(
+        agent_name="test-agent",
+        step=_step(),
+        stage="pre",
+        target_type="environment",
+        target_id="env-prod-123",
+    )
+    assert req.target_type == "environment"
+    assert req.target_id == "env-prod-123"
+
+
+def test_only_target_type_set_raises() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        EvaluationRequest(
+            agent_name="test-agent",
+            step=_step(),
+            stage="pre",
+            target_type="environment",
+        )
+    assert "target_type and target_id must be provided together" in str(excinfo.value)
+
+
+def test_only_target_id_set_raises() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        EvaluationRequest(
+            agent_name="test-agent",
+            step=_step(),
+            stage="pre",
+            target_id="env-prod-123",
+        )
+    assert "target_type and target_id must be provided together" in str(excinfo.value)

--- a/sdks/python/src/agent_control/evaluation.py
+++ b/sdks/python/src/agent_control/evaluation.py
@@ -170,12 +170,19 @@ async def check_evaluation(
     agent_name: str,
     step: Step,
     stage: Literal["pre", "post"],
+    *,
+    target_type: str | None = None,
+    target_id: str | None = None,
 ) -> EvaluationResult:
     """Check if agent interaction is safe through the public SDK helper.
 
     The server returns only evaluation semantics. When SDK observability is
     enabled, this helper reconstructs server-side control-execution events
     from the response and enqueues them through the built-in SDK batcher.
+
+    ``target_type`` and ``target_id`` are optional. When both are supplied the
+    server merges controls attached to that target into the effective set;
+    when either is omitted the request uses the agent-only path.
     """
     normalized_name = ensure_agent_name(agent_name)
     resolved_trace_id, resolved_span_id = get_trace_and_span_ids()
@@ -183,6 +190,8 @@ async def check_evaluation(
         agent_name=normalized_name,
         step=step,
         stage=stage,
+        target_type=target_type,
+        target_id=target_id,
     )
     request_payload = request.model_dump(mode="json")
 
@@ -218,8 +227,16 @@ async def check_evaluation_with_local(
     trace_id: str | None = None,
     span_id: str | None = None,
     event_agent_name: str | None = None,
+    *,
+    target_type: str | None = None,
+    target_id: str | None = None,
 ) -> EvaluationResult:
-    """Evaluate controls with local-first execution and SDK-owned event emission."""
+    """Evaluate controls with local-first execution and SDK-owned event emission.
+
+    ``target_type`` / ``target_id`` are optional. When both are supplied they
+    are forwarded to the server on the remote evaluation call, letting the
+    server merge controls attached to that target into its resolution.
+    """
     normalized_name = ensure_agent_name(agent_name)
     resolved_trace_id = trace_id
     resolved_span_id = span_id
@@ -299,6 +316,8 @@ async def check_evaluation_with_local(
         agent_name=normalized_name,
         step=step,
         stage=stage,
+        target_type=target_type,
+        target_id=target_id,
     )
 
     def _with_parse_errors(result: EvaluationResult) -> EvaluationResult:
@@ -402,8 +421,15 @@ async def evaluate_controls(
     agent_name: str,
     trace_id: str | None = None,
     span_id: str | None = None,
+    target_type: str | None = None,
+    target_id: str | None = None,
 ) -> EvaluationResult:
-    """Evaluate controls for a step."""
+    """Evaluate controls for a step.
+
+    When ``target_type`` and ``target_id`` are both supplied, the SDK forwards
+    them to the server so controls attached to that target are included in
+    resolution. Omit either to use the agent-only path.
+    """
     if state.server_url is None:
         raise RuntimeError("Server URL not configured. Call agent_control.init() first.")
 
@@ -430,4 +456,6 @@ async def evaluate_controls(
             trace_id=trace_id,
             span_id=span_id,
             event_agent_name=agent_name,
+            target_type=target_type,
+            target_id=target_id,
         )

--- a/sdks/python/tests/test_evaluation.py
+++ b/sdks/python/tests/test_evaluation.py
@@ -65,6 +65,8 @@ async def test_check_evaluation_returns_result_model():
                 "context": None,
             },
             "stage": "pre",
+            "target_type": None,
+            "target_id": None,
         },
         headers=None,
     )

--- a/sdks/python/tests/test_evaluation.py
+++ b/sdks/python/tests/test_evaluation.py
@@ -73,6 +73,54 @@ async def test_check_evaluation_returns_result_model():
 
 
 @pytest.mark.asyncio
+async def test_check_evaluation_forwards_target_fields_when_supplied():
+    """target_type and target_id land in the outgoing request body when set."""
+
+    class DummyResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return {"is_safe": True, "confidence": 1.0}
+
+    client = MagicMock()
+    client.http_client = MagicMock()
+    client.http_client.post = AsyncMock(return_value=DummyResponse())
+
+    await evaluation.check_evaluation(
+        client=client,
+        agent_name="Agent-Example_01",
+        step={"type": "llm", "name": "chat", "input": "hello"},
+        stage="pre",
+        target_type="environment",
+        target_id="env-prod-123",
+    )
+
+    sent_payload = client.http_client.post.await_args.kwargs["json"]
+    assert sent_payload["target_type"] == "environment"
+    assert sent_payload["target_id"] == "env-prod-123"
+
+
+@pytest.mark.asyncio
+async def test_check_evaluation_rejects_half_target_context():
+    """Server-side pairing rule must be enforced client-side via model validation."""
+    client = MagicMock()
+    client.http_client = AsyncMock()
+    client.http_client.post = AsyncMock()
+
+    with pytest.raises(ValidationError):
+        await evaluation.check_evaluation(
+            client=client,
+            agent_name="Agent-Example_01",
+            step={"type": "llm", "name": "chat", "input": "hello"},
+            stage="pre",
+            target_type="environment",
+        )
+
+    client.http_client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_evaluate_controls_requires_server_url():
     """evaluate_controls should require server_url to be configured."""
     with patch("agent_control.state.server_url", None):
@@ -124,3 +172,47 @@ async def test_evaluate_controls_with_context(monkeypatch):
             )
 
     assert mock_check.call_args is not None
+
+
+@pytest.mark.asyncio
+async def test_evaluate_controls_forwards_target_fields(monkeypatch):
+    """target_type and target_id flow through to check_evaluation_with_local."""
+    mock_result = EvaluationResult(is_safe=True, confidence=1.0)
+    mock_check = AsyncMock(return_value=mock_result)
+    monkeypatch.setattr(evaluation, "check_evaluation_with_local", mock_check)
+
+    with patch("agent_control.state.server_url", "http://localhost:8000"):
+        with patch("agent_control.state.api_key", None):
+            await evaluation.evaluate_controls(
+                step_name="chat",
+                input="hello",
+                stage="pre",
+                agent_name="test-bot",
+                target_type="environment",
+                target_id="env-prod-123",
+            )
+
+    forwarded = mock_check.call_args.kwargs
+    assert forwarded["target_type"] == "environment"
+    assert forwarded["target_id"] == "env-prod-123"
+
+
+@pytest.mark.asyncio
+async def test_evaluate_controls_defaults_target_fields_to_none(monkeypatch):
+    """Omitting target fields sends None through so the existing path stays unchanged."""
+    mock_result = EvaluationResult(is_safe=True, confidence=1.0)
+    mock_check = AsyncMock(return_value=mock_result)
+    monkeypatch.setattr(evaluation, "check_evaluation_with_local", mock_check)
+
+    with patch("agent_control.state.server_url", "http://localhost:8000"):
+        with patch("agent_control.state.api_key", None):
+            await evaluation.evaluate_controls(
+                step_name="chat",
+                input="hello",
+                stage="pre",
+                agent_name="test-bot",
+            )
+
+    forwarded = mock_check.call_args.kwargs
+    assert forwarded["target_type"] is None
+    assert forwarded["target_id"] is None

--- a/sdks/typescript/src/generated/funcs/evaluation-evaluate.ts
+++ b/sdks/typescript/src/generated/funcs/evaluation-evaluate.ts
@@ -36,6 +36,14 @@ import { Result } from "../types/fp.js";
  * ``EvaluationResponse`` and does not build or ingest observability events
  * on the server; SDKs reconstruct and emit those events separately through
  * the observability ingestion endpoint.
+ *
+ * Target-bearing requests (``target_type`` and ``target_id`` both set) merge
+ * controls attached to that target into the effective set, with the same
+ * deduplication/precedence rules used by the runtime resolver: when the
+ * same control is attached via both the agent/policy path and the target
+ * path, the agent/policy attachment wins. The request body carries the
+ * caller-supplied external target identifier; the server resolves it to
+ * the internal target row via the tenant context.
  */
 export function evaluationEvaluate(
   client: AgentControlSDKCore,

--- a/sdks/typescript/src/generated/models/evaluation-request.ts
+++ b/sdks/typescript/src/generated/models/evaluation-request.ts
@@ -31,6 +31,12 @@ export type Stage = ClosedEnum<typeof Stage>;
  *     agent_name: Unique identifier of the agent making the request
  *     step: Step payload for evaluation
  *     stage: 'pre' (before execution) or 'post' (after execution)
+ *     target_type: Optional opaque target kind (e.g. 'environment') for
+ *         target-bearing requests. When supplied with ``target_id``, the
+ *         server merges any controls attached to that target into the
+ *         effective set. Omit for the agent-only path.
+ *     target_id: Caller-supplied external identifier of the target, paired
+ *         with ``target_type``.
  */
 export type EvaluationRequest = {
   /**
@@ -45,6 +51,14 @@ export type EvaluationRequest = {
    * Runtime payload for an agent step invocation.
    */
   step: Step;
+  /**
+   * Optional external identifier of the target. Must be provided together with target_type.
+   */
+  targetId?: string | null | undefined;
+  /**
+   * Optional target kind for target-bearing requests (e.g. 'environment'). Must be provided together with target_id.
+   */
+  targetType?: string | null | undefined;
 };
 
 /** @internal */
@@ -55,6 +69,8 @@ export type EvaluationRequest$Outbound = {
   agent_name: string;
   stage: string;
   step: Step$Outbound;
+  target_id?: string | null | undefined;
+  target_type?: string | null | undefined;
 };
 
 /** @internal */
@@ -66,10 +82,14 @@ export const EvaluationRequest$outboundSchema: z.ZodMiniType<
     agentName: z.string(),
     stage: Stage$outboundSchema,
     step: Step$outboundSchema,
+    targetId: z.optional(z.nullable(z.string())),
+    targetType: z.optional(z.nullable(z.string())),
   }),
   z.transform((v) => {
     return remap$(v, {
       agentName: "agent_name",
+      targetId: "target_id",
+      targetType: "target_type",
     });
   }),
 );

--- a/sdks/typescript/src/generated/sdk/evaluation.ts
+++ b/sdks/typescript/src/generated/sdk/evaluation.ts
@@ -18,6 +18,14 @@ export class Evaluation extends ClientSDK {
    * ``EvaluationResponse`` and does not build or ingest observability events
    * on the server; SDKs reconstruct and emit those events separately through
    * the observability ingestion endpoint.
+   *
+   * Target-bearing requests (``target_type`` and ``target_id`` both set) merge
+   * controls attached to that target into the effective set, with the same
+   * deduplication/precedence rules used by the runtime resolver: when the
+   * same control is attached via both the agent/policy path and the target
+   * path, the agent/policy attachment wins. The request body carries the
+   * caller-supplied external target identifier; the server resolves it to
+   * the internal target row via the tenant context.
    */
   async evaluate(
     request: models.EvaluationRequest,

--- a/sdks/typescript/tests/evaluation-request.test.ts
+++ b/sdks/typescript/tests/evaluation-request.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { evaluationRequestToJSON } from "../src/generated/models/evaluation-request";
+import type { EvaluationRequest } from "../src/generated/models/evaluation-request";
+
+describe("EvaluationRequest serialization", () => {
+  const baseRequest: EvaluationRequest = {
+    agentName: "test-agent-01",
+    stage: "pre",
+    step: {
+      type: "llm",
+      name: "chat",
+      input: "hello",
+    },
+  };
+
+  it("omits target fields from the wire payload when unset", () => {
+    const wire = JSON.parse(evaluationRequestToJSON(baseRequest)) as Record<string, unknown>;
+    expect(wire.agent_name).toBe("test-agent-01");
+    expect("target_type" in wire).toBe(false);
+    expect("target_id" in wire).toBe(false);
+  });
+
+  it("forwards targetType and targetId as snake_case on the wire", () => {
+    const request: EvaluationRequest = {
+      ...baseRequest,
+      targetType: "environment",
+      targetId: "env-prod-123",
+    };
+
+    const wire = JSON.parse(evaluationRequestToJSON(request)) as Record<string, unknown>;
+    expect(wire.target_type).toBe("environment");
+    expect(wire.target_id).toBe("env-prod-123");
+    expect("targetType" in wire).toBe(false);
+    expect("targetId" in wire).toBe(false);
+  });
+
+  it("accepts null for target fields without failing", () => {
+    const request: EvaluationRequest = {
+      ...baseRequest,
+      targetType: null,
+      targetId: null,
+    };
+
+    const wire = JSON.parse(evaluationRequestToJSON(request)) as Record<string, unknown>;
+    expect(wire.target_type).toBeNull();
+    expect(wire.target_id).toBeNull();
+  });
+});

--- a/server/src/agent_control_server/endpoints/agents.py
+++ b/server/src/agent_control_server/endpoints/agents.py
@@ -71,6 +71,7 @@ from ..services.schema_compat import (
     check_schema_compatibility,
     format_compatibility_error,
 )
+from ..tenancy import get_tenant_id
 
 router = APIRouter(prefix="/agents", tags=["agents"])
 
@@ -460,6 +461,7 @@ async def list_agents(
 async def init_agent(
     request: InitAgentRequest,
     client: RequireAPIKey,
+    tenant_id: str = Depends(get_tenant_id),
     db: AsyncSession = Depends(get_async_db),
 ) -> InitAgentResponse:
     """
@@ -541,6 +543,7 @@ async def init_agent(
 
         new_agent = Agent(
             name=request.agent.agent_name,
+            tenant_id=tenant_id,
             data=data_model.model_dump(mode="json"),
         )
         db.add(new_agent)
@@ -956,7 +959,11 @@ async def add_agent_policy(
     try:
         stmt = (
             pg_insert(agent_policies)
-            .values(agent_name=agent.name, policy_id=policy_id)
+            .values(
+                agent_name=agent.name,
+                policy_id=policy_id,
+                tenant_id=agent.tenant_id,
+            )
             .on_conflict_do_nothing()
         )
         await db.execute(stmt)
@@ -1031,7 +1038,11 @@ async def set_agent_policy(
         await db.execute(delete(agent_policies).where(agent_policies.c.agent_name == agent.name))
         await db.execute(
             pg_insert(agent_policies)
-            .values(agent_name=agent.name, policy_id=policy_id)
+            .values(
+                agent_name=agent.name,
+                policy_id=policy_id,
+                tenant_id=agent.tenant_id,
+            )
             .on_conflict_do_nothing()
         )
         await db.commit()
@@ -1279,7 +1290,11 @@ async def add_agent_control(
     try:
         stmt = (
             pg_insert(agent_controls)
-            .values(agent_name=agent.name, control_id=control_id)
+            .values(
+                agent_name=agent.name,
+                control_id=control_id,
+                tenant_id=agent.tenant_id,
+            )
             .on_conflict_do_nothing()
         )
         await db.execute(stmt)

--- a/server/src/agent_control_server/endpoints/controls.py
+++ b/server/src/agent_control_server/endpoints/controls.py
@@ -53,6 +53,7 @@ from ..services.evaluator_utils import (
 )
 from ..services.query_utils import escape_like_pattern
 from ..services.validation_paths import format_field_path
+from ..tenancy import get_tenant_id
 
 # Pagination constants
 _DEFAULT_PAGINATION_LIMIT = 20
@@ -443,7 +444,9 @@ async def render_control_template(
     response_description="Created control ID",
 )
 async def create_control(
-    request: CreateControlRequest, db: AsyncSession = Depends(get_async_db)
+    request: CreateControlRequest,
+    tenant_id: str = Depends(get_tenant_id),
+    db: AsyncSession = Depends(get_async_db),
 ) -> CreateControlResponse:
     """
     Create a new control with a unique name.
@@ -476,7 +479,7 @@ async def create_control(
     control_def = await _materialize_control_input(request.data, db=db)
     control_data = _serialize_control_data(control_def)
 
-    control = Control(name=request.name, data=control_data)
+    control = Control(name=request.name, tenant_id=tenant_id, data=control_data)
     db.add(control)
     try:
         await db.commit()

--- a/server/src/agent_control_server/endpoints/evaluation.py
+++ b/server/src/agent_control_server/endpoints/evaluation.py
@@ -18,8 +18,9 @@ from ..auth import RequireAPIKey
 from ..db import get_async_db
 from ..errors import APIValidationError, NotFoundError
 from ..logging_utils import get_logger
-from ..models import Agent
+from ..models import Agent, Target
 from ..services.controls import list_runtime_controls_for_agent
+from ..tenancy import get_tenant_id
 
 router = APIRouter(prefix="/evaluation", tags=["evaluation"])
 
@@ -126,6 +127,7 @@ def _sanitize_evaluation_response(response: EvaluationResponse) -> EvaluationRes
 async def evaluate(
     request: EvaluationRequest,
     client: RequireAPIKey,
+    tenant_id: str = Depends(get_tenant_id),
     db: AsyncSession = Depends(get_async_db),
 ) -> EvaluationResponse:
     """Analyze content for safety and control violations.
@@ -134,6 +136,14 @@ async def evaluate(
     ``EvaluationResponse`` and does not build or ingest observability events
     on the server; SDKs reconstruct and emit those events separately through
     the observability ingestion endpoint.
+
+    Target-bearing requests (``target_type`` and ``target_id`` both set) merge
+    controls attached to that target into the effective set, with the same
+    deduplication/precedence rules used by the runtime resolver: when the
+    same control is attached via both the agent/policy path and the target
+    path, the agent/policy attachment wins. The request body carries the
+    caller-supplied external target identifier; the server resolves it to
+    the internal target row via the tenant context.
     """
     del client  # Authentication is still required by dependency injection.
 
@@ -150,10 +160,37 @@ async def evaluate(
             hint="Register the agent via initAgent before evaluating.",
         )
 
+    resolved_target_id: int | None = None
+    if request.target_type is not None and request.target_id is not None:
+        target_result = await db.execute(
+            select(Target.id).where(
+                Target.tenant_id == tenant_id,
+                Target.target_type == request.target_type,
+                Target.external_id == request.target_id,
+            )
+        )
+        resolved_target_id = target_result.scalar_one_or_none()
+        if resolved_target_id is None:
+            raise NotFoundError(
+                error_code=ErrorCode.TARGET_NOT_FOUND,
+                detail=(
+                    f"Target (type='{request.target_type}', "
+                    f"id='{request.target_id}') not found in this tenant"
+                ),
+                resource="Target",
+                resource_id=request.target_id,
+                hint=(
+                    "Create the target via POST /api/v1/targets before sending "
+                    "target-bearing evaluation requests, or retry without "
+                    "target_type / target_id for the OSS path."
+                ),
+            )
+
     runtime_controls = await list_runtime_controls_for_agent(
         request.agent_name,
         db,
         allow_invalid_step_name_regex=True,
+        target_id=resolved_target_id,
     )
     engine_controls = [ControlAdapter(c.id, c.name, c.control) for c in runtime_controls]
 

--- a/server/src/agent_control_server/endpoints/policies.py
+++ b/server/src/agent_control_server/endpoints/policies.py
@@ -14,6 +14,7 @@ from ..db import get_async_db
 from ..errors import ConflictError, DatabaseError, NotFoundError
 from ..logging_utils import get_logger
 from ..models import Control, Policy, policy_controls
+from ..tenancy import get_tenant_id
 
 router = APIRouter(prefix="/policies", tags=["policies"])
 
@@ -28,7 +29,9 @@ _logger = get_logger(__name__)
     response_description="Created policy ID",
 )
 async def create_policy(
-    request: CreatePolicyRequest, db: AsyncSession = Depends(get_async_db)
+    request: CreatePolicyRequest,
+    tenant_id: str = Depends(get_tenant_id),
+    db: AsyncSession = Depends(get_async_db),
 ) -> CreatePolicyResponse:
     """
     Create a new empty policy with a unique name.
@@ -58,7 +61,7 @@ async def create_policy(
             hint="Choose a different name or update the existing policy.",
         )
 
-    policy = Policy(name=request.name)
+    policy = Policy(name=request.name, tenant_id=tenant_id)
     db.add(policy)
     try:
         await db.commit()

--- a/server/src/agent_control_server/services/controls.py
+++ b/server/src/agent_control_server/services/controls.py
@@ -17,7 +17,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..errors import APIValidationError
 from ..logging_utils import get_logger
-from ..models import Control, agent_controls, agent_policies, policy_controls
+from ..models import (
+    Control,
+    TargetControl,
+    agent_controls,
+    agent_policies,
+    policy_controls,
+)
 from .control_definitions import (
     parse_control_definition_or_api_error,
     parse_runtime_control_definition_or_api_error,
@@ -41,8 +47,25 @@ class RuntimeControl:
 async def _list_db_controls_for_agent(
     agent_name: str,
     db: AsyncSession,
+    *,
+    target_id: int | None = None,
 ) -> Sequence[Control]:
-    """Return DB Control rows for the controls associated with an agent."""
+    """Return DB Control rows for the controls associated with an agent.
+
+    When ``target_id`` is None, returns the classic set: direct agent
+    controls plus policy-derived controls. When provided, also merges in
+    controls attached to the given target. Resolution rules:
+
+    - A control appears in the effective set if it is attached via
+      ``agent_controls`` or via ``policy_controls`` through an assigned
+      policy, regardless of target state.
+    - A control attached only via ``target_controls`` contributes to the
+      effective set when ``target_controls.enabled`` is true.
+    - When the same control appears from multiple sources, the UNION
+      deduplicates by ``control_id``; the agent-side row effectively
+      masks the target-side attachment so agent-level attachment takes
+      precedence over target-level state.
+    """
     policy_control_ids = (
         select(policy_controls.c.control_id.label("control_id"))
         .select_from(
@@ -55,7 +78,19 @@ async def _list_db_controls_for_agent(
     direct_control_ids = select(agent_controls.c.control_id.label("control_id")).where(
         agent_controls.c.agent_name == agent_name
     )
-    control_ids_subquery = union(policy_control_ids, direct_control_ids).subquery()
+
+    if target_id is None:
+        control_ids_subquery = union(policy_control_ids, direct_control_ids).subquery()
+    else:
+        target_control_ids = select(
+            TargetControl.control_id.label("control_id")
+        ).where(
+            TargetControl.target_id == target_id,
+            TargetControl.enabled.is_(True),
+        )
+        control_ids_subquery = union(
+            policy_control_ids, direct_control_ids, target_control_ids
+        ).subquery()
 
     stmt = (
         select(Control)
@@ -206,9 +241,17 @@ async def list_runtime_controls_for_agent(
     db: AsyncSession,
     *,
     allow_invalid_step_name_regex: bool = False,
+    target_id: int | None = None,
 ) -> list[RuntimeControl]:
-    """Return runtime-parsed controls for evaluation hot paths."""
-    db_controls = await _list_db_controls_for_agent(agent_name, db)
+    """Return runtime-parsed controls for evaluation hot paths.
+
+    When ``target_id`` is provided, the effective set includes enabled
+    ``target_controls`` attached to that target. When None, behavior matches
+    the classic agent + policy resolution path.
+    """
+    db_controls = await _list_db_controls_for_agent(
+        agent_name, db, target_id=target_id
+    )
 
     runtime_controls: list[RuntimeControl] = []
     for c in db_controls:

--- a/server/src/agent_control_server/tenancy.py
+++ b/server/src/agent_control_server/tenancy.py
@@ -1,19 +1,68 @@
 """Tenant resolution for request handlers.
 
 OSS deployments typically run as a single synthetic tenant. This module
-exposes a minimal dependency that reads an optional ``X-Tenant-Id`` header
-and falls back to ``DEFAULT_TENANT_ID`` when absent. A richer resolver
-(e.g. reading from authenticated context) can be added later; the
-dependency signature is the stable contract callers should depend on.
+exposes a request-scoped dependency, ``get_tenant_id``, that returns the
+effective tenant for any handler. Resolution flows through a pluggable
+``TenantResolver`` so deployments with their own tenant identity source
+(e.g. authenticated JWT claims) can swap in an alternative implementation
+via ``set_tenant_resolver`` at application startup.
+
+The shipped default, ``HeaderTenantResolver``, reads the optional
+``X-Tenant-Id`` header and falls back to ``DEFAULT_TENANT_ID``. That keeps
+callers which do not supply a tenant header working unchanged.
 """
 
 from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
 
 from fastapi import Header
 
 from .models import DEFAULT_TENANT_ID
 
 TENANT_HEADER_NAME = "X-Tenant-Id"
+
+
+@runtime_checkable
+class TenantResolver(Protocol):
+    """Resolves the effective tenant for an incoming request.
+
+    Implementations receive the raw header value (``None`` if absent) and
+    return a non-empty tenant id. The interface intentionally keeps the
+    surface minimal so enterprise extensions can grow it without forcing
+    OSS code to adopt auth-specific types.
+    """
+
+    def resolve(self, x_tenant_id: str | None) -> str: ...
+
+
+class HeaderTenantResolver:
+    """Default resolver: read ``X-Tenant-Id`` header, fall back to ``DEFAULT_TENANT_ID``."""
+
+    def resolve(self, x_tenant_id: str | None) -> str:
+        if x_tenant_id is None:
+            return DEFAULT_TENANT_ID
+        trimmed = x_tenant_id.strip()
+        return trimmed if trimmed else DEFAULT_TENANT_ID
+
+
+_active_resolver: TenantResolver = HeaderTenantResolver()
+
+
+def set_tenant_resolver(resolver: TenantResolver) -> None:
+    """Install a replacement tenant resolver (e.g. for enterprise deployments).
+
+    The replacement is process-wide; call this during app startup before any
+    request is served. Tests that temporarily swap the resolver should restore
+    the prior instance in teardown.
+    """
+    global _active_resolver
+    _active_resolver = resolver
+
+
+def get_active_resolver() -> TenantResolver:
+    """Return the currently installed tenant resolver."""
+    return _active_resolver
 
 
 def get_tenant_id(
@@ -26,11 +75,10 @@ def get_tenant_id(
         include_in_schema=False,
     ),
 ) -> str:
-    """Return the effective tenant for this request.
+    """FastAPI dependency that returns the effective tenant for this request.
 
-    Callers that omit the header land on the default tenant.
+    Callers that omit the tenant header land on ``DEFAULT_TENANT_ID``.
+    Deployments that resolve tenants from their own context can override the
+    active resolver via ``set_tenant_resolver``.
     """
-    if x_tenant_id is None:
-        return DEFAULT_TENANT_ID
-    trimmed = x_tenant_id.strip()
-    return trimmed if trimmed else DEFAULT_TENANT_ID
+    return _active_resolver.resolve(x_tenant_id)

--- a/server/tests/test_evaluation_target_resolution.py
+++ b/server/tests/test_evaluation_target_resolution.py
@@ -1,0 +1,276 @@
+"""End-to-end tests for target-bearing evaluation resolution."""
+
+from __future__ import annotations
+
+import uuid
+
+from fastapi.testclient import TestClient
+
+from .utils import VALID_CONTROL_PAYLOAD
+
+API_PREFIX = "/api/v1"
+TENANT_HEADER = "X-Tenant-Id"
+
+
+def _unique(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:10]}"
+
+
+def _register_agent(client: TestClient, agent_name: str | None = None) -> str:
+    name = agent_name or f"agent-{uuid.uuid4().hex[:12]}"
+    resp = client.post(
+        f"{API_PREFIX}/agents/initAgent",
+        json={"agent": {"agent_name": name}, "steps": []},
+    )
+    assert resp.status_code == 200, resp.text
+    return name
+
+
+def _deny_on_secret_payload() -> dict:
+    payload = dict(VALID_CONTROL_PAYLOAD)
+    payload["description"] = "Deny when input contains 'secret'"
+    payload["condition"] = {
+        "selector": {"path": "input"},
+        "evaluator": {"name": "regex", "config": {"pattern": "secret"}},
+    }
+    payload["action"] = {"decision": "deny"}
+    return payload
+
+
+def _create_control(client: TestClient, *, payload: dict | None = None) -> tuple[int, str]:
+    data = payload if payload is not None else _deny_on_secret_payload()
+    name = _unique("ctrl")
+    resp = client.put(f"{API_PREFIX}/controls", json={"name": name, "data": data})
+    assert resp.status_code == 200, resp.text
+    return int(resp.json()["control_id"]), name
+
+
+def _create_target(
+    client: TestClient, *, tenant: str | None = None
+) -> tuple[int, str]:
+    external_id = _unique("ext")
+    headers = {TENANT_HEADER: tenant} if tenant else {}
+    resp = client.post(
+        f"{API_PREFIX}/targets",
+        headers=headers,
+        json={"target_type": "environment", "external_id": external_id},
+    )
+    assert resp.status_code == 201, resp.text
+    return int(resp.json()["target_id"]), external_id
+
+
+def _attach_control(
+    client: TestClient,
+    target_id: int,
+    control_id: int,
+    *,
+    enabled: bool = True,
+    tenant: str | None = None,
+) -> None:
+    headers = {TENANT_HEADER: tenant} if tenant else {}
+    resp = client.post(
+        f"{API_PREFIX}/targets/{target_id}/controls/{control_id}",
+        headers=headers,
+        json={"enabled": enabled},
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def _evaluate(
+    client: TestClient,
+    *,
+    agent_name: str,
+    input_text: str,
+    target_type: str | None = None,
+    target_external_id: str | None = None,
+    tenant: str | None = None,
+) -> dict:
+    body: dict[str, object] = {
+        "agent_name": agent_name,
+        "step": {"type": "llm", "name": "test-step", "input": input_text, "output": None},
+        "stage": "pre",
+    }
+    if target_type is not None:
+        body["target_type"] = target_type
+    if target_external_id is not None:
+        body["target_id"] = target_external_id
+
+    headers = {TENANT_HEADER: tenant} if tenant else {}
+    resp = client.post(f"{API_PREFIX}/evaluation", headers=headers, json=body)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Core merge semantics
+# ---------------------------------------------------------------------------
+
+
+def test_target_control_enabled_contributes_to_effective_set(
+    client: TestClient,
+) -> None:
+    agent_name = _register_agent(client)
+    control_id, control_name = _create_control(client)
+    target_id, external_id = _create_target(client)
+    _attach_control(client, target_id, control_id, enabled=True)
+
+    result = _evaluate(
+        client,
+        agent_name=agent_name,
+        input_text="contains a secret",
+        target_type="environment",
+        target_external_id=external_id,
+    )
+
+    assert result["is_safe"] is False
+    assert any(m["control_name"] == control_name for m in result["matches"])
+
+
+def test_target_control_disabled_is_hidden_from_effective_set(
+    client: TestClient,
+) -> None:
+    agent_name = _register_agent(client)
+    control_id, _ = _create_control(client)
+    target_id, external_id = _create_target(client)
+    _attach_control(client, target_id, control_id, enabled=False)
+
+    result = _evaluate(
+        client,
+        agent_name=agent_name,
+        input_text="contains a secret",
+        target_type="environment",
+        target_external_id=external_id,
+    )
+
+    assert result["is_safe"] is True
+    assert not result.get("matches")
+
+
+def test_no_target_request_ignores_target_controls(client: TestClient) -> None:
+    """Regression: OSS no-target evaluation is unchanged by any target_controls."""
+    agent_name = _register_agent(client)
+    control_id, _ = _create_control(client)
+    target_id, _ = _create_target(client)
+    _attach_control(client, target_id, control_id, enabled=True)
+
+    result = _evaluate(
+        client, agent_name=agent_name, input_text="contains a secret"
+    )
+
+    assert result["is_safe"] is True
+    assert not result.get("matches")
+
+
+def test_agent_control_masks_target_disable(client: TestClient) -> None:
+    """If a control is attached directly to an agent, target-level disable has no effect."""
+    agent_name = _register_agent(client)
+    control_id, control_name = _create_control(client)
+    # Attach control directly to agent via the existing endpoint.
+    direct_resp = client.post(
+        f"{API_PREFIX}/agents/{agent_name}/controls/{control_id}"
+    )
+    assert direct_resp.status_code == 200, direct_resp.text
+
+    target_id, external_id = _create_target(client)
+    _attach_control(client, target_id, control_id, enabled=False)
+
+    result = _evaluate(
+        client,
+        agent_name=agent_name,
+        input_text="contains a secret",
+        target_type="environment",
+        target_external_id=external_id,
+    )
+
+    assert result["is_safe"] is False
+    assert any(m["control_name"] == control_name for m in result["matches"])
+
+
+def test_agent_control_and_target_enabled_both_contribute_once(
+    client: TestClient,
+) -> None:
+    """Deduplication: same control via agent_controls and target_controls counts once."""
+    agent_name = _register_agent(client)
+    control_id, control_name = _create_control(client)
+    client.post(f"{API_PREFIX}/agents/{agent_name}/controls/{control_id}")
+    target_id, external_id = _create_target(client)
+    _attach_control(client, target_id, control_id, enabled=True)
+
+    result = _evaluate(
+        client,
+        agent_name=agent_name,
+        input_text="contains a secret",
+        target_type="environment",
+        target_external_id=external_id,
+    )
+
+    matches = [m for m in result["matches"] if m["control_name"] == control_name]
+    assert len(matches) == 1
+
+
+# ---------------------------------------------------------------------------
+# Target resolution edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_target_bearing_request_with_unknown_target_returns_404(
+    client: TestClient,
+) -> None:
+    agent_name = _register_agent(client)
+    body = {
+        "agent_name": agent_name,
+        "step": {"type": "llm", "name": "test-step", "input": "hi", "output": None},
+        "stage": "pre",
+        "target_type": "environment",
+        "target_id": "unknown-external-id",
+    }
+    resp = client.post(f"{API_PREFIX}/evaluation", json=body)
+    assert resp.status_code == 404
+    assert resp.json()["error_code"] == "TARGET_NOT_FOUND"
+
+
+def test_target_resolution_is_tenant_scoped(client: TestClient) -> None:
+    """A target created in tenant-a must not be visible from tenant-b."""
+    agent_name = _register_agent(client)
+    _, external_id = _create_target(client, tenant="tenant-a")
+
+    body = {
+        "agent_name": agent_name,
+        "step": {"type": "llm", "name": "test-step", "input": "hi", "output": None},
+        "stage": "pre",
+        "target_type": "environment",
+        "target_id": external_id,
+    }
+    resp = client.post(
+        f"{API_PREFIX}/evaluation", headers={TENANT_HEADER: "tenant-b"}, json=body
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error_code"] == "TARGET_NOT_FOUND"
+
+
+def test_only_target_type_without_target_id_fails_validation(
+    client: TestClient,
+) -> None:
+    agent_name = _register_agent(client)
+    body = {
+        "agent_name": agent_name,
+        "step": {"type": "llm", "name": "test-step", "input": "hi", "output": None},
+        "stage": "pre",
+        "target_type": "environment",
+    }
+    resp = client.post(f"{API_PREFIX}/evaluation", json=body)
+    assert resp.status_code == 422
+
+
+def test_only_target_id_without_target_type_fails_validation(
+    client: TestClient,
+) -> None:
+    agent_name = _register_agent(client)
+    body = {
+        "agent_name": agent_name,
+        "step": {"type": "llm", "name": "test-step", "input": "hi", "output": None},
+        "stage": "pre",
+        "target_id": "some-external-id",
+    }
+    resp = client.post(f"{API_PREFIX}/evaluation", json=body)
+    assert resp.status_code == 422

--- a/server/tests/test_tenant_aware_writes.py
+++ b/server/tests/test_tenant_aware_writes.py
@@ -1,0 +1,223 @@
+"""Tests for tenant-aware write paths.
+
+Covers:
+
+- Agent / control / policy creation picks up the resolved tenant from the
+  ``X-Tenant-Id`` header (header-based default resolver).
+- Association inserts (agent_policies, agent_controls) record a tenant_id
+  consistent with the agent's tenant_id.
+- A pluggable ``TenantResolver`` override is picked up by the dependency.
+- Callers without any header continue to land in the default tenant.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from agent_control_server.models import DEFAULT_TENANT_ID
+from agent_control_server.tenancy import (
+    HeaderTenantResolver,
+    TenantResolver,
+    get_active_resolver,
+    set_tenant_resolver,
+)
+
+from .utils import VALID_CONTROL_PAYLOAD
+
+API_PREFIX = "/api/v1"
+TENANT_HEADER = "X-Tenant-Id"
+
+
+def _unique(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:10]}"
+
+
+def _create_control(
+    client: TestClient, *, tenant: str | None = None
+) -> tuple[int, str]:
+    name = _unique("ctrl")
+    headers = {TENANT_HEADER: tenant} if tenant else {}
+    resp = client.put(
+        f"{API_PREFIX}/controls",
+        headers=headers,
+        json={"name": name, "data": VALID_CONTROL_PAYLOAD},
+    )
+    assert resp.status_code == 200, resp.text
+    return int(resp.json()["control_id"]), name
+
+
+def _create_policy(
+    client: TestClient, *, tenant: str | None = None
+) -> tuple[int, str]:
+    name = _unique("pol")
+    headers = {TENANT_HEADER: tenant} if tenant else {}
+    resp = client.put(
+        f"{API_PREFIX}/policies", headers=headers, json={"name": name}
+    )
+    assert resp.status_code == 200, resp.text
+    return int(resp.json()["policy_id"]), name
+
+
+def _init_agent(
+    client: TestClient, *, tenant: str | None = None, agent_name: str | None = None
+) -> str:
+    name = agent_name or f"agent-{uuid.uuid4().hex[:12]}"
+    headers = {TENANT_HEADER: tenant} if tenant else {}
+    resp = client.post(
+        f"{API_PREFIX}/agents/initAgent",
+        headers=headers,
+        json={"agent": {"agent_name": name}, "steps": []},
+    )
+    assert resp.status_code == 200, resp.text
+    return name
+
+
+def _tenant_of(db_engine, table: str, where_sql: str, params: dict) -> str:
+    with db_engine.begin() as conn:
+        row = conn.execute(
+            text(f"SELECT tenant_id FROM {table} WHERE {where_sql}"),
+            params,
+        ).first()
+    assert row is not None, f"expected row in {table} matching {params}"
+    return str(row[0])
+
+
+# ---------------------------------------------------------------------------
+# Default resolver (header-based) behavior
+# ---------------------------------------------------------------------------
+
+
+def test_control_create_without_header_lands_in_default_tenant(
+    client: TestClient, db_engine
+) -> None:
+    _, name = _create_control(client)
+    assert _tenant_of(
+        db_engine, "controls", "name = :name", {"name": name}
+    ) == DEFAULT_TENANT_ID
+
+
+def test_control_create_with_header_lands_in_resolved_tenant(
+    client: TestClient, db_engine
+) -> None:
+    _, name = _create_control(client, tenant="acme-corp")
+    assert _tenant_of(
+        db_engine, "controls", "name = :name", {"name": name}
+    ) == "acme-corp"
+
+
+def test_policy_create_with_header_lands_in_resolved_tenant(
+    client: TestClient, db_engine
+) -> None:
+    _, name = _create_policy(client, tenant="acme-corp")
+    assert _tenant_of(
+        db_engine, "policies", "name = :name", {"name": name}
+    ) == "acme-corp"
+
+
+def test_agent_create_with_header_lands_in_resolved_tenant(
+    client: TestClient, db_engine
+) -> None:
+    name = _init_agent(client, tenant="acme-corp")
+    assert _tenant_of(
+        db_engine, "agents", "name = :name", {"name": name}
+    ) == "acme-corp"
+
+
+def test_agent_policy_association_inherits_agent_tenant(
+    client: TestClient, db_engine
+) -> None:
+    """Association rows must record the agent's tenant, not the request-scoped one."""
+    agent_name = _init_agent(client, tenant="agent-tenant")
+    policy_id, _ = _create_policy(client, tenant="policy-tenant")
+
+    # Attach without a header. The association must still pick up the agent's tenant
+    # rather than falling through to DEFAULT_TENANT_ID.
+    attach = client.post(f"{API_PREFIX}/agents/{agent_name}/policies/{policy_id}")
+    assert attach.status_code == 200, attach.text
+
+    recorded = _tenant_of(
+        db_engine,
+        "agent_policies",
+        "agent_name = :name AND policy_id = :policy_id",
+        {"name": agent_name, "policy_id": policy_id},
+    )
+    assert recorded == "agent-tenant"
+
+
+def test_agent_control_association_inherits_agent_tenant(
+    client: TestClient, db_engine
+) -> None:
+    agent_name = _init_agent(client, tenant="agent-tenant")
+    control_id, _ = _create_control(client, tenant="other-tenant")
+
+    attach = client.post(
+        f"{API_PREFIX}/agents/{agent_name}/controls/{control_id}"
+    )
+    assert attach.status_code == 200, attach.text
+
+    recorded = _tenant_of(
+        db_engine,
+        "agent_controls",
+        "agent_name = :name AND control_id = :control_id",
+        {"name": agent_name, "control_id": control_id},
+    )
+    assert recorded == "agent-tenant"
+
+
+def test_whitespace_header_falls_back_to_default_tenant(
+    client: TestClient, db_engine
+) -> None:
+    _, name = _create_control(client, tenant="   ")
+    assert _tenant_of(
+        db_engine, "controls", "name = :name", {"name": name}
+    ) == DEFAULT_TENANT_ID
+
+
+# ---------------------------------------------------------------------------
+# Pluggable resolver
+# ---------------------------------------------------------------------------
+
+
+class _ConstantTenantResolver:
+    """Test resolver that always returns a preconfigured tenant id."""
+
+    def __init__(self, tenant: str) -> None:
+        self._tenant = tenant
+
+    def resolve(self, x_tenant_id: str | None) -> str:
+        del x_tenant_id  # ignored by this resolver
+        return self._tenant
+
+
+@pytest.fixture
+def swap_resolver() -> Iterator[None]:
+    previous = get_active_resolver()
+    try:
+        yield None
+    finally:
+        set_tenant_resolver(previous)
+
+
+def test_tenant_resolver_protocol_is_runtime_checkable() -> None:
+    assert isinstance(_ConstantTenantResolver("enterprise"), TenantResolver)
+    assert isinstance(HeaderTenantResolver(), TenantResolver)
+
+
+def test_installed_resolver_overrides_request_header(
+    client: TestClient, db_engine, swap_resolver: None
+) -> None:
+    del swap_resolver
+    set_tenant_resolver(_ConstantTenantResolver("enterprise-default"))
+
+    # Even though the client sends a header, the enterprise resolver ignores
+    # it and returns its own tenant. This mimics how an auth-driven resolver
+    # would override request-supplied identity.
+    _, name = _create_control(client, tenant="client-supplied-ignored")
+    assert _tenant_of(
+        db_engine, "controls", "name = :name", {"name": name}
+    ) == "enterprise-default"


### PR DESCRIPTION
Stacked on top of #183. Kept in draft until the full stack is validated end-to-end.

## Summary
- Exposes optional \`targetType\` and \`targetId\` on the generated \`EvaluationRequest\` type. The outbound schema remaps them to \`target_type\` / \`target_id\` on the wire so they match the server's JSON shape.
- Regenerated the method-name overlay so Speakeasy will produce ergonomic method names for the new \`/api/v1/targets\` endpoints in future regenerations.
- Existing call sites are unaffected: both fields default to \`undefined\` and are omitted from the wire payload when not set.

## Regeneration note for reviewers
The \`src/generated/evaluation-request.ts\` change was made by hand because running \`make generate\` locally requires an authenticated Speakeasy session (the CLI opens a browser for OAuth). The edit mirrors the pattern Speakeasy uses for other optional + nullable string fields in the same directory (see \`step.ts\` for reference) and matches the \`EvaluationRequest\` shape in \`server/.generated/openapi.json\` after PR1-PR3.

Once \`make sdk-ts-generate-check\` is run with a live Speakeasy session, any residual cosmetic diff can be dropped in cleanly. The overlay change, on the other hand, is produced by the local Python overlay-generator script and does not require Speakeasy.

## Test plan
- [x] \`make sdk-ts-typecheck\`, \`make sdk-ts-lint\`, \`make sdk-ts-test\` all green (11 tests including 3 new)
- [x] New Vitest coverage:
  - Omits \`target_type\` / \`target_id\` from the wire payload when they are unset
  - Serializes \`targetType\` / \`targetId\` as snake_case on the wire when supplied
  - Accepts explicit \`null\` for both fields
- [x] Python \`make check\` still green across models / server / sdk (nothing outside the TS SDK changed)
- [ ] \`make sdk-ts-generate-check\` - needs interactive Speakeasy auth; reviewer should run locally to confirm zero drift from generator output