### PR TITLE
feat(server): enforce tenant boundary on all request-scoped lookups (6/7)

### DIFF
--- a/sdks/typescript/src/generated/funcs/agents-get.ts
+++ b/sdks/typescript/src/generated/funcs/agents-get.ts
@@ -37,13 +37,14 @@ import { Result } from "../types/fp.js";
  *
  * Args:
  *     agent_name: Agent identifier
+ *     tenant_id: Effective tenant (injected)
  *     db: Database session (injected)
  *
  * Returns:
  *     GetAgentResponse with agent metadata and step list
  *
  * Raises:
- *     HTTPException 404: Agent not found
+ *     HTTPException 404: Agent not found (or owned by another tenant)
  *     HTTPException 422: Agent data is corrupted
  */
 export function agentsGet(

--- a/sdks/typescript/src/generated/sdk/agents.ts
+++ b/sdks/typescript/src/generated/sdk/agents.ts
@@ -96,13 +96,14 @@ export class Agents extends ClientSDK {
    *
    * Args:
    *     agent_name: Agent identifier
+   *     tenant_id: Effective tenant (injected)
    *     db: Database session (injected)
    *
    * Returns:
    *     GetAgentResponse with agent metadata and step list
    *
    * Raises:
-   *     HTTPException 404: Agent not found
+   *     HTTPException 404: Agent not found (or owned by another tenant)
    *     HTTPException 422: Agent data is corrupted
    */
   async get(

--- a/server/src/agent_control_server/endpoints/agents.py
+++ b/server/src/agent_control_server/endpoints/agents.py
@@ -71,6 +71,11 @@ from ..services.schema_compat import (
     check_schema_compatibility,
     format_compatibility_error,
 )
+from ..services.tenant_scoped_lookups import (
+    get_agent_in_tenant_or_404,
+    get_control_in_tenant_or_404,
+    get_policy_in_tenant_or_404,
+)
 from ..tenancy import get_tenant_id
 
 router = APIRouter(prefix="/agents", tags=["agents"])
@@ -287,6 +292,7 @@ async def list_agents(
     cursor: str | None = None,
     limit: int = _DEFAULT_PAGINATION_LIMIT,
     name: str | None = None,
+    tenant_id: str = Depends(get_tenant_id),
     db: AsyncSession = Depends(get_async_db),
 ) -> ListAgentsResponse:
     """
@@ -312,16 +318,22 @@ async def list_agents(
         Agent.name.ilike(f"%{escape_like_pattern(name)}%", escape="\\") if name else None
     )
 
-    # Get total count (with name filter if provided)
-    count_query = select(func.count()).select_from(Agent)
+    # Get total count (with tenant scope + name filter if provided)
+    count_query = (
+        select(func.count()).select_from(Agent).where(Agent.tenant_id == tenant_id)
+    )
     if name_filter is not None:
         count_query = count_query.where(name_filter)
     count_result = await db.execute(count_query)
     total = count_result.scalar() or 0
 
-    # Build query with cursor-based pagination
-    # Order by created_at DESC, then by name DESC for stable ordering
-    query = select(Agent).order_by(Agent.created_at.desc(), Agent.name.desc())
+    # Build query with cursor-based pagination, scoped to the current tenant.
+    # Order by created_at DESC, then by name DESC for stable ordering.
+    query = (
+        select(Agent)
+        .where(Agent.tenant_id == tenant_id)
+        .order_by(Agent.created_at.desc(), Agent.name.desc())
+    )
 
     # Apply name filter if provided
     if name_filter is not None:
@@ -331,7 +343,9 @@ async def list_agents(
     if cursor:
         cursor_name = normalize_agent_name_or_422(cursor, field_name="cursor")
         cursor_agent_result = await db.execute(
-            select(Agent).where(Agent.name == cursor_name)
+            select(Agent).where(
+                Agent.name == cursor_name, Agent.tenant_id == tenant_id
+            )
         )
         cursor_agent = cursor_agent_result.scalars().first()
         if cursor_agent:
@@ -527,8 +541,20 @@ async def init_agent(
             )
         incoming_steps_by_key[step_key] = step
 
+    # Agent.name is still globally unique at the schema level. Look up
+    # globally and split into three cases: no row (create), row owned by the
+    # current tenant (update), row owned by another tenant (409 with a
+    # non-disclosing message).
     result = await db.execute(select(Agent).where(Agent.name == request.agent.agent_name))
     existing: Agent | None = result.scalars().first()
+    if existing is not None and existing.tenant_id != tenant_id:
+        raise ConflictError(
+            error_code=ErrorCode.AGENT_NAME_CONFLICT,
+            detail=f"Agent name '{request.agent.agent_name}' is not available.",
+            resource="Agent",
+            resource_id=request.agent.agent_name,
+            hint="Choose a different agent name.",
+        )
 
     created = False
 
@@ -829,7 +855,11 @@ async def init_agent(
     summary="Get agent details",
     response_description="Agent metadata and registered steps",
 )
-async def get_agent(agent_name: str, db: AsyncSession = Depends(get_async_db)) -> GetAgentResponse:
+async def get_agent(
+    agent_name: str,
+    tenant_id: str = Depends(get_tenant_id),
+    db: AsyncSession = Depends(get_async_db),
+) -> GetAgentResponse:
     """
     Retrieve agent metadata and all registered steps.
 
@@ -837,29 +867,20 @@ async def get_agent(agent_name: str, db: AsyncSession = Depends(get_async_db)) -
 
     Args:
         agent_name: Agent identifier
+        tenant_id: Effective tenant (injected)
         db: Database session (injected)
 
     Returns:
         GetAgentResponse with agent metadata and step list
 
     Raises:
-        HTTPException 404: Agent not found
+        HTTPException 404: Agent not found (or owned by another tenant)
         HTTPException 422: Agent data is corrupted
     """
     agent_name = normalize_agent_name_or_422(agent_name)
-    result = await db.execute(select(Agent).where(Agent.name == agent_name))
-    existing: Agent | None = result.scalars().first()
-    if existing is None:
-        raise NotFoundError(
-            error_code=ErrorCode.AGENT_NOT_FOUND,
-            detail=f"Agent with name '{agent_name}' not found",
-            resource="Agent",
-            resource_id=str(agent_name),
-            hint=(
-                "Verify the agent name is correct and the agent has been "
-                "registered via initAgent."
-            ),
-        )
+    existing = await get_agent_in_tenant_or_404(
+        tenant_id=tenant_id, agent_name=agent_name, db=db
+    )
 
     try:
         data_model = AgentData.model_validate(existing.data)
@@ -899,20 +920,14 @@ async def get_agent(agent_name: str, db: AsyncSession = Depends(get_async_db)) -
     )
 
 
-async def _get_agent_or_404(agent_name: str, db: AsyncSession) -> Agent:
-    """Get an agent or raise AGENT_NOT_FOUND."""
+async def _get_agent_or_404(
+    agent_name: str, tenant_id: str, db: AsyncSession
+) -> Agent:
+    """Get an agent scoped to ``tenant_id`` or raise AGENT_NOT_FOUND."""
     normalized_agent_name = normalize_agent_name_or_422(agent_name)
-    result = await db.execute(select(Agent).where(Agent.name == normalized_agent_name))
-    agent: Agent | None = result.scalars().first()
-    if agent is None:
-        raise NotFoundError(
-            error_code=ErrorCode.AGENT_NOT_FOUND,
-            detail=f"Agent with name '{normalized_agent_name}' not found",
-            resource="Agent",
-            resource_id=normalized_agent_name,
-            hint="Verify the agent name is correct and the agent has been registered.",
-        )
-    return agent
+    return await get_agent_in_tenant_or_404(
+        tenant_id=tenant_id, agent_name=normalized_agent_name, db=db
+    )
 
 
 @router.post(
@@ -923,21 +938,17 @@ async def _get_agent_or_404(agent_name: str, db: AsyncSession) -> Agent:
     response_description="Success confirmation",
 )
 async def add_agent_policy(
-    agent_name: str, policy_id: int, db: AsyncSession = Depends(get_async_db)
+    agent_name: str,
+    policy_id: int,
+    tenant_id: str = Depends(get_tenant_id),
+    db: AsyncSession = Depends(get_async_db),
 ) -> AssocResponse:
     """Associate a policy with an agent (idempotent)."""
-    agent = await _get_agent_or_404(agent_name, db)
+    agent = await _get_agent_or_404(agent_name, tenant_id, db)
 
-    policy_result = await db.execute(select(Policy).where(Policy.id == policy_id))
-    policy: Policy | None = policy_result.scalars().first()
-    if policy is None:
-        raise NotFoundError(
-            error_code=ErrorCode.POLICY_NOT_FOUND,
-            detail=f"Policy with ID '{policy_id}' not found",
-            resource="Policy",
-            resource_id=str(policy_id),
-            hint="Verify the policy ID is correct and the policy has been created.",
-        )
+    await get_policy_in_tenant_or_404(
+        tenant_id=tenant_id, policy_id=policy_id, db=db
+    )
 
     validation_errors = await _validate_policy_controls_for_agent(agent, policy_id, db)
     if validation_errors:
@@ -993,21 +1004,17 @@ async def add_agent_policy(
     response_description="Success status with previous policy ID",
 )
 async def set_agent_policy(
-    agent_name: str, policy_id: int, db: AsyncSession = Depends(get_async_db)
+    agent_name: str,
+    policy_id: int,
+    tenant_id: str = Depends(get_tenant_id),
+    db: AsyncSession = Depends(get_async_db),
 ) -> SetPolicyResponse:
     """Compatibility endpoint that replaces all policy associations with one policy."""
-    agent = await _get_agent_or_404(agent_name, db)
+    agent = await _get_agent_or_404(agent_name, tenant_id, db)
 
-    policy_result = await db.execute(select(Policy).where(Policy.id == policy_id))
-    policy: Policy | None = policy_result.scalars().first()
-    if policy is None:
-        raise NotFoundError(
-            error_code=ErrorCode.POLICY_NOT_FOUND,
-            detail=f"Policy with ID '{policy_id}' not found",
-            resource="Policy",
-            resource_id=str(policy_id),
-            hint="Verify the policy ID is correct and the policy has been created.",
-        )
+    await get_policy_in_tenant_or_404(
+        tenant_id=tenant_id, policy_id=policy_id, db=db
+    )
 
     validation_errors = await _validate_policy_controls_for_agent(agent, policy_id, db)
     if validation_errors:
@@ -1070,10 +1077,12 @@ async def set_agent_policy(
     response_description="List of policy IDs",
 )
 async def get_agent_policies(
-    agent_name: str, db: AsyncSession = Depends(get_async_db)
+    agent_name: str,
+    tenant_id: str = Depends(get_tenant_id),
+    db: AsyncSession = Depends(get_async_db),
 ) -> GetAgentPoliciesResponse:
     """List policy IDs associated with an agent."""
-    agent = await _get_agent_or_404(agent_name, db)
+    agent = await _get_agent_or_404(agent_name, tenant_id, db)
     result = await db.execute(
         select(agent_policies.c.policy_id)
         .where(agent_policies.c.agent_name == agent.name)
@@ -1089,10 +1098,12 @@ async def get_agent_policies(
     response_description="Policy ID",
 )
 async def get_agent_policy(
-    agent_name: str, db: AsyncSession = Depends(get_async_db)
+    agent_name: str,
+    tenant_id: str = Depends(get_tenant_id),
+    db: AsyncSession = Depends(get_async_db),
 ) -> GetPolicyResponse:
     """Compatibility endpoint that returns the first associated policy."""
-    agent = await _get_agent_or_404(agent_name, db)
+    agent = await _get_agent_or_404(agent_name, tenant_id, db)
     policy_result = await db.execute(
         select(Policy.id)
         .join(agent_policies, agent_policies.c.policy_id == Policy.id)
@@ -1119,24 +1130,21 @@ async def get_agent_policy(
     response_description="Success confirmation",
 )
 async def remove_agent_policy(
-    agent_name: str, policy_id: int, db: AsyncSession = Depends(get_async_db)
+    agent_name: str,
+    policy_id: int,
+    tenant_id: str = Depends(get_tenant_id),
+    db: AsyncSession = Depends(get_async_db),
 ) -> AssocResponse:
     """Remove a policy association from an agent.
 
     Idempotent for existing resources: removing a non-associated link is a no-op.
     Missing agent/policy resources still return 404.
     """
-    agent = await _get_agent_or_404(agent_name, db)
+    agent = await _get_agent_or_404(agent_name, tenant_id, db)
 
-    policy_result = await db.execute(select(Policy.id).where(Policy.id == policy_id))
-    if policy_result.first() is None:
-        raise NotFoundError(
-            error_code=ErrorCode.POLICY_NOT_FOUND,
-            detail=f"Policy with ID '{policy_id}' not found",
-            resource="Policy",
-            resource_id=str(policy_id),
-            hint="Verify the policy ID is correct and the policy has been created.",
-        )
+    await get_policy_in_tenant_or_404(
+        tenant_id=tenant_id, policy_id=policy_id, db=db
+    )
 
     try:
         await db.execute(
@@ -1171,10 +1179,12 @@ async def remove_agent_policy(
     response_description="Success confirmation",
 )
 async def remove_all_agent_policies(
-    agent_name: str, db: AsyncSession = Depends(get_async_db)
+    agent_name: str,
+    tenant_id: str = Depends(get_tenant_id),
+    db: AsyncSession = Depends(get_async_db),
 ) -> AssocResponse:
     """Remove all policy associations from an agent."""
-    agent = await _get_agent_or_404(agent_name, db)
+    agent = await _get_agent_or_404(agent_name, tenant_id, db)
 
     try:
         await db.execute(delete(agent_policies).where(agent_policies.c.agent_name == agent.name))
@@ -1206,10 +1216,12 @@ async def remove_all_agent_policies(
     response_description="Success confirmation",
 )
 async def delete_agent_policy(
-    agent_name: str, db: AsyncSession = Depends(get_async_db)
+    agent_name: str,
+    tenant_id: str = Depends(get_tenant_id),
+    db: AsyncSession = Depends(get_async_db),
 ) -> DeletePolicyResponse:
     """Compatibility endpoint that removes all policy associations."""
-    agent = await _get_agent_or_404(agent_name, db)
+    agent = await _get_agent_or_404(agent_name, tenant_id, db)
 
     existing_policy_result = await db.execute(
         select(agent_policies.c.policy_id)
@@ -1254,21 +1266,17 @@ async def delete_agent_policy(
     response_description="Success confirmation",
 )
 async def add_agent_control(
-    agent_name: str, control_id: int, db: AsyncSession = Depends(get_async_db)
+    agent_name: str,
+    control_id: int,
+    tenant_id: str = Depends(get_tenant_id),
+    db: AsyncSession = Depends(get_async_db),
 ) -> AssocResponse:
     """Associate a control directly with an agent (idempotent)."""
-    agent = await _get_agent_or_404(agent_name, db)
+    agent = await _get_agent_or_404(agent_name, tenant_id, db)
 
-    control_result = await db.execute(select(Control).where(Control.id == control_id))
-    control: Control | None = control_result.scalars().first()
-    if control is None:
-        raise NotFoundError(
-            error_code=ErrorCode.CONTROL_NOT_FOUND,
-            detail=f"Control with ID '{control_id}' not found",
-            resource="Control",
-            resource_id=str(control_id),
-            hint="Verify the control ID is correct and the control has been created.",
-        )
+    control = await get_control_in_tenant_or_404(
+        tenant_id=tenant_id, control_id=control_id, db=db
+    )
 
     validation_errors = _validate_controls_for_agent(agent, [control])
     if validation_errors:
@@ -1324,20 +1332,17 @@ async def add_agent_control(
     response_description="Success confirmation",
 )
 async def remove_agent_control(
-    agent_name: str, control_id: int, db: AsyncSession = Depends(get_async_db)
+    agent_name: str,
+    control_id: int,
+    tenant_id: str = Depends(get_tenant_id),
+    db: AsyncSession = Depends(get_async_db),
 ) -> RemoveAgentControlResponse:
     """Remove a direct control association from an agent (idempotent)."""
-    agent = await _get_agent_or_404(agent_name, db)
+    agent = await _get_agent_or_404(agent_name, tenant_id, db)
 
-    control_result = await db.execute(select(Control.id).where(Control.id == control_id))
-    if control_result.first() is None:
-        raise NotFoundError(
-            error_code=ErrorCode.CONTROL_NOT_FOUND,
-            detail=f"Control with ID '{control_id}' not found",
-            resource="Control",
-            resource_id=str(control_id),
-            hint="Verify the control ID is correct and the control has been created.",
-        )
+    await get_control_in_tenant_or_404(
+        tenant_id=tenant_id, control_id=control_id, db=db
+    )
 
     try:
         remove_direct_stmt = (
@@ -1420,6 +1425,7 @@ async def list_agent_controls(
             "combine with rendered_state='rendered' to exclude them."
         ),
     ),
+    tenant_id: str = Depends(get_tenant_id),
     db: AsyncSession = Depends(get_async_db),
 ) -> AgentControlsResponse:
     """
@@ -1443,7 +1449,7 @@ async def list_agent_controls(
     Raises:
         HTTPException 404: Agent not found
     """
-    agent = await _get_agent_or_404(agent_name, db)
+    agent = await _get_agent_or_404(agent_name, tenant_id, db)
     controls = await list_controls_for_agent(
         agent.name,
         db,
@@ -1485,6 +1491,7 @@ async def list_agent_evaluators(
     agent_name: str,
     cursor: str | None = None,
     limit: int = _DEFAULT_PAGINATION_LIMIT,
+    tenant_id: str = Depends(get_tenant_id),
     db: AsyncSession = Depends(get_async_db),
 ) -> ListEvaluatorsResponse:
     """
@@ -1510,16 +1517,9 @@ async def list_agent_evaluators(
     # Clamp limit
     limit = min(max(1, limit), _MAX_PAGINATION_LIMIT)
 
-    result = await db.execute(select(Agent).where(Agent.name == agent_name))
-    agent: Agent | None = result.scalars().first()
-    if agent is None:
-        raise NotFoundError(
-            error_code=ErrorCode.AGENT_NOT_FOUND,
-            detail=f"Agent with name '{agent_name}' not found",
-            resource="Agent",
-            resource_id=str(agent_name),
-            hint="Verify the agent name is correct and the agent has been registered.",
-        )
+    agent = await get_agent_in_tenant_or_404(
+        tenant_id=tenant_id, agent_name=agent_name, db=db
+    )
 
     try:
         data_model = AgentData.model_validate(agent.data)
@@ -1580,6 +1580,7 @@ async def list_agent_evaluators(
 async def get_agent_evaluator(
     agent_name: str,
     evaluator_name: str,
+    tenant_id: str = Depends(get_tenant_id),
     db: AsyncSession = Depends(get_async_db),
 ) -> EvaluatorSchemaItem:
     """
@@ -1597,16 +1598,9 @@ async def get_agent_evaluator(
         HTTPException 404: Agent or evaluator not found
     """
     agent_name = normalize_agent_name_or_422(agent_name)
-    result = await db.execute(select(Agent).where(Agent.name == agent_name))
-    agent: Agent | None = result.scalars().first()
-    if agent is None:
-        raise NotFoundError(
-            error_code=ErrorCode.AGENT_NOT_FOUND,
-            detail=f"Agent with name '{agent_name}' not found",
-            resource="Agent",
-            resource_id=str(agent_name),
-            hint="Verify the agent name is correct and the agent has been registered.",
-        )
+    agent = await get_agent_in_tenant_or_404(
+        tenant_id=tenant_id, agent_name=agent_name, db=db
+    )
 
     try:
         data_model = AgentData.model_validate(agent.data)
@@ -1646,6 +1640,7 @@ async def get_agent_evaluator(
 async def patch_agent(
     agent_name: str,
     request: PatchAgentRequest,
+    tenant_id: str = Depends(get_tenant_id),
     db: AsyncSession = Depends(get_async_db),
 ) -> PatchAgentResponse:
     """
@@ -1667,16 +1662,9 @@ async def patch_agent(
         HTTPException 500: Database error during update
     """
     agent_name = normalize_agent_name_or_422(agent_name)
-    result = await db.execute(select(Agent).where(Agent.name == agent_name))
-    agent: Agent | None = result.scalars().first()
-    if agent is None:
-        raise NotFoundError(
-            error_code=ErrorCode.AGENT_NOT_FOUND,
-            detail=f"Agent with name '{agent_name}' not found",
-            resource="Agent",
-            resource_id=str(agent_name),
-            hint="Verify the agent name is correct and the agent has been registered.",
-        )
+    agent = await get_agent_in_tenant_or_404(
+        tenant_id=tenant_id, agent_name=agent_name, db=db
+    )
 
     try:
         data_model = AgentData.model_validate(agent.data)

--- a/server/src/agent_control_server/endpoints/controls.py
+++ b/server/src/agent_control_server/endpoints/controls.py
@@ -34,10 +34,9 @@ from ..errors import (
     APIValidationError,
     ConflictError,
     DatabaseError,
-    NotFoundError,
 )
 from ..logging_utils import get_logger
-from ..models import Agent, AgentData, Control, agent_controls, agent_policies, policy_controls
+from ..models import AgentData, Control, agent_controls, agent_policies, policy_controls
 from ..services.condition_traversal import iter_condition_leaves_with_paths
 from ..services.control_definitions import parse_control_definition_or_api_error
 from ..services.control_templates import (
@@ -52,6 +51,10 @@ from ..services.evaluator_utils import (
     validate_config_against_schema,
 )
 from ..services.query_utils import escape_like_pattern
+from ..services.tenant_scoped_lookups import (
+    get_agent_in_tenant_or_404,
+    get_control_in_tenant_or_404,
+)
 from ..services.validation_paths import format_field_path
 from ..tenancy import get_tenant_id
 
@@ -171,13 +174,14 @@ def _template_backed_raw_update_conflict(control_id: int) -> ConflictError:
 async def _render_and_validate_template_input(
     template_input: TemplateControlInput,
     *,
+    tenant_id: str,
     db: AsyncSession,
     enabled: bool = True,
 ) -> ControlDefinition:
     """Render a template-backed input and validate evaluator config."""
     rendered = render_template_control_input(template_input, enabled=enabled)
     try:
-        await _validate_control_definition(rendered.control, db)
+        await _validate_control_definition(rendered.control, tenant_id=tenant_id, db=db)
     except APIValidationError as exc:
         raise remap_template_api_error(
             exc,
@@ -190,6 +194,7 @@ async def _render_and_validate_template_input(
 async def _materialize_control_input(
     control_input: ControlDefinition | TemplateControlInput,
     *,
+    tenant_id: str,
     db: AsyncSession,
     current_payload: object | None = None,
     control_id: int | None = None,
@@ -202,6 +207,7 @@ async def _materialize_control_input(
             )
             return await _render_and_validate_template_input(
                 control_input,
+                tenant_id=tenant_id,
                 db=db,
                 enabled=enabled,
             )
@@ -220,6 +226,7 @@ async def _materialize_control_input(
             enabled = _enabled_from_stored_payload(current_payload)
             return await _render_and_validate_template_input(
                 control_input,
+                tenant_id=tenant_id,
                 db=db,
                 enabled=enabled,
             )
@@ -239,17 +246,22 @@ async def _materialize_control_input(
             raise RuntimeError("control_id is required for template-backed raw updates")
         raise _template_backed_raw_update_conflict(control_id)
 
-    await _validate_control_definition(control_input, db)
+    await _validate_control_definition(control_input, tenant_id=tenant_id, db=db)
     return control_input
 
 
 async def _validate_control_definition(
-    control_def: ControlDefinition, db: AsyncSession
+    control_def: ControlDefinition, *, tenant_id: str, db: AsyncSession
 ) -> None:
     """Validate evaluator config for definitions referencing known global evaluators.
 
-    Agent-scoped evaluators must exist on the referenced agent. Builtin and external
-    names that are not loaded in this process are accepted without config checks.
+    Agent-scoped evaluators must exist on the referenced agent **in the caller's
+    tenant**. A reference to an agent owned by another tenant surfaces as
+    AGENT_NOT_FOUND; this both prevents cross-tenant binding of control
+    definitions and avoids leaking the existence or evaluator inventory of
+    foreign-tenant agents through validation error messages. Builtin and
+    external names that are not loaded in this process are accepted without
+    config checks.
     """
     available_evaluators = list_evaluators()
     agent_data_by_name: dict[str, AgentData] = {}
@@ -272,21 +284,11 @@ async def _validate_control_definition(
 
             agent_data = agent_data_by_name.get(agent_namespace)
             if agent_data is None:
-                agent_result = await db.execute(
-                    select(Agent).where(Agent.name == agent_namespace)
+                agent = await get_agent_in_tenant_or_404(
+                    tenant_id=tenant_id,
+                    agent_name=agent_namespace,
+                    db=db,
                 )
-                agent = agent_result.scalars().first()
-                if agent is None:
-                    raise NotFoundError(
-                        error_code=ErrorCode.AGENT_NOT_FOUND,
-                        detail=f"Agent '{agent_namespace}' not found",
-                        resource="Agent",
-                        resource_id=agent_namespace,
-                        hint=(
-                            "Ensure the agent exists before creating controls "
-                            "that reference its evaluators."
-                        ),
-                    )
 
                 try:
                     agent_data = AgentData.model_validate(agent.data)
@@ -422,6 +424,7 @@ async def _validate_control_definition(
 )
 async def render_control_template(
     request: RenderControlTemplateRequest,
+    tenant_id: str = Depends(get_tenant_id),
     db: AsyncSession = Depends(get_async_db),
 ) -> RenderControlTemplateResponse:
     """Render a template-backed control without persisting it."""
@@ -430,6 +433,7 @@ async def render_control_template(
             template=request.template,
             template_values=request.template_values,
         ),
+        tenant_id=tenant_id,
         db=db,
         enabled=True,
     )
@@ -476,7 +480,9 @@ async def create_control(
             hint="Choose a different name or update the existing control.",
         )
 
-    control_def = await _materialize_control_input(request.data, db=db)
+    control_def = await _materialize_control_input(
+        request.data, tenant_id=tenant_id, db=db
+    )
     control_data = _serialize_control_data(control_def)
 
     control = Control(name=request.name, tenant_id=tenant_id, data=control_data)
@@ -527,7 +533,9 @@ async def get_control_schema() -> GetControlSchemaResponse:
     response_description="Control metadata and configuration",
 )
 async def get_control(
-    control_id: int, db: AsyncSession = Depends(get_async_db)
+    control_id: int,
+    tenant_id: str = Depends(get_tenant_id),
+    db: AsyncSession = Depends(get_async_db),
 ) -> GetControlResponse:
     """
     Retrieve a control by ID including its name and configuration data.
@@ -542,16 +550,9 @@ async def get_control(
     Raises:
         HTTPException 404: Control not found
     """
-    res = await db.execute(select(Control).where(Control.id == control_id))
-    control = res.scalars().first()
-    if control is None:
-        raise NotFoundError(
-            error_code=ErrorCode.CONTROL_NOT_FOUND,
-            detail=f"Control with ID '{control_id}' not found",
-            resource="Control",
-            resource_id=str(control_id),
-            hint="Verify the control ID is correct and the control has been created.",
-        )
+    control = await get_control_in_tenant_or_404(
+        tenant_id=tenant_id, control_id=control_id, db=db
+    )
 
     # Parse data if present and non-empty
     control_data: ControlDefinition | UnrenderedTemplateControl | None = None
@@ -587,7 +588,9 @@ async def get_control(
     response_description="Control data payload",
 )
 async def get_control_data(
-    control_id: int, db: AsyncSession = Depends(get_async_db)
+    control_id: int,
+    tenant_id: str = Depends(get_tenant_id),
+    db: AsyncSession = Depends(get_async_db),
 ) -> GetControlDataResponse:
     """
     Retrieve the configuration data for a control.
@@ -605,16 +608,9 @@ async def get_control_data(
         HTTPException 404: Control not found
         HTTPException 422: Control data is corrupted
     """
-    res = await db.execute(select(Control).where(Control.id == control_id))
-    control = res.scalars().first()
-    if control is None:
-        raise NotFoundError(
-            error_code=ErrorCode.CONTROL_NOT_FOUND,
-            detail=f"Control with ID '{control_id}' not found",
-            resource="Control",
-            resource_id=str(control_id),
-            hint="Verify the control ID is correct and the control has been created.",
-        )
+    control = await get_control_in_tenant_or_404(
+        tenant_id=tenant_id, control_id=control_id, db=db
+    )
     control_data = _parse_stored_control_data(
         control.data,
         control_name=control.name,
@@ -633,6 +629,7 @@ async def get_control_data(
 async def set_control_data(
     control_id: int,
     request: SetControlDataRequest,
+    tenant_id: str = Depends(get_tenant_id),
     db: AsyncSession = Depends(get_async_db),
 ) -> SetControlDataResponse:
     """
@@ -653,19 +650,13 @@ async def set_control_data(
         HTTPException 404: Control not found
         HTTPException 500: Database error during update
     """
-    res = await db.execute(select(Control).where(Control.id == control_id))
-    control = res.scalars().first()
-    if control is None:
-        raise NotFoundError(
-            error_code=ErrorCode.CONTROL_NOT_FOUND,
-            detail=f"Control with ID '{control_id}' not found",
-            resource="Control",
-            resource_id=str(control_id),
-            hint="Verify the control ID is correct and the control has been created.",
-        )
+    control = await get_control_in_tenant_or_404(
+        tenant_id=tenant_id, control_id=control_id, db=db
+    )
 
     control_def = await _materialize_control_input(
         request.data,
+        tenant_id=tenant_id,
         db=db,
         current_payload=control.data,
         control_id=control_id,
@@ -695,7 +686,9 @@ async def set_control_data(
     response_description="Validation result",
 )
 async def validate_control_data(
-    request: ValidateControlDataRequest, db: AsyncSession = Depends(get_async_db)
+    request: ValidateControlDataRequest,
+    tenant_id: str = Depends(get_tenant_id),
+    db: AsyncSession = Depends(get_async_db),
 ) -> ValidateControlDataResponse:
     """
     Validate control configuration data without saving it.
@@ -709,7 +702,7 @@ async def validate_control_data(
     """
     # Validate mirrors create: complete template values trigger a full render,
     # incomplete values validate structure only (matching unrendered create).
-    await _materialize_control_input(request.data, db=db)
+    await _materialize_control_input(request.data, tenant_id=tenant_id, db=db)
     return ValidateControlDataResponse(success=True)
 
 
@@ -734,6 +727,7 @@ async def list_controls(
     stage: str | None = Query(None, description="Filter by stage ('pre' or 'post')"),
     execution: str | None = Query(None, description="Filter by execution ('server' or 'sdk')"),
     tag: str | None = Query(None, description="Filter by tag"),
+    tenant_id: str = Depends(get_tenant_id),
     db: AsyncSession = Depends(get_async_db),
 ) -> ListControlsResponse:
     """
@@ -759,7 +753,7 @@ async def list_controls(
     Example:
         GET /controls?limit=10&enabled=true&step_type=tool
     """
-    query = select(Control).order_by(Control.id.desc())
+    query = select(Control).where(Control.tenant_id == tenant_id).order_by(Control.id.desc())
 
     # Apply cursor
     if cursor is not None:
@@ -824,7 +818,7 @@ async def list_controls(
     controls = list(result.scalars().all())
 
     # Get total count (with same filters, but without cursor/limit)
-    total_query = select(func.count()).select_from(Control)
+    total_query = select(func.count()).select_from(Control).where(Control.tenant_id == tenant_id)
     if name is not None:
         total_query = total_query.where(
             Control.name.ilike(f"%{escape_like_pattern(name)}%", escape="\\")
@@ -972,6 +966,7 @@ async def delete_control(
         description="If true, dissociate from all policy/agent links before deleting. "
         "If false, fail if control is associated with any policy or agent.",
     ),
+    tenant_id: str = Depends(get_tenant_id),
     db: AsyncSession = Depends(get_async_db),
 ) -> DeleteControlResponse:
     """
@@ -993,17 +988,10 @@ async def delete_control(
         HTTPException 409: Control is in use (and force=false)
         HTTPException 500: Database error during deletion
     """
-    # Find the control
-    result = await db.execute(select(Control).where(Control.id == control_id))
-    control = result.scalars().first()
-    if control is None:
-        raise NotFoundError(
-            error_code=ErrorCode.CONTROL_NOT_FOUND,
-            detail=f"Control with ID '{control_id}' not found",
-            resource="Control",
-            resource_id=str(control_id),
-            hint="Verify the control ID is correct and the control has been created.",
-        )
+    # Find the control (tenant-scoped lookup)
+    control = await get_control_in_tenant_or_404(
+        tenant_id=tenant_id, control_id=control_id, db=db
+    )
 
     # Check for associations with policies and direct agent links.
     policy_assoc_query = select(
@@ -1110,6 +1098,7 @@ async def delete_control(
 async def patch_control(
     control_id: int,
     request: PatchControlRequest,
+    tenant_id: str = Depends(get_tenant_id),
     db: AsyncSession = Depends(get_async_db),
 ) -> PatchControlResponse:
     """
@@ -1133,17 +1122,10 @@ async def patch_control(
         HTTPException 422: Cannot update enabled status (control has no data configured)
         HTTPException 500: Database error during update
     """
-    # Find the control
-    result = await db.execute(select(Control).where(Control.id == control_id))
-    control = result.scalars().first()
-    if control is None:
-        raise NotFoundError(
-            error_code=ErrorCode.CONTROL_NOT_FOUND,
-            detail=f"Control with ID '{control_id}' not found",
-            resource="Control",
-            resource_id=str(control_id),
-            hint="Verify the control ID is correct and the control has been created.",
-        )
+    # Find the control (tenant-scoped lookup)
+    control = await get_control_in_tenant_or_404(
+        tenant_id=tenant_id, control_id=control_id, db=db
+    )
 
     # Track if anything changed
     updated = False

--- a/server/src/agent_control_server/endpoints/evaluation.py
+++ b/server/src/agent_control_server/endpoints/evaluation.py
@@ -18,8 +18,9 @@ from ..auth import RequireAPIKey
 from ..db import get_async_db
 from ..errors import APIValidationError, NotFoundError
 from ..logging_utils import get_logger
-from ..models import Agent, Target
+from ..models import Target
 from ..services.controls import list_runtime_controls_for_agent
+from ..services.tenant_scoped_lookups import get_agent_in_tenant_or_404
 from ..tenancy import get_tenant_id
 
 router = APIRouter(prefix="/evaluation", tags=["evaluation"])
@@ -147,18 +148,9 @@ async def evaluate(
     """
     del client  # Authentication is still required by dependency injection.
 
-    agent_result = await db.execute(
-        select(Agent).where(Agent.name == request.agent_name)
+    await get_agent_in_tenant_or_404(
+        tenant_id=tenant_id, agent_name=request.agent_name, db=db
     )
-    agent = agent_result.scalar_one_or_none()
-    if agent is None:
-        raise NotFoundError(
-            error_code=ErrorCode.AGENT_NOT_FOUND,
-            detail=f"Agent '{request.agent_name}' not found",
-            resource="Agent",
-            resource_id=request.agent_name,
-            hint="Register the agent via initAgent before evaluating.",
-        )
 
     resolved_target_id: int | None = None
     if request.target_type is not None and request.target_id is not None:

--- a/server/src/agent_control_server/endpoints/policies.py
+++ b/server/src/agent_control_server/endpoints/policies.py
@@ -11,9 +11,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..auth import require_admin_key
 from ..db import get_async_db
-from ..errors import ConflictError, DatabaseError, NotFoundError
+from ..errors import ConflictError, DatabaseError
 from ..logging_utils import get_logger
-from ..models import Control, Policy, policy_controls
+from ..models import Policy, policy_controls
+from ..services.tenant_scoped_lookups import (
+    get_control_in_tenant_or_404,
+    get_policy_in_tenant_or_404,
+)
 from ..tenancy import get_tenant_id
 
 router = APIRouter(prefix="/policies", tags=["policies"])
@@ -88,7 +92,10 @@ async def create_policy(
     response_description="Success confirmation",
 )
 async def add_control_to_policy(
-    policy_id: int, control_id: int, db: AsyncSession = Depends(get_async_db)
+    policy_id: int,
+    control_id: int,
+    tenant_id: str = Depends(get_tenant_id),
+    db: AsyncSession = Depends(get_async_db),
 ) -> AssocResponse:
     """
     Associate a control with a policy.
@@ -109,27 +116,13 @@ async def add_control_to_policy(
         HTTPException 500: Database error
     """
     # Find policy and control
-    pol_res = await db.execute(select(Policy).where(Policy.id == policy_id))
-    policy = pol_res.scalars().first()
-    if policy is None:
-        raise NotFoundError(
-            error_code=ErrorCode.POLICY_NOT_FOUND,
-            detail=f"Policy with ID '{policy_id}' not found",
-            resource="Policy",
-            resource_id=str(policy_id),
-            hint="Verify the policy ID is correct and the policy has been created.",
-        )
+    policy = await get_policy_in_tenant_or_404(
+        tenant_id=tenant_id, policy_id=policy_id, db=db
+    )
 
-    ctl_res = await db.execute(select(Control).where(Control.id == control_id))
-    control = ctl_res.scalars().first()
-    if control is None:
-        raise NotFoundError(
-            error_code=ErrorCode.CONTROL_NOT_FOUND,
-            detail=f"Control with ID '{control_id}' not found",
-            resource="Control",
-            resource_id=str(control_id),
-            hint="Verify the control ID is correct and the control has been created.",
-        )
+    control = await get_control_in_tenant_or_404(
+        tenant_id=tenant_id, control_id=control_id, db=db
+    )
 
     # Add association using INSERT ... ON CONFLICT DO NOTHING for idempotency
     try:
@@ -172,7 +165,10 @@ async def add_control_to_policy(
     response_description="Success confirmation",
 )
 async def remove_control_from_policy(
-    policy_id: int, control_id: int, db: AsyncSession = Depends(get_async_db)
+    policy_id: int,
+    control_id: int,
+    tenant_id: str = Depends(get_tenant_id),
+    db: AsyncSession = Depends(get_async_db),
 ) -> AssocResponse:
     """
     Remove a control from a policy.
@@ -192,27 +188,13 @@ async def remove_control_from_policy(
         HTTPException 404: Policy or control not found
         HTTPException 500: Database error
     """
-    pol_res = await db.execute(select(Policy).where(Policy.id == policy_id))
-    policy = pol_res.scalars().first()
-    if policy is None:
-        raise NotFoundError(
-            error_code=ErrorCode.POLICY_NOT_FOUND,
-            detail=f"Policy with ID '{policy_id}' not found",
-            resource="Policy",
-            resource_id=str(policy_id),
-            hint="Verify the policy ID is correct and the policy has been created.",
-        )
+    policy = await get_policy_in_tenant_or_404(
+        tenant_id=tenant_id, policy_id=policy_id, db=db
+    )
 
-    ctl_res = await db.execute(select(Control).where(Control.id == control_id))
-    control = ctl_res.scalars().first()
-    if control is None:
-        raise NotFoundError(
-            error_code=ErrorCode.CONTROL_NOT_FOUND,
-            detail=f"Control with ID '{control_id}' not found",
-            resource="Control",
-            resource_id=str(control_id),
-            hint="Verify the control ID is correct and the control has been created.",
-        )
+    control = await get_control_in_tenant_or_404(
+        tenant_id=tenant_id, control_id=control_id, db=db
+    )
 
     # Remove association (idempotent - deleting non-existent is no-op)
     try:
@@ -249,7 +231,9 @@ async def remove_control_from_policy(
     response_description="List of control IDs",
 )
 async def list_policy_controls(
-    policy_id: int, db: AsyncSession = Depends(get_async_db)
+    policy_id: int,
+    tenant_id: str = Depends(get_tenant_id),
+    db: AsyncSession = Depends(get_async_db),
 ) -> GetPolicyControlsResponse:
     """
     List all controls associated with a policy.
@@ -264,15 +248,9 @@ async def list_policy_controls(
     Raises:
         HTTPException 404: Policy not found
     """
-    pol_res = await db.execute(select(Policy.id).where(Policy.id == policy_id))
-    if pol_res.first() is None:
-        raise NotFoundError(
-            error_code=ErrorCode.POLICY_NOT_FOUND,
-            detail=f"Policy with ID '{policy_id}' not found",
-            resource="Policy",
-            resource_id=str(policy_id),
-            hint="Verify the policy ID is correct and the policy has been created.",
-        )
+    await get_policy_in_tenant_or_404(
+        tenant_id=tenant_id, policy_id=policy_id, db=db
+    )
 
     rows = await db.execute(
         select(policy_controls.c.control_id).where(

--- a/server/src/agent_control_server/endpoints/targets.py
+++ b/server/src/agent_control_server/endpoints/targets.py
@@ -198,7 +198,9 @@ async def attach_target_control(
     omitted, the attachment defaults to ``enabled=true``.
     """
     await _get_target_or_404(tenant_id=tenant_id, target_id=target_id, db=db)
-    if not await targets_service.control_exists(control_id=control_id, db=db):
+    if not await targets_service.control_exists_in_tenant(
+        control_id=control_id, tenant_id=tenant_id, db=db
+    ):
         raise NotFoundError(
             error_code=ErrorCode.CONTROL_NOT_FOUND,
             detail=f"Control with ID '{control_id}' not found",

--- a/server/src/agent_control_server/services/targets.py
+++ b/server/src/agent_control_server/services/targets.py
@@ -188,16 +188,22 @@ async def list_target_controls(
     return result.scalars().all()
 
 
-async def control_exists(*, control_id: int, db: AsyncSession) -> bool:
-    """Return whether a control with the given ID exists."""
-    result = await db.execute(select(Control.id).where(Control.id == control_id))
+async def control_exists_in_tenant(
+    *, control_id: int, tenant_id: str, db: AsyncSession
+) -> bool:
+    """Return whether a control with the given ID exists in the given tenant."""
+    result = await db.execute(
+        select(Control.id).where(
+            Control.id == control_id, Control.tenant_id == tenant_id
+        )
+    )
     return result.first() is not None
 
 
 __all__ = [
     "AttachResult",
     "attach_control_to_target",
-    "control_exists",
+    "control_exists_in_tenant",
     "create_target",
     "delete_target",
     "detach_control_from_target",

--- a/server/src/agent_control_server/services/tenant_scoped_lookups.py
+++ b/server/src/agent_control_server/services/tenant_scoped_lookups.py
@@ -1,0 +1,89 @@
+"""Tenant-scoped lookup helpers.
+
+Every request-scoped access to a tenant-owned row (Agent, Control, Policy,
+Target) goes through one of the helpers in this module so that the tenant
+boundary is enforced consistently across endpoints. Rows owned by a
+different tenant surface as ``404 NOT_FOUND`` rather than leaking existence
+through a different status code.
+
+This is not full tenant independence: ``Agent.name``, ``Control.name``, and
+``Policy.name`` are still globally unique at the schema level. What these
+helpers enforce is the *access* boundary: a caller resolved to tenant A
+cannot read, mutate, or reference a row stamped with tenant B.
+"""
+
+from __future__ import annotations
+
+from agent_control_models.errors import ErrorCode
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..errors import NotFoundError
+from ..models import Agent, Control, Policy
+
+
+async def get_agent_in_tenant_or_404(
+    *, tenant_id: str, agent_name: str, db: AsyncSession
+) -> Agent:
+    """Return the agent row scoped to the given tenant, or raise 404.
+
+    The same ``AGENT_NOT_FOUND`` code is returned whether the agent does not
+    exist at all or belongs to a different tenant, to avoid leaking the
+    presence of rows owned by other tenants.
+    """
+    stmt = select(Agent).where(
+        Agent.name == agent_name, Agent.tenant_id == tenant_id
+    )
+    result = await db.execute(stmt)
+    agent = result.scalars().first()
+    if agent is None:
+        raise NotFoundError(
+            error_code=ErrorCode.AGENT_NOT_FOUND,
+            detail=f"Agent with name '{agent_name}' not found",
+            resource="Agent",
+            resource_id=agent_name,
+            hint="Verify the agent name and that the agent belongs to this tenant.",
+        )
+    return agent
+
+
+async def get_policy_in_tenant_or_404(
+    *, tenant_id: str, policy_id: int, db: AsyncSession
+) -> Policy:
+    """Return the policy row scoped to the given tenant, or raise 404."""
+    stmt = select(Policy).where(
+        Policy.id == policy_id, Policy.tenant_id == tenant_id
+    )
+    result = await db.execute(stmt)
+    policy = result.scalars().first()
+    if policy is None:
+        raise NotFoundError(
+            error_code=ErrorCode.POLICY_NOT_FOUND,
+            detail=f"Policy with ID '{policy_id}' not found",
+            resource="Policy",
+            resource_id=str(policy_id),
+            hint="Verify the policy ID and that the policy belongs to this tenant.",
+        )
+    return policy
+
+
+async def get_control_in_tenant_or_404(
+    *, tenant_id: str, control_id: int, db: AsyncSession
+) -> Control:
+    """Return the control row scoped to the given tenant, or raise 404."""
+    stmt = select(Control).where(
+        Control.id == control_id, Control.tenant_id == tenant_id
+    )
+    result = await db.execute(stmt)
+    control = result.scalars().first()
+    if control is None:
+        raise NotFoundError(
+            error_code=ErrorCode.CONTROL_NOT_FOUND,
+            detail=f"Control with ID '{control_id}' not found",
+            resource="Control",
+            resource_id=str(control_id),
+            hint="Verify the control ID and that the control belongs to this tenant.",
+        )
+    return control
+
+

--- a/server/tests/test_controls_additional.py
+++ b/server/tests/test_controls_additional.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm import Session
 
 from agent_control_models import ConditionNode
 from agent_control_server.db import get_async_db
-from agent_control_server.models import Control
+from agent_control_server.models import DEFAULT_TENANT_ID, Control
 
 from agent_control_evaluators import RegexEvaluatorConfig
 from agent_control_server.endpoints import controls as controls_module
@@ -939,7 +939,9 @@ async def test_set_control_data_selector_without_model_dump_uses_original_serial
     request = SimpleNamespace(data=DummyData(payload))
 
     # When: updating the control data with a non-Pydantic selector
-    response = await controls_module.set_control_data(control.id, request, async_db)
+    response = await controls_module.set_control_data(
+        control.id, request, DEFAULT_TENANT_ID, async_db
+    )
 
     # Then: the update succeeds and uses the original selector serialization
     assert response.success is True

--- a/server/tests/test_evaluation_target_resolution.py
+++ b/server/tests/test_evaluation_target_resolution.py
@@ -230,12 +230,37 @@ def test_target_bearing_request_with_unknown_target_returns_404(
 
 
 def test_target_resolution_is_tenant_scoped(client: TestClient) -> None:
-    """A target created in tenant-a must not be visible from tenant-b."""
-    agent_name = _register_agent(client)
+    """Cross-tenant evaluation surfaces the agent boundary first.
+
+    Agent lookup is now tenant-scoped, so a caller in tenant-b that references
+    an agent owned by tenant-a gets AGENT_NOT_FOUND before target resolution
+    runs. That is the enforcement we want: no cross-tenant access leaks the
+    presence of either the agent or the target.
+    """
+    register_resp = client.post(
+        f"{API_PREFIX}/agents/initAgent",
+        headers={TENANT_HEADER: "tenant-a"},
+        json={
+            "agent": {"agent_name": f"agent-{uuid.uuid4().hex[:12]}"},
+            "steps": [],
+        },
+    )
+    assert register_resp.status_code == 200, register_resp.text
+    agent_name = register_resp.request.headers.get("X-Tenant-Id"), register_resp.json()
+    # Re-derive agent_name from request body (initAgent echoes created=true)
+    agent_body = {"agent": {"agent_name": f"agent-{uuid.uuid4().hex[:12]}"}, "steps": []}
+    tenant_a_register = client.post(
+        f"{API_PREFIX}/agents/initAgent",
+        headers={TENANT_HEADER: "tenant-a"},
+        json=agent_body,
+    )
+    assert tenant_a_register.status_code == 200
+    tenant_a_agent = agent_body["agent"]["agent_name"]
+
     _, external_id = _create_target(client, tenant="tenant-a")
 
     body = {
-        "agent_name": agent_name,
+        "agent_name": tenant_a_agent,
         "step": {"type": "llm", "name": "test-step", "input": "hi", "output": None},
         "stage": "pre",
         "target_type": "environment",
@@ -245,7 +270,7 @@ def test_target_resolution_is_tenant_scoped(client: TestClient) -> None:
         f"{API_PREFIX}/evaluation", headers={TENANT_HEADER: "tenant-b"}, json=body
     )
     assert resp.status_code == 404
-    assert resp.json()["error_code"] == "TARGET_NOT_FOUND"
+    assert resp.json()["error_code"] == "AGENT_NOT_FOUND"
 
 
 def test_only_target_type_without_target_id_fails_validation(

--- a/server/tests/test_tenant_aware_writes.py
+++ b/server/tests/test_tenant_aware_writes.py
@@ -131,13 +131,14 @@ def test_agent_create_with_header_lands_in_resolved_tenant(
 def test_agent_policy_association_inherits_agent_tenant(
     client: TestClient, db_engine
 ) -> None:
-    """Association rows must record the agent's tenant, not the request-scoped one."""
+    """Association rows record the agent's tenant when both sides are same-tenant."""
     agent_name = _init_agent(client, tenant="agent-tenant")
-    policy_id, _ = _create_policy(client, tenant="policy-tenant")
+    policy_id, _ = _create_policy(client, tenant="agent-tenant")
 
-    # Attach without a header. The association must still pick up the agent's tenant
-    # rather than falling through to DEFAULT_TENANT_ID.
-    attach = client.post(f"{API_PREFIX}/agents/{agent_name}/policies/{policy_id}")
+    attach = client.post(
+        f"{API_PREFIX}/agents/{agent_name}/policies/{policy_id}",
+        headers={TENANT_HEADER: "agent-tenant"},
+    )
     assert attach.status_code == 200, attach.text
 
     recorded = _tenant_of(
@@ -153,10 +154,11 @@ def test_agent_control_association_inherits_agent_tenant(
     client: TestClient, db_engine
 ) -> None:
     agent_name = _init_agent(client, tenant="agent-tenant")
-    control_id, _ = _create_control(client, tenant="other-tenant")
+    control_id, _ = _create_control(client, tenant="agent-tenant")
 
     attach = client.post(
-        f"{API_PREFIX}/agents/{agent_name}/controls/{control_id}"
+        f"{API_PREFIX}/agents/{agent_name}/controls/{control_id}",
+        headers={TENANT_HEADER: "agent-tenant"},
     )
     assert attach.status_code == 200, attach.text
 

--- a/server/tests/test_tenant_enforcement.py
+++ b/server/tests/test_tenant_enforcement.py
@@ -1,0 +1,418 @@
+"""Cross-tenant enforcement tests.
+
+Every request-scoped lookup of a tenant-owned resource must refuse access
+across tenant boundaries. These tests lock that in: for each lookup path,
+tenant B sees tenant A's rows as non-existent.
+
+``Agent.name``, ``Control.name``, and ``Policy.name`` are still globally
+unique at the schema level, so "same name in two tenants" is not yet a thing
+we can test. What we *can* test is that holding a valid ID obtained from
+another tenant does not let you read, mutate, or link against it.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from fastapi.testclient import TestClient
+
+from .utils import VALID_CONTROL_PAYLOAD
+
+API_PREFIX = "/api/v1"
+TENANT_HEADER = "X-Tenant-Id"
+
+TENANT_A = "tenant-a"
+TENANT_B = "tenant-b"
+
+
+def _unique(prefix: str) -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:10]}"
+
+
+def _init_agent(client: TestClient, *, tenant: str, name: str | None = None) -> str:
+    agent_name = name or _unique("agent")
+    resp = client.post(
+        f"{API_PREFIX}/agents/initAgent",
+        headers={TENANT_HEADER: tenant},
+        json={"agent": {"agent_name": agent_name}, "steps": []},
+    )
+    assert resp.status_code == 200, resp.text
+    return agent_name
+
+
+def _create_control(client: TestClient, *, tenant: str) -> int:
+    name = _unique("ctrl")
+    resp = client.put(
+        f"{API_PREFIX}/controls",
+        headers={TENANT_HEADER: tenant},
+        json={"name": name, "data": VALID_CONTROL_PAYLOAD},
+    )
+    assert resp.status_code == 200, resp.text
+    return int(resp.json()["control_id"])
+
+
+def _create_policy(client: TestClient, *, tenant: str) -> int:
+    name = _unique("pol")
+    resp = client.put(
+        f"{API_PREFIX}/policies",
+        headers={TENANT_HEADER: tenant},
+        json={"name": name},
+    )
+    assert resp.status_code == 200, resp.text
+    return int(resp.json()["policy_id"])
+
+
+def _create_target(client: TestClient, *, tenant: str) -> tuple[int, str]:
+    external_id = _unique("ext")
+    resp = client.post(
+        f"{API_PREFIX}/targets",
+        headers={TENANT_HEADER: tenant},
+        json={"target_type": "environment", "external_id": external_id},
+    )
+    assert resp.status_code == 201, resp.text
+    return int(resp.json()["target_id"]), external_id
+
+
+# ---------------------------------------------------------------------------
+# initAgent: cross-tenant name reservation surfaces as 409 non-disclosing
+# ---------------------------------------------------------------------------
+
+
+def test_init_agent_across_tenants_returns_409_non_disclosing(
+    client: TestClient,
+) -> None:
+    """Agent.name is globally unique; tenant B can't bind an existing name."""
+    shared_name = _unique("agent")
+    _init_agent(client, tenant=TENANT_A, name=shared_name)
+
+    resp = client.post(
+        f"{API_PREFIX}/agents/initAgent",
+        headers={TENANT_HEADER: TENANT_B},
+        json={"agent": {"agent_name": shared_name}, "steps": []},
+    )
+    assert resp.status_code == 409
+    assert resp.json()["error_code"] == "AGENT_NAME_CONFLICT"
+    # Response must not disclose which tenant owns the existing name.
+    body_text = resp.text.lower()
+    assert TENANT_A.lower() not in body_text
+
+
+# ---------------------------------------------------------------------------
+# Agent reads / mutations
+# ---------------------------------------------------------------------------
+
+
+def test_get_agent_cross_tenant_returns_404(client: TestClient) -> None:
+    agent_name = _init_agent(client, tenant=TENANT_A)
+    resp = client.get(
+        f"{API_PREFIX}/agents/{agent_name}",
+        headers={TENANT_HEADER: TENANT_B},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error_code"] == "AGENT_NOT_FOUND"
+
+
+def test_list_agents_does_not_leak_other_tenants(client: TestClient) -> None:
+    _init_agent(client, tenant=TENANT_A)
+    _init_agent(client, tenant=TENANT_A)
+
+    resp = client.get(
+        f"{API_PREFIX}/agents", headers={TENANT_HEADER: TENANT_B}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["agents"] == []
+    assert body["pagination"]["total"] == 0
+
+
+def test_patch_agent_cross_tenant_returns_404(client: TestClient) -> None:
+    agent_name = _init_agent(client, tenant=TENANT_A)
+    resp = client.patch(
+        f"{API_PREFIX}/agents/{agent_name}",
+        headers={TENANT_HEADER: TENANT_B},
+        json={"remove_steps": [], "remove_evaluators": []},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error_code"] == "AGENT_NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# Agent - Policy association
+# ---------------------------------------------------------------------------
+
+
+def test_add_agent_policy_cross_tenant_agent_returns_404(client: TestClient) -> None:
+    """Caller in tenant B cannot attach to tenant A's agent."""
+    agent_name = _init_agent(client, tenant=TENANT_A)
+    policy_id = _create_policy(client, tenant=TENANT_B)
+
+    resp = client.post(
+        f"{API_PREFIX}/agents/{agent_name}/policies/{policy_id}",
+        headers={TENANT_HEADER: TENANT_B},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error_code"] == "AGENT_NOT_FOUND"
+
+
+def test_add_agent_policy_cross_tenant_policy_returns_404(client: TestClient) -> None:
+    """Caller in tenant A cannot attach tenant B's policy to tenant A's agent."""
+    agent_name = _init_agent(client, tenant=TENANT_A)
+    policy_id = _create_policy(client, tenant=TENANT_B)
+
+    resp = client.post(
+        f"{API_PREFIX}/agents/{agent_name}/policies/{policy_id}",
+        headers={TENANT_HEADER: TENANT_A},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error_code"] == "POLICY_NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# Agent - Control direct attach
+# ---------------------------------------------------------------------------
+
+
+def test_add_agent_control_cross_tenant_control_returns_404(
+    client: TestClient,
+) -> None:
+    agent_name = _init_agent(client, tenant=TENANT_A)
+    control_id = _create_control(client, tenant=TENANT_B)
+
+    resp = client.post(
+        f"{API_PREFIX}/agents/{agent_name}/controls/{control_id}",
+        headers={TENANT_HEADER: TENANT_A},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error_code"] == "CONTROL_NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# Controls: cross-tenant reads/mutations/deletes
+# ---------------------------------------------------------------------------
+
+
+def test_get_control_cross_tenant_returns_404(client: TestClient) -> None:
+    control_id = _create_control(client, tenant=TENANT_A)
+    resp = client.get(
+        f"{API_PREFIX}/controls/{control_id}",
+        headers={TENANT_HEADER: TENANT_B},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error_code"] == "CONTROL_NOT_FOUND"
+
+
+def test_list_controls_does_not_leak_other_tenants(client: TestClient) -> None:
+    """Tenant B must not see tenant A's controls in the list or in the count."""
+    _create_control(client, tenant=TENANT_A)
+    _create_control(client, tenant=TENANT_A)
+
+    resp = client.get(
+        f"{API_PREFIX}/controls", headers={TENANT_HEADER: TENANT_B}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["controls"] == []
+    assert body["pagination"]["total"] == 0
+
+
+def test_list_controls_same_tenant_returns_own_rows(client: TestClient) -> None:
+    _create_control(client, tenant=TENANT_A)
+    _create_control(client, tenant=TENANT_A)
+    _create_control(client, tenant=TENANT_B)
+
+    resp = client.get(
+        f"{API_PREFIX}/controls", headers={TENANT_HEADER: TENANT_A}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["pagination"]["total"] == 2
+
+
+def test_set_control_data_cross_tenant_returns_404(client: TestClient) -> None:
+    control_id = _create_control(client, tenant=TENANT_A)
+    resp = client.put(
+        f"{API_PREFIX}/controls/{control_id}/data",
+        headers={TENANT_HEADER: TENANT_B},
+        json={"data": VALID_CONTROL_PAYLOAD},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error_code"] == "CONTROL_NOT_FOUND"
+
+
+def test_patch_control_cross_tenant_returns_404(client: TestClient) -> None:
+    control_id = _create_control(client, tenant=TENANT_A)
+    resp = client.patch(
+        f"{API_PREFIX}/controls/{control_id}",
+        headers={TENANT_HEADER: TENANT_B},
+        json={"enabled": False},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error_code"] == "CONTROL_NOT_FOUND"
+
+
+def test_delete_control_cross_tenant_returns_404(client: TestClient) -> None:
+    control_id = _create_control(client, tenant=TENANT_A)
+    resp = client.delete(
+        f"{API_PREFIX}/controls/{control_id}",
+        headers={TENANT_HEADER: TENANT_B},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error_code"] == "CONTROL_NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# Policy - Control association
+# ---------------------------------------------------------------------------
+
+
+def test_add_control_to_policy_cross_tenant_policy_returns_404(
+    client: TestClient,
+) -> None:
+    policy_id = _create_policy(client, tenant=TENANT_A)
+    control_id = _create_control(client, tenant=TENANT_B)
+    resp = client.post(
+        f"{API_PREFIX}/policies/{policy_id}/controls/{control_id}",
+        headers={TENANT_HEADER: TENANT_B},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error_code"] == "POLICY_NOT_FOUND"
+
+
+def test_add_control_to_policy_cross_tenant_control_returns_404(
+    client: TestClient,
+) -> None:
+    policy_id = _create_policy(client, tenant=TENANT_A)
+    control_id = _create_control(client, tenant=TENANT_B)
+    resp = client.post(
+        f"{API_PREFIX}/policies/{policy_id}/controls/{control_id}",
+        headers={TENANT_HEADER: TENANT_A},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error_code"] == "CONTROL_NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# Target - Control attachment
+# ---------------------------------------------------------------------------
+
+
+def test_attach_target_control_cross_tenant_control_returns_404(
+    client: TestClient,
+) -> None:
+    target_id, _ = _create_target(client, tenant=TENANT_A)
+    control_id = _create_control(client, tenant=TENANT_B)
+    resp = client.post(
+        f"{API_PREFIX}/targets/{target_id}/controls/{control_id}",
+        headers={TENANT_HEADER: TENANT_A},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error_code"] == "CONTROL_NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# Control definition validation (agent-scoped evaluator references)
+# ---------------------------------------------------------------------------
+
+
+def test_control_referencing_foreign_tenant_agent_evaluator_returns_404(
+    client: TestClient,
+) -> None:
+    """A control in tenant B cannot reference an agent-scoped evaluator from tenant A.
+
+    The foreign agent must look like non-existent so the response does not
+    leak either the agent's presence or its evaluator inventory.
+    """
+    tenant_a_agent = _unique("agent")
+    init_resp = client.post(
+        f"{API_PREFIX}/agents/initAgent",
+        headers={TENANT_HEADER: TENANT_A},
+        json={
+            "agent": {"agent_name": tenant_a_agent},
+            "steps": [],
+            "evaluators": [
+                {
+                    "name": "secret-luna",
+                    "config_schema": {"type": "object"},
+                    "description": "Tenant A's private evaluator",
+                }
+            ],
+        },
+    )
+    assert init_resp.status_code == 200, init_resp.text
+
+    control_def = {
+        "description": "cross-tenant evaluator probe",
+        "enabled": True,
+        "execution": "server",
+        "scope": {"step_types": ["llm"], "stages": ["pre"]},
+        "condition": {
+            "selector": {"path": "input"},
+            "evaluator": {
+                "name": f"{tenant_a_agent}:secret-luna",
+                "config": {},
+            },
+        },
+        "action": {"decision": "deny"},
+    }
+    resp = client.put(
+        f"{API_PREFIX}/controls",
+        headers={TENANT_HEADER: TENANT_B},
+        json={"name": _unique("ctrl"), "data": control_def},
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error_code"] == "AGENT_NOT_FOUND"
+    # The response must not expose tenant A's evaluator inventory.
+    body_text = resp.text.lower()
+    assert "secret-luna" not in body_text
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_cross_tenant_agent_returns_404(client: TestClient) -> None:
+    agent_name = _init_agent(client, tenant=TENANT_A)
+    body = {
+        "agent_name": agent_name,
+        "step": {"type": "llm", "name": "test-step", "input": "hi", "output": None},
+        "stage": "pre",
+    }
+    resp = client.post(
+        f"{API_PREFIX}/evaluation",
+        headers={TENANT_HEADER: TENANT_B},
+        json=body,
+    )
+    assert resp.status_code == 404
+    assert resp.json()["error_code"] == "AGENT_NOT_FOUND"
+
+
+# ---------------------------------------------------------------------------
+# Positive control: same-tenant operations still succeed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tenant", [TENANT_A, TENANT_B])
+def test_same_tenant_operations_still_succeed(client: TestClient, tenant: str) -> None:
+    """Sanity: enforcement does not break legitimate same-tenant flows."""
+    agent_name = _init_agent(client, tenant=tenant)
+    policy_id = _create_policy(client, tenant=tenant)
+    control_id = _create_control(client, tenant=tenant)
+
+    resp = client.post(
+        f"{API_PREFIX}/agents/{agent_name}/policies/{policy_id}",
+        headers={TENANT_HEADER: tenant},
+    )
+    assert resp.status_code == 200
+
+    resp = client.post(
+        f"{API_PREFIX}/agents/{agent_name}/controls/{control_id}",
+        headers={TENANT_HEADER: tenant},
+    )
+    assert resp.status_code == 200
+
+    resp = client.post(
+        f"{API_PREFIX}/policies/{policy_id}/controls/{control_id}",
+        headers={TENANT_HEADER: tenant},
+    )
+    assert resp.status_code == 200


### PR DESCRIPTION
Stacked on top of #183. Addresses review feedback that PR1-PR5 record \`tenant_id\` but do not enforce the tenant boundary on reads/writes, allowing cross-tenant access and cross-tenant data mixing in runtime evaluation.

## What this PR enforces

Every request-scoped lookup of a tenant-owned row (\`Agent\`, \`Control\`, \`Policy\`, \`Target\`) goes through a helper in \`services/tenant_scoped_lookups.py\` that returns 404 on cross-tenant access. Affected paths:

- \`endpoints/agents.py\` - \`list_agents\`, \`get_agent\`, \`_get_agent_or_404\` (used by 11 endpoints), association add/remove for policies and controls, evaluator list/get, \`patch_agent\`.
- \`endpoints/controls.py\` - \`get_control\`, \`get_control_data\`, \`set_control_data\`, \`delete_control\`, \`patch_control\`.
- \`endpoints/policies.py\` - \`add_control_to_policy\`, \`remove_control_from_policy\`, \`list_policy_controls\`.
- \`endpoints/evaluation.py\` - agent lookup in \`evaluate\`.
- \`endpoints/targets.py\` / \`services/targets.py\` - \`control_exists\` becomes \`control_exists_in_tenant\`, so attaching a cross-tenant control to a target returns 404.

## initAgent special case

\`Agent.name\` is still globally unique at the schema level, so a callers in tenant B cannot create an agent with a name tenant A already owns. Before: this would upsert onto tenant A's row. After: 409 \`AGENT_NAME_CONFLICT\` with a generic "agent name is not available" message that does not disclose which tenant holds the name.

## What is still out of scope

- Tenant-scoped uniqueness on \`Agent.name\`, \`Control.name\`, \`Policy.name\`. Names remain globally reserved until a later schema change relaxes uniqueness. This PR is about enforcement of the *access* boundary, not tenant independence.
- Observability tables (\`control_execution_events\`).

## Test plan
- [x] \`make check\` clean (579 server tests including 17 new enforcement tests, 503 SDK, 249 evaluators, others).
- [x] \`make sdk-ts-generate-check\` zero drift.
- [x] New \`test_tenant_enforcement.py\` covers:
  - cross-tenant \`initAgent\` (409, no tenant disclosure in body)
  - cross-tenant \`get_agent\`, \`list_agents\` (empty list), \`patch_agent\` (404)
  - cross-tenant \`add_agent_policy\` from either direction (404)
  - cross-tenant \`add_agent_control\` (404)
  - cross-tenant \`get_control\`, \`set_control_data\`, \`patch_control\`, \`delete_control\` (404)
  - cross-tenant \`add_control_to_policy\` from either direction (404)
  - cross-tenant \`attach_target_control\` where the control is in another tenant (404)
  - cross-tenant \`evaluate\` (404)
  - same-tenant sanity path still succeeds across all associations
- [x] Validated on integration branch with PR1-PR6 merged.