### PR TITLE
build(evaluators): normalize contrib package wiring

### DIFF
--- a/evaluators/builtin/pyproject.toml
+++ b/evaluators/builtin/pyproject.toml
@@ -16,8 +16,9 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-galileo = ["agent-control-evaluator-galileo>=3.0.0"]
-cisco = ["agent-control-evaluator-cisco>=0.1.0"]
+galileo = ["agent-control-evaluator-galileo>=7.5.0"]
+budget = ["agent-control-evaluator-budget>=7.5.0"]
+cisco = ["agent-control-evaluator-cisco>=7.5.0"]
 dev = ["pytest>=8.0.0", "pytest-asyncio>=0.23.0"]
 
 [project.entry-points."agent_control.evaluators"]
@@ -35,6 +36,7 @@ packages = ["src/agent_control_evaluators"]
 
 [tool.uv.sources]
 agent-control-models = { workspace = true }
-# For local dev: use local galileo package instead of PyPI
+# For local dev: use local contrib packages instead of PyPI
 agent-control-evaluator-galileo = { path = "../contrib/galileo", editable = true }
+agent-control-evaluator-budget = { path = "../contrib/budget", editable = true }
 agent-control-evaluator-cisco = { path = "../contrib/cisco", editable = true }

--- a/evaluators/contrib/budget/Makefile
+++ b/evaluators/contrib/budget/Makefile
@@ -1,0 +1,28 @@
+.PHONY: help test lint lint-fix typecheck check build
+
+help:
+	@echo "Agent Control Evaluator - Budget - Makefile commands"
+	@echo ""
+	@echo "  make test            - run pytest"
+	@echo "  make lint            - run ruff check"
+	@echo "  make lint-fix        - run ruff check --fix"
+	@echo "  make typecheck       - run mypy"
+	@echo "  make check           - run lint, typecheck, and test"
+	@echo "  make build           - build package"
+
+test:
+	uv run --with pytest --with pytest-asyncio --with pytest-cov pytest tests --cov=src --cov-report=xml:../../../coverage-evaluators-budget.xml -q
+
+lint:
+	uv run --with ruff ruff check --config ../../../pyproject.toml src/
+
+lint-fix:
+	uv run --with ruff ruff check --config ../../../pyproject.toml --fix src/
+
+typecheck:
+	uv run --with mypy mypy --config-file ../../../pyproject.toml src/
+
+check: lint typecheck test
+
+build:
+	uv build

--- a/evaluators/contrib/budget/README.md
+++ b/evaluators/contrib/budget/README.md
@@ -5,7 +5,19 @@ Budget evaluator for agent-control that tracks cumulative LLM token and cost usa
 ## Install
 
 ```bash
+pip install "agent-control-evaluators[budget]"
+```
+
+Fallback direct wheel install:
+
+```bash
 pip install agent-control-evaluator-budget
+```
+
+For local development:
+
+```bash
+uv pip install -e evaluators/contrib/budget
 ```
 
 ## Quickstart

--- a/evaluators/contrib/budget/pyproject.toml
+++ b/evaluators/contrib/budget/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "agent-control-evaluator-budget"
-version = "0.1.0"
+version = "7.5.0"
 description = "Budget evaluator for agent-control -- cumulative LLM cost and token tracking"
 readme = "README.md"
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }
 authors = [{ name = "Agent Control Team" }]
 dependencies = [
-    "agent-control-evaluators>=3.0.0",
-    "agent-control-models>=3.0.0",
+    "agent-control-evaluators>=7.5.0",
+    "agent-control-models>=7.5.0",
 ]
 
 [project.optional-dependencies]

--- a/evaluators/contrib/budget/src/agent_control_evaluator_budget/budget/config.py
+++ b/evaluators/contrib/budget/src/agent_control_evaluator_budget/budget/config.py
@@ -109,7 +109,7 @@ class BudgetEvaluatorConfig(EvaluatorConfig):
     metadata_paths: dict[str, str] = Field(default_factory=dict)
 
     @model_validator(mode="after")
-    def require_pricing_for_cost_rules(self) -> "BudgetEvaluatorConfig":
+    def require_pricing_for_cost_rules(self) -> BudgetEvaluatorConfig:
         has_cost_rule = any(rule.limit_unit == "usd_cents" for rule in self.limits)
         if has_cost_rule and self.pricing is None:
             raise ValueError('pricing is required when any rule uses limit_unit="usd_cents"')

--- a/evaluators/contrib/budget/src/agent_control_evaluator_budget/budget/evaluator.py
+++ b/evaluators/contrib/budget/src/agent_control_evaluator_budget/budget/evaluator.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import logging
 import math
 import threading
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
 from agent_control_evaluators._base import Evaluator, EvaluatorMetadata
@@ -26,6 +27,11 @@ from .memory_store import InMemoryBudgetStore, _scope_matches
 from .store import BudgetStore
 
 logger = logging.getLogger(__name__)
+
+try:
+    _PACKAGE_VERSION = version("agent-control-evaluator-budget")
+except PackageNotFoundError:
+    _PACKAGE_VERSION = "0.0.0.dev"
 
 # ---------------------------------------------------------------------------
 # Module-level store registry
@@ -173,7 +179,7 @@ class BudgetEvaluator(Evaluator[BudgetEvaluatorConfig]):
 
     metadata = EvaluatorMetadata(
         name="budget",
-        version="3.0.0",
+        version=_PACKAGE_VERSION,
         description="Cumulative LLM token and cost budget tracking",
     )
     config_model = BudgetEvaluatorConfig

--- a/evaluators/contrib/budget/tests/budget/test_budget.py
+++ b/evaluators/contrib/budget/tests/budget/test_budget.py
@@ -5,6 +5,7 @@ Given/When/Then comment style per reviewer request.
 
 from __future__ import annotations
 
+from importlib.metadata import version
 import threading
 from typing import Any
 
@@ -37,6 +38,10 @@ from agent_control_evaluator_budget.budget.memory_store import (
 def _clean_store_registry() -> None:
     """Clear the module-level store registry before each test."""
     clear_budget_stores()
+
+
+def test_metadata_version_matches_distribution_version() -> None:
+    assert BudgetEvaluator.metadata.version == version("agent-control-evaluator-budget")
 
 
 # ---------------------------------------------------------------------------

--- a/evaluators/contrib/cisco/README.md
+++ b/evaluators/contrib/cisco/README.md
@@ -7,22 +7,22 @@ External evaluator that calls Cisco AI Defense Chat Inspection via REST and maps
 
 ## Installation
 
-Install from PyPI (if available):
+Canonical install path:
+
+```bash
+pip install "agent-control-evaluators[cisco]"
+```
+
+Fallback direct wheel install:
 
 ```bash
 pip install agent-control-evaluator-cisco
 ```
 
-Or install from the workspace for local development:
+For local development:
 
 ```bash
 uv pip install -e evaluators/contrib/cisco
-```
-
-Alternatively, install via the builtin evaluators package extra (one-liner):
-
-```bash
-pip install agent-control-evaluators[cisco]
 ```
 
 - Build wheel from the repo root (contrib package only):

--- a/evaluators/contrib/cisco/pyproject.toml
+++ b/evaluators/contrib/cisco/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "agent-control-evaluator-cisco"
-version = "0.1.0"
+version = "7.5.0"
 description = "Cisco AI Defense evaluator for agent-control"
 readme = "README.md"
 requires-python = ">=3.12"
 license = { text = "Apache-2.0" }
 authors = [{ name = "Cisco AI Defense Team" }]
 dependencies = [
-    "agent-control-evaluators>=3.0.0",
-    "agent-control-models>=3.0.0",
+    "agent-control-evaluators>=7.5.0",
+    "agent-control-models>=7.5.0",
     "httpx>=0.24.0",
 ]
 

--- a/evaluators/contrib/cisco/src/agent_control_evaluator_cisco/ai_defense/evaluator.py
+++ b/evaluators/contrib/cisco/src/agent_control_evaluator_cisco/ai_defense/evaluator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
 from agent_control_evaluators import (
@@ -13,6 +14,11 @@ from agent_control_models import EvaluatorResult
 
 from .client import AI_DEFENSE_HTTPX_AVAILABLE, REGION_BASE_URLS, AIDefenseClient, build_endpoint
 from .config import CiscoAIDefenseConfig
+
+try:
+    _PACKAGE_VERSION = version("agent-control-evaluator-cisco")
+except PackageNotFoundError:
+    _PACKAGE_VERSION = "0.0.0.dev"
 
 
 def _load_api_key(env_name: str) -> str:
@@ -99,7 +105,7 @@ class CiscoAIDefenseEvaluator(Evaluator[CiscoAIDefenseConfig]):
 
     metadata = EvaluatorMetadata(
         name="cisco.ai_defense",
-        version="0.1.0",
+        version=_PACKAGE_VERSION,
         description="Cisco AI Defense Chat Inspection integration",
         requires_api_key=True,
         timeout_ms=15000,

--- a/evaluators/contrib/cisco/tests/test_evaluator.py
+++ b/evaluators/contrib/cisco/tests/test_evaluator.py
@@ -1,3 +1,5 @@
+from importlib.metadata import version
+
 import pytest
 from pydantic import ValidationError
 
@@ -11,6 +13,10 @@ from agent_control_evaluator_cisco.ai_defense.client import AIDefenseClient
 @pytest.fixture(autouse=True)
 def _env_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("AI_DEFENSE_API_KEY", "test-key")
+
+
+def test_metadata_version_matches_distribution_version() -> None:
+    assert CiscoAIDefenseEvaluator.metadata.version == version("agent-control-evaluator-cisco")
 
 
 @pytest.mark.asyncio

--- a/evaluators/contrib/galileo/README.md
+++ b/evaluators/contrib/galileo/README.md
@@ -2,6 +2,27 @@
 
 Integration package for Galileo Luna-2 evaluator.
 
+## Install
+
+Canonical install path:
+
+```bash
+pip install "agent-control-evaluators[galileo]"
+```
+
+Grandfathered convenience aliases remain available:
+
+```bash
+pip install "agent-control-sdk[galileo]"
+pip install "agent-control-server[galileo]"
+```
+
+Fallback direct wheel install:
+
+```bash
+pip install agent-control-evaluator-galileo
+```
+
 See full documentation in: https://docs.agentcontrol.dev/concepts/evaluators/contributing-evaluator
 
 Example with usage: https://docs.agentcontrol.dev/examples/galileo-luna2

--- a/evaluators/contrib/galileo/pyproject.toml
+++ b/evaluators/contrib/galileo/pyproject.toml
@@ -7,8 +7,8 @@ requires-python = ">=3.12"
 license = { text = "Apache-2.0" }
 authors = [{ name = "Agent Control Team" }]
 dependencies = [
-    "agent-control-evaluators>=3.0.0",
-    "agent-control-models>=3.0.0",
+    "agent-control-evaluators>=7.5.0",
+    "agent-control-models>=7.5.0",
     "httpx>=0.24.0",
     "pydantic>=2.12.4",
 ]

--- a/evaluators/contrib/galileo/src/agent_control_evaluator_galileo/luna2/evaluator.py
+++ b/evaluators/contrib/galileo/src/agent_control_evaluator_galileo/luna2/evaluator.py
@@ -6,6 +6,7 @@ the full galileo-sdk package. Only httpx is needed as a dependency.
 
 import logging
 import os
+from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
 from agent_control_evaluators import Evaluator, EvaluatorMetadata, register_evaluator
@@ -14,6 +15,11 @@ from agent_control_models import EvaluatorResult
 from agent_control_evaluator_galileo.luna2.config import Luna2EvaluatorConfig
 
 logger = logging.getLogger(__name__)
+
+try:
+    _PACKAGE_VERSION = version("agent-control-evaluator-galileo")
+except PackageNotFoundError:
+    _PACKAGE_VERSION = "0.0.0.dev"
 
 # Check if httpx is available
 try:
@@ -84,7 +90,7 @@ class Luna2Evaluator(Evaluator[Luna2EvaluatorConfig]):
 
     metadata = EvaluatorMetadata(
         name="galileo.luna2",
-        version="3.0.0",
+        version=_PACKAGE_VERSION,
         description="Galileo Luna-2 enterprise runtime protection (direct API)",
         requires_api_key=True,
         timeout_ms=10000,

--- a/evaluators/contrib/galileo/tests/test_luna2_evaluator.py
+++ b/evaluators/contrib/galileo/tests/test_luna2_evaluator.py
@@ -7,6 +7,7 @@ Evaluators take config at __init__, evaluate() only takes data.
 The evaluator uses direct HTTP API calls instead of the galileo SDK.
 """
 
+from importlib.metadata import version
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -282,7 +283,7 @@ class TestLuna2EvaluatorImport:
 
         assert Luna2Evaluator is not None
         assert Luna2Evaluator.metadata.name == "galileo.luna2"
-        assert Luna2Evaluator.metadata.version == "3.0.0"
+        assert Luna2Evaluator.metadata.version == version("agent-control-evaluator-galileo")
 
     @patch("agent_control_evaluator_galileo.luna2.evaluator.LUNA2_AVAILABLE", False)
     def test_luna2_evaluator_is_available_false_without_httpx(self):

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "docstring-parser>=0.15",  # For @tool decorator schema inference
     "google-re2>=1.1",  # For engine (bundled)
     "jsonschema>=4.0.0",  # For models/engine (bundled)
-    "agent-control-evaluators>=3.0.0",  # NOT vendored - avoid conflict with galileo
+    "agent-control-evaluators>=7.5.0",  # NOT vendored - avoid conflict with galileo
 ]
 authors = [
     {name = "Agent Control Team"}
@@ -38,7 +38,7 @@ Repository = "https://github.com/yourusername/agent-control"
 [project.optional-dependencies]
 strands-agents = ["strands-agents>=1.26.0"]
 google-adk = ["google-adk>=1.0.0"]
-galileo = ["agent-control-evaluator-galileo>=3.0.0"]
+galileo = ["agent-control-evaluator-galileo>=7.5.0"]
 
 [dependency-groups]
 dev = [

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "jsonschema-rs>=0.22.0",
     "PyJWT>=2.8.0",
     "google-re2>=1.1",  # For engine (bundled)
-    "agent-control-evaluators>=3.0.0",  # NOT vendored - avoid conflict with galileo
+    "agent-control-evaluators>=7.5.0",  # NOT vendored - avoid conflict with galileo
 ]
 authors = [
     {name = "Agent Control Team"}
@@ -31,7 +31,7 @@ readme = "README.md"
 license = {text = "Apache-2.0"}
 
 [project.optional-dependencies]
-galileo = ["agent-control-evaluator-galileo>=3.0.0"]
+galileo = ["agent-control-evaluator-galileo>=7.5.0"]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary
- add the missing package-local `budget` Makefile target surface for contrib normalization
- normalize contrib README install guidance around `agent-control-evaluators[...]` and keep direct wheel installs as fallback docs
- add `budget` wiring to `agent-control-evaluators` extras and local uv sources, and lift contrib-related floors to `7.5.0`
- keep the grandfathered `galileo` SDK/server extras while avoiding new SDK/server aliases for `budget` or `cisco`

## Why
Phase 1 of the contrib packaging plan is about making the real contrib packages look like one coherent packaging model before discovery, CI, and release automation are updated in later PRs.

## Impact
Users get one canonical install path for real contrib evaluators via `agent-control-evaluators[...]`, and local development now resolves the in-repo `budget` package the same way as the other real contrib packages.

## Validation
- `make -C evaluators/contrib/budget check` *(fails on pre-existing budget source lint/type issues outside this PR-owned file set)*
- `make -C evaluators/contrib/budget test`
- `make -C evaluators/contrib/budget build`
- `make -C evaluators/contrib/cisco lint`
- `make -C evaluators/contrib/cisco typecheck`
- `make -C evaluators/contrib/cisco test`
- `make -C evaluators/contrib/cisco build`
- `uv sync --extra dev` in `evaluators/contrib/galileo`
- `make -C evaluators/contrib/galileo lint`
- `make -C evaluators/contrib/galileo typecheck`
- `make -C evaluators/contrib/galileo test`
- `make -C evaluators/contrib/galileo build`

## Notes
- `cisco` and `galileo` do not expose `make check` in this branch yet, so their existing package-local targets were run individually.
- `budget` still has pre-existing `ruff`/`mypy` failures in package source files that are outside this PR scope.

## Design Context
- Shared design doc and implementation plan: https://gist.github.com/lan17/823617097f4b7e9f4ff717979de7dba4
