### PR TITLE
refactor(models): share control definition runtime fields

### DIFF
--- a/models/src/agent_control_models/__init__.py
+++ b/models/src/agent_control_models/__init__.py
@@ -30,7 +30,6 @@ from .controls import (
     ConditionNode,
     ControlAction,
     ControlDefinition,
-    ControlDefinitionBase,
     ControlDefinitionRuntime,
     ControlMatch,
     ControlScope,
@@ -127,7 +126,6 @@ __all__ = [
     "EvaluationResult",
     # Controls
     "ControlDefinition",
-    "ControlDefinitionBase",
     "ConditionNode",
     "ControlAction",
     "ControlMatch",

--- a/models/src/agent_control_models/__init__.py
+++ b/models/src/agent_control_models/__init__.py
@@ -30,6 +30,7 @@ from .controls import (
     ConditionNode,
     ControlAction,
     ControlDefinition,
+    ControlDefinitionBase,
     ControlDefinitionRuntime,
     ControlMatch,
     ControlScope,
@@ -126,6 +127,7 @@ __all__ = [
     "EvaluationResult",
     # Controls
     "ControlDefinition",
+    "ControlDefinitionBase",
     "ConditionNode",
     "ControlAction",
     "ControlMatch",

--- a/models/src/agent_control_models/controls.py
+++ b/models/src/agent_control_models/controls.py
@@ -752,12 +752,38 @@ class _ConditionBackedControlMixin:
         return _build_observability_identity(self.condition)
 
 
-class ControlDefinition(_ConditionBackedControlMixin, BaseModel):
-    """A control definition to evaluate agent interactions.
+def canonicalize_control_payload(data: Any) -> Any:
+    """Rewrite legacy selector/evaluator payloads into canonical condition shape."""
+    if not isinstance(data, dict):
+        return data
 
-    This model contains only the logic and configuration.
-    Identity fields (id, name) are managed by the database.
-    """
+    has_condition = "condition" in data
+    has_selector = "selector" in data
+    has_evaluator = "evaluator" in data
+
+    if has_condition and (has_selector or has_evaluator):
+        raise ValueError(
+            "Control definition mixes canonical condition fields "
+            "with legacy selector/evaluator fields."
+        )
+    if has_selector != has_evaluator:
+        raise ValueError(
+            "Legacy control definition must include both selector and evaluator."
+        )
+    if not has_condition and has_selector:
+        canonical = dict(data)
+        selector = canonical.pop("selector")
+        evaluator = canonical.pop("evaluator")
+        canonical["condition"] = {
+            "selector": selector,
+            "evaluator": evaluator,
+        }
+        return canonical
+    return data
+
+
+class ControlDefinitionBase(_ConditionBackedControlMixin, BaseModel):
+    """Runtime-relevant fields shared by authored and runtime controls."""
 
     description: str | None = Field(None, description="Detailed description of the control")
     enabled: bool = Field(True, description="Whether this control is active")
@@ -785,6 +811,32 @@ class ControlDefinition(_ConditionBackedControlMixin, BaseModel):
 
     # Metadata
     tags: list[str] = Field(default_factory=list, description="Tags for categorization")
+
+    @classmethod
+    def canonicalize_payload(cls, data: Any) -> Any:
+        """Rewrite legacy selector/evaluator payloads into canonical condition shape."""
+        return canonicalize_control_payload(data)
+
+    @model_validator(mode="before")
+    @classmethod
+    def canonicalize_legacy_condition_shape(cls, data: Any) -> Any:
+        """Accept legacy flat leaf payloads during condition-tree rollout."""
+        return canonicalize_control_payload(data)
+
+    @model_validator(mode="after")
+    def validate_condition_constraints(self) -> Self:
+        """Validate runtime-relevant control constraints."""
+        _validate_common_control_constraints(self.condition, self.action)
+        return self
+
+
+class ControlDefinition(ControlDefinitionBase):
+    """A control definition to evaluate agent interactions.
+
+    This model contains only the logic and configuration.
+    Identity fields (id, name) are managed by the database.
+    """
+
     template: TemplateDefinition | None = Field(
         None,
         description="Template metadata for template-backed controls",
@@ -794,46 +846,9 @@ class ControlDefinition(_ConditionBackedControlMixin, BaseModel):
         description="Resolved parameter values for template-backed controls",
     )
 
-    @classmethod
-    def canonicalize_payload(cls, data: Any) -> Any:
-        """Rewrite legacy selector/evaluator payloads into canonical condition shape."""
-        if not isinstance(data, dict):
-            return data
-
-        has_condition = "condition" in data
-        has_selector = "selector" in data
-        has_evaluator = "evaluator" in data
-
-        if has_condition and (has_selector or has_evaluator):
-            raise ValueError(
-                "Control definition mixes canonical condition fields "
-                "with legacy selector/evaluator fields."
-            )
-        if has_selector != has_evaluator:
-            raise ValueError(
-                "Legacy control definition must include both selector and evaluator."
-            )
-        if not has_condition and has_selector:
-            canonical = dict(data)
-            selector = canonical.pop("selector")
-            evaluator = canonical.pop("evaluator")
-            canonical["condition"] = {
-                "selector": selector,
-                "evaluator": evaluator,
-            }
-            return canonical
-        return data
-
-    @model_validator(mode="before")
-    @classmethod
-    def canonicalize_legacy_condition_shape(cls, data: Any) -> Any:
-        """Accept legacy flat leaf payloads during condition-tree rollout."""
-        return cls.canonicalize_payload(data)
-
     @model_validator(mode="after")
-    def validate_condition_constraints(self) -> Self:
-        """Validate cross-field control constraints."""
-        _validate_common_control_constraints(self.condition, self.action)
+    def validate_template_pairing(self) -> Self:
+        """Validate authoring-only template constraints."""
         has_template = self.template is not None
         has_template_values = self.template_values is not None
         if has_template != has_template_values:
@@ -884,41 +899,10 @@ class ControlDefinition(_ConditionBackedControlMixin, BaseModel):
     }
 
 
-class ControlDefinitionRuntime(_ConditionBackedControlMixin, BaseModel):
+class ControlDefinitionRuntime(ControlDefinitionBase):
     """Slim runtime control model that ignores template authoring metadata."""
 
     model_config = ConfigDict(extra="ignore")
-
-    description: str | None = Field(None, description="Detailed description of the control")
-    enabled: bool = Field(True, description="Whether this control is active")
-    execution: Literal["server", "sdk"] = Field(
-        ..., description="Where this control executes"
-    )
-    scope: ControlScope = Field(
-        default_factory=ControlScope,
-        description="Which steps and stages this control applies to",
-    )
-    condition: ConditionNode = Field(
-        ...,
-        description=(
-            "Recursive boolean condition tree. Leaf nodes contain selector + evaluator; "
-            "composite nodes contain and/or/not."
-        ),
-    )
-    action: ControlAction = Field(..., description="What action to take when control matches")
-    tags: list[str] = Field(default_factory=list, description="Tags for categorization")
-
-    @model_validator(mode="before")
-    @classmethod
-    def canonicalize_legacy_condition_shape(cls, data: Any) -> Any:
-        """Accept legacy flat leaf payloads during runtime parsing."""
-        return ControlDefinition.canonicalize_payload(data)
-
-    @model_validator(mode="after")
-    def validate_condition_constraints(self) -> Self:
-        """Validate runtime-relevant control constraints."""
-        _validate_common_control_constraints(self.condition, self.action)
-        return self
 
 
 class EvaluatorResult(BaseModel):

--- a/models/tests/test_controls.py
+++ b/models/tests/test_controls.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import pytest
 from agent_control_models import (
     ControlDefinition,
-    ControlDefinitionBase,
     ControlDefinitionRuntime,
 )
+from agent_control_models.controls import ControlDefinitionBase
 from pydantic import ValidationError
 
 

--- a/models/tests/test_controls.py
+++ b/models/tests/test_controls.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import pytest
-from agent_control_models import ControlDefinition
+from agent_control_models import (
+    ControlDefinition,
+    ControlDefinitionBase,
+    ControlDefinitionRuntime,
+)
 from pydantic import ValidationError
 
 
@@ -82,6 +86,27 @@ def test_legacy_leaf_payload_is_canonicalized() -> None:
     assert dumped["condition"]["evaluator"]["name"] == "regex"
 
 
+def test_runtime_legacy_leaf_payload_is_canonicalized() -> None:
+    # Given: a legacy flat selector/evaluator payload loaded for runtime evaluation
+    legacy_payload = {
+        "execution": "server",
+        "scope": {"step_types": ["llm"], "stages": ["pre"]},
+        "selector": {"path": "input"},
+        "evaluator": {"name": "regex", "config": {"pattern": "ok"}},
+        "action": {"decision": "deny"},
+    }
+
+    # When: validating the payload through the runtime model
+    control = ControlDefinitionRuntime.model_validate(legacy_payload)
+
+    # Then: runtime parsing uses the same canonical condition shape
+    dumped = control.model_dump(mode="json", exclude_none=True)
+    assert "selector" not in dumped
+    assert "evaluator" not in dumped
+    assert dumped["condition"]["selector"]["path"] == "input"
+    assert dumped["condition"]["evaluator"]["name"] == "regex"
+
+
 def test_mixed_legacy_and_condition_fields_are_rejected() -> None:
     # Given: a payload that mixes canonical condition and legacy flat fields
     payload = {
@@ -101,6 +126,27 @@ def test_mixed_legacy_and_condition_fields_are_rejected() -> None:
         # When: validating the mixed payload
         ControlDefinition.model_validate(payload)
     # Then: validation rejects the mixed shape
+
+
+def test_runtime_mixed_legacy_and_condition_fields_are_rejected() -> None:
+    # Given: a runtime payload that mixes canonical condition and legacy flat fields
+    payload = {
+        "execution": "server",
+        "scope": {"step_types": ["llm"], "stages": ["pre"]},
+        "condition": _leaf("input"),
+        "selector": {"path": "output"},
+        "evaluator": {"name": "regex", "config": {"pattern": "ok"}},
+        "action": {"decision": "deny"},
+    }
+
+    with pytest.raises(
+        ValidationError,
+        match="Control definition mixes canonical condition fields "
+        "with legacy selector/evaluator fields",
+    ):
+        # When: validating the mixed payload through the runtime model
+        ControlDefinitionRuntime.model_validate(payload)
+    # Then: runtime parsing rejects the same ambiguous legacy shape
 
 
 def test_condition_and_requires_at_least_one_child() -> None:
@@ -220,6 +266,53 @@ def test_composite_steer_requires_steering_context() -> None:
             }
         )
     # Then: validation rejects the steer action without guidance
+
+
+def test_runtime_composite_steer_requires_steering_context() -> None:
+    # Given: a runtime composite steer control without steering context
+    with pytest.raises(
+        ValidationError,
+        match="Composite steer controls require action.steering_context",
+    ):
+        # When: validating the runtime control definition
+        ControlDefinitionRuntime.model_validate(
+            {
+                "execution": "server",
+                "scope": {"step_types": ["llm"], "stages": ["pre"]},
+                "condition": {
+                    "or": [
+                        _leaf("input"),
+                        _leaf("output"),
+                    ]
+                },
+                "action": {"decision": "steer"},
+            }
+        )
+    # Then: runtime validation enforces the shared condition/action constraint
+
+
+def test_control_definition_base_owns_shared_runtime_fields() -> None:
+    # Given: the runtime-relevant control fields shared by authored and runtime models
+    runtime_fields = {
+        "description",
+        "enabled",
+        "execution",
+        "scope",
+        "condition",
+        "action",
+        "tags",
+    }
+
+    # When: inspecting the public Pydantic model fields
+    base_fields = set(ControlDefinitionBase.model_fields)
+    authored_fields = set(ControlDefinition.model_fields)
+    runtime_model_fields = set(ControlDefinitionRuntime.model_fields)
+
+    # Then: those fields are declared once on the base and inherited by both models
+    assert base_fields == runtime_fields
+    assert runtime_fields.issubset(authored_fields)
+    assert runtime_model_fields == runtime_fields
+    assert {"template", "template_values"}.issubset(authored_fields)
 
 
 def test_single_leaf_control_returns_primary_leaf() -> None:


### PR DESCRIPTION
## Summary
- Introduce `ControlDefinitionBase` for runtime-relevant control fields shared by authored and runtime control models.
- Move legacy selector/evaluator canonicalization and common condition/action validation onto the shared base.
- Keep template metadata and template pairing validation only on `ControlDefinition`, while `ControlDefinitionRuntime` keeps runtime parsing with `extra="ignore"`.

## Why
This addresses https://github.com/agentcontrol/agent-control/issues/200 by removing duplicated runtime fields and validators between `ControlDefinition` and `ControlDefinitionRuntime`, making future root-level runtime fields easier to add once.

## Validation
- `make models-test`
- `make lint`
- `make typecheck`
- `make check`

Fixes https://github.com/agentcontrol/agent-control/issues/200