### PR TITLE
feat(sdk-ts): expose debug logger option

### DIFF
--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -1,4 +1,5 @@
 import { AgentControlSDK } from "./generated/sdk/sdk";
+import type { Logger } from "./generated/lib/logger";
 
 export interface StepSchema {
   name: string;
@@ -15,6 +16,7 @@ export interface AgentControlInitOptions {
   steps?: StepSchema[];
   timeoutMs?: number;
   userAgent?: string;
+  debugLogger?: Logger;
 }
 
 export type AgentsApi = AgentControlSDK["agents"];
@@ -38,6 +40,7 @@ export class AgentControlClient {
       apiKeyHeader: options.apiKey,
       timeoutMs: options.timeoutMs,
       userAgent: options.userAgent,
+      debugLogger: options.debugLogger,
     });
   }
 

--- a/sdks/typescript/tests/client-api.test.ts
+++ b/sdks/typescript/tests/client-api.test.ts
@@ -61,6 +61,44 @@ describe("AgentControlClient API wiring", () => {
     expect(request.headers.get("X-API-Key")).toBe("test-api-key");
   });
 
+  it("passes debugLogger through to the generated SDK", async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        agents: [],
+        pagination: {
+          has_more: false,
+          limit: 20,
+          next_cursor: null,
+          total: 0,
+        },
+      }),
+    );
+
+    const debugLogger = {
+      group: vi.fn(),
+      groupEnd: vi.fn(),
+      log: vi.fn(),
+    };
+
+    const client = new AgentControlClient();
+    client.init({
+      agentName: "test-agent",
+      serverUrl: "https://api.example.com",
+      debugLogger,
+    });
+
+    await client.agents.list();
+
+    expect(debugLogger.group).toHaveBeenCalledWith(
+      "> Request: GET https://api.example.com/api/v1/agents",
+    );
+    expect(debugLogger.group).toHaveBeenCalledWith(
+      "< Response: GET https://api.example.com/api/v1/agents",
+    );
+    expect(debugLogger.log).toHaveBeenCalledWith("Status Code:", 200, "");
+  });
+
   it("builds JSON request bodies for write operations", async () => {
     const fetchMock = vi.mocked(globalThis.fetch);
     fetchMock.mockResolvedValueOnce(


### PR DESCRIPTION
## Summary
- add `debugLogger` to `AgentControlClient` init options
- pass `debugLogger` through to the generated Speakeasy `AgentControlSDK`
- cover the public wrapper path with a Vitest assertion that request/response logging is invoked

## Validation
- `make sdk-ts-test`
- `make sdk-ts-typecheck`
- `make sdk-ts-lint`
- `make sdk-ts-build`

## Notes
- `debugLogger` can log request/response headers and bodies, so callers should use a redacting logger when sensitive headers or payloads may be present.
