### PR TITLE
ci(server): publish agent-control-server to PyPI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -148,11 +148,11 @@ jobs:
 
   publish-sdk:
     runs-on: ubuntu-latest
-    needs: [release, publish-server]
+    needs: [release, publish-evaluators]
     if: >-
       always() &&
       needs.release.outputs.released == 'true' &&
-      needs.publish-server.result == 'success'
+      needs.publish-evaluators.result == 'success'
     permissions:
       id-token: write
 
@@ -172,8 +172,10 @@ jobs:
 
   upload-release-assets:
     runs-on: ubuntu-latest
-    needs: [release, publish-sdk]
-    if: needs.release.outputs.released == 'true'
+    needs: [release, publish-models, publish-evaluators, publish-server, publish-sdk]
+    if: >-
+      always() &&
+      needs.release.outputs.released == 'true'
     permissions:
       contents: write
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -122,13 +122,37 @@ jobs:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
 
-  publish-sdk:
+  publish-server:
     runs-on: ubuntu-latest
     needs: [release, publish-evaluators]
     if: >-
       always() &&
       needs.release.outputs.released == 'true' &&
       needs.publish-evaluators.result == 'success'
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download built distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: .
+
+      - name: Publish agent-control-server to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: release-dists/server/dist/
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+  publish-sdk:
+    runs-on: ubuntu-latest
+    needs: [release, publish-server]
+    if: >-
+      always() &&
+      needs.release.outputs.released == 'true' &&
+      needs.publish-server.result == 'success'
     permissions:
       id-token: write
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,7 +92,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: release-dists
-          path: .
+          path: release-dists
 
       - name: Publish agent-control-models to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -113,7 +113,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: release-dists
-          path: .
+          path: release-dists
 
       - name: Publish evaluator distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -137,7 +137,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: release-dists
-          path: .
+          path: release-dists
 
       - name: Publish agent-control-server to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -161,7 +161,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: release-dists
-          path: .
+          path: release-dists
 
       - name: Publish agent-control-sdk to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -184,7 +184,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: release-dists
-          path: .
+          path: release-dists
 
       - name: Upload to GitHub Release
         uses: python-semantic-release/upload-to-gh-release@main


### PR DESCRIPTION
## Summary
The release workflow stages \`server/dist/\` and uploads it to GitHub release assets, but does not currently push the server wheel to PyPI. Models, evaluators, and the SDK are published; the server is not.

This change adds a \`publish-server\` job between \`publish-evaluators\` and \`publish-sdk\`, matching the pattern of the other publish jobs.

## Scope
- User-facing/API changes: \`agent-control-server\` becomes installable via \`pip install agent-control-server\` after the next release.
- Internal changes: dependency chain in the workflow updated to evaluators -> server -> sdk (server depends on evaluators at runtime, so evaluators publishes first).
- Out of scope: anything outside the release workflow.

## Risk and Rollout
- Risk level: low. New workflow job; failure to publish server doesn't affect previously published packages because \`pypa/gh-action-pypi-publish\` is per-job atomic.
- Rollback plan: revert the workflow file.

## Testing
- [x] Validated YAML structure locally.
- [ ] Verified by the next \`workflow_dispatch\` release run.