### PR TITLE
fix(server): add httpx to runtime dependencies

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "fastapi>=0.109.0",
     "starlette-exporter>=0.23.0",
     "uvicorn[standard]>=0.27.0",
+    "httpx>=0.27.0",  # For auth_framework HTTP providers
     "pydantic>=2.5.0",
     "pydantic-settings>=2.1.0",
     "SQLAlchemy>=2.0.0",


### PR DESCRIPTION
## Summary

`httpx` is listed only under `[dependency-groups] dev`, but `server/src/agent_control_server/auth_framework/providers/http_upstream.py` imports `httpx` at module load time. Wheels built without dev dependencies therefore fail with `ModuleNotFoundError: No module named 'httpx'` on server start.

## Reproduction

Build a production wheel (no dev deps) and start the server:

```
uv sync --package agent-control-server --no-dev
.venv/bin/agent-control-server
# ...
# File "src/agent_control_server/auth_framework/providers/__init__.py", line 4, in <module>
#   from .http_upstream import HttpUpstreamAuthProvider
# File "src/agent_control_server/auth_framework/providers/http_upstream.py", line 45, in <module>
#   import httpx
# ModuleNotFoundError: No module named 'httpx'
```

## Fix

Add `"httpx>=0.27.0"` to the runtime `dependencies` list in `server/pyproject.toml`. Existing dev-deps entry is unchanged.

## Test plan

- [x] Diff is one line.
- [ ] CI green.
- [ ] Verified locally that a wheel installed without dev deps starts the server without ImportError.