### PR TITLE
fix(evaluators): handle invalid unicode in detect-secrets evaluator

### DIFF
--- a/evaluators/contrib/detect_secrets/src/agent_control_evaluator_detect_secrets/detect_secrets/evaluator.py
+++ b/evaluators/contrib/detect_secrets/src/agent_control_evaluator_detect_secrets/detect_secrets/evaluator.py
@@ -102,7 +102,16 @@ class DetectSecretsEvaluator(Evaluator[DetectSecretsEvaluatorConfig]):
 
         assert normalized.text is not None
         filtered_text = apply_line_exclusions(normalized.text, self._exclude_line_patterns)
-        if len(filtered_text.encode("utf-8")) > self.config.max_bytes:
+        try:
+            filtered_bytes = filtered_text.encode("utf-8")
+        except UnicodeError:
+            return self._failure_result(
+                failure_mode="normalization_error",
+                normalized_payload_type=normalized.payload_type,
+                detect_secrets_version=runtime_info.detect_secrets_version,
+            )
+
+        if len(filtered_bytes) > self.config.max_bytes:
             return self._failure_result(
                 failure_mode="payload_too_large",
                 normalized_payload_type=normalized.payload_type,

--- a/evaluators/contrib/detect_secrets/tests/detect_secrets/test_evaluator.py
+++ b/evaluators/contrib/detect_secrets/tests/detect_secrets/test_evaluator.py
@@ -351,6 +351,19 @@ async def test_non_json_serializable_payload_routes_through_on_error_allow() -> 
 
 
 @pytest.mark.asyncio
+async def test_invalid_unicode_payload_routes_through_on_error_deny() -> None:
+    evaluator = DetectSecretsEvaluator(DetectSecretsEvaluatorConfig(on_error="deny"))
+
+    result = await evaluator.evaluate("\ud800")
+
+    assert result.matched is True
+    assert result.error is None
+    assert result.metadata is not None
+    assert result.metadata["failure_mode"] == "normalization_error"
+    assert result.metadata["fallback_action"] == "deny"
+
+
+@pytest.mark.asyncio
 async def test_recursive_payload_routes_through_normalization_error() -> None:
     evaluator = DetectSecretsEvaluator(DetectSecretsEvaluatorConfig())
     payload: dict[str, Any] = {}


### PR DESCRIPTION
## Summary\n- route UTF-8 encoding failures through the evaluator's normalization error path\n- add a regression test for lone surrogate input under on_error="deny"\n\n## Validation\n- make check (evaluators/contrib/detect_secrets)