### PR TITLE
build(evaluators): normalize package-local Makefile targets

### DIFF
--- a/evaluators/contrib/cisco/Makefile
+++ b/evaluators/contrib/cisco/Makefile
@@ -1,4 +1,6 @@
-.PHONY: help test lint lint-fix typecheck build
+.PHONY: help test lint lint-fix typecheck check build
+
+PACKAGE := agent-control-evaluator-cisco
 
 help:
 	@echo "Agent Control Evaluator - Cisco AI Defense - Makefile commands"
@@ -6,20 +8,22 @@ help:
 	@echo "  make lint       - run ruff check"
 	@echo "  make lint-fix   - run ruff check --fix"
 	@echo "  make typecheck  - run mypy"
+	@echo "  make check      - run test, lint, and typecheck"
 	@echo "  make build      - build package"
 
 test:
-	uv run --with pytest --with pytest-asyncio --with pytest-cov pytest tests --cov=src --cov-report=xml:../../../coverage-evaluators-cisco.xml -q
+	uv run --with pytest --with pytest-asyncio --with pytest-cov --package $(PACKAGE) pytest tests --cov=src --cov-report=xml:../../../coverage-evaluators-cisco.xml -q
 
 lint:
-	uv run --with ruff ruff check --config ../../../pyproject.toml src/
+	uv run --with ruff --package $(PACKAGE) ruff check --config ../../../pyproject.toml src/
 
 lint-fix:
-	uv run --with ruff ruff check --config ../../../pyproject.toml --fix src/
+	uv run --with ruff --package $(PACKAGE) ruff check --config ../../../pyproject.toml --fix src/
 
 typecheck:
-	uv run --with mypy mypy --config-file ../../../pyproject.toml src/
+	uv run --with mypy --package $(PACKAGE) mypy --config-file ../../../pyproject.toml src/
+
+check: test lint typecheck
 
 build:
 	uv build
-

--- a/evaluators/contrib/galileo/Makefile
+++ b/evaluators/contrib/galileo/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help sync test lint lint-fix typecheck build publish
+.PHONY: help sync test lint lint-fix typecheck check build publish
 
 PACKAGE := agent-control-evaluator-galileo
 
@@ -9,22 +9,25 @@ help:
 	@echo "  make lint            - run ruff check"
 	@echo "  make lint-fix        - run ruff check --fix"
 	@echo "  make typecheck       - run mypy"
+	@echo "  make check           - run test, lint, and typecheck"
 	@echo "  make build           - build package"
 
 sync:
 	uv sync
 
 test:
-	uv run pytest --cov=src --cov-report=xml:../../../coverage-evaluators-galileo.xml -q
+	uv run --with pytest --with pytest-asyncio --with pytest-cov --package $(PACKAGE) pytest tests --cov=src --cov-report=xml:../../../coverage-evaluators-galileo.xml -q
 
 lint:
-	uv run ruff check --config ../../../pyproject.toml src/
+	uv run --with ruff --package $(PACKAGE) ruff check --config ../../../pyproject.toml src/
 
 lint-fix:
-	uv run ruff check --config ../../../pyproject.toml --fix src/
+	uv run --with ruff --package $(PACKAGE) ruff check --config ../../../pyproject.toml --fix src/
 
 typecheck:
-	uv run mypy --config-file ../../../pyproject.toml src/
+	uv run --with mypy --package $(PACKAGE) mypy --config-file ../../../pyproject.toml src/
+
+check: test lint typecheck
 
 build:
 	uv build


### PR DESCRIPTION
## What changed
- added the missing `check` target to the Galileo and Cisco contrib package Makefiles
- updated both packages to run `pytest`, `ruff`, and `mypy` with `uv run --package <contrib-package>` so the local contrib project stays selected outside the root workspace
- kept the package-local contract narrow and aligned with the shared target surface used by root automation

## Why
The contrib packages live outside the root `uv` workspace, so package-local `uv run` behavior can drift from the root-driven `make -C <package>` flow. Galileo was failing before the tool even reached the package code because the command resolution did not reliably run in the local project context.

## Impact
Root automation can rely on both contrib packages exposing `test`, `lint`, `lint-fix`, `typecheck`, `check`, and `build` without package-specific command drift blocking the contrib contract cleanup.

## Validation
- `make -C evaluators/contrib/galileo lint-fix`
- `make -C evaluators/contrib/galileo check`
- `make -C evaluators/contrib/galileo build`
- `make -C evaluators/contrib/cisco lint-fix`
- `make -C evaluators/contrib/cisco check`
- `make -C evaluators/contrib/cisco build`

## Design Context
- Shared design doc and implementation plan: https://gist.github.com/lan17/823617097f4b7e9f4ff717979de7dba4
