### PR TITLE
feat(sdk): add runtime token auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <!-- version list -->
 
+## Unreleased
+
+### Changed
+
+- **sdk**: Strict `runtime_auth_mode="jwt"` evaluation requests now require both
+  `target_type` and `target_id`; missing target context raises an error instead
+  of falling back to API-key auth.
+
 ## v7.7.0 (2026-05-07)
 
 ### Bug Fixes

--- a/sdks/python/src/agent_control/__init__.py
+++ b/sdks/python/src/agent_control/__init__.py
@@ -160,6 +160,7 @@ class _RefreshContext:
     agent_name: str
     server_url: str
     api_key: str | None
+    api_key_header: str | None
     target_type: str | None
     target_id: str | None
 
@@ -221,6 +222,7 @@ def _snapshot_refresh_context() -> _RefreshContext:
         agent = state.current_agent
         server_url = state.server_url
         api_key = state.api_key
+        api_key_header = state.api_key_header
         target_type = state.target_type
         target_id = state.target_id
 
@@ -234,6 +236,7 @@ def _snapshot_refresh_context() -> _RefreshContext:
         agent_name=agent.agent_name,
         server_url=server_url,
         api_key=api_key,
+        api_key_header=api_key_header,
         target_type=target_type,
         target_id=target_id,
     )
@@ -244,6 +247,7 @@ async def _fetch_controls_for_context_async(context: _RefreshContext) -> list[di
     async with AgentControlClient(
         base_url=context.server_url,
         api_key=context.api_key,
+        api_key_header=context.api_key_header,
     ) as client:
         response = await agents.list_agent_controls(
             client,
@@ -430,6 +434,7 @@ def init(
     agent_version: str | None = None,
     server_url: str | None = None,
     api_key: str | None = None,
+    api_key_header: str | None = None,
     controls_file: str | None = None,
     steps: list[StepSchemaDict] | None = None,
     conflict_mode: Literal["strict", "overwrite"] = "overwrite",
@@ -468,6 +473,8 @@ def init(
         server_url: Optional server URL (defaults to AGENT_CONTROL_URL env var
                    or http://localhost:8000)
         api_key: Optional API key for authentication (defaults to AGENT_CONTROL_API_KEY env var)
+        api_key_header: Optional HTTP header name for API key authentication
+            (defaults to AGENT_CONTROL_API_KEY_HEADER env var or X-API-Key)
         controls_file: Optional explicit path to controls.yaml (auto-discovered if not provided)
         steps: Optional list of step schemas for registration:
                [{"type": "tool", "name": "search", "input_schema": {...}, "output_schema": {...}}]
@@ -562,6 +569,7 @@ def init(
         state.current_agent = next_agent
         state.server_url = server_url or os.getenv('AGENT_CONTROL_URL') or 'http://localhost:8000'
         state.api_key = api_key
+        state.api_key_header = api_key_header
         state.runtime_token_cache.clear()
         state.target_type = target_type
         state.target_id = target_id
@@ -600,6 +608,7 @@ def init(
             async with AgentControlClient(
                 base_url=state.server_url,
                 api_key=state.api_key,
+                api_key_header=state.api_key_header,
             ) as client:
                 # Check server health first
                 try:
@@ -686,6 +695,7 @@ def init(
     batcher = init_observability(
         server_url=state.server_url,
         api_key=state.api_key,
+        api_key_header=state.api_key_header,
         enabled=observability_enabled,
         sink_name=observability_sink_name,
         sink_config=observability_sink_config,
@@ -717,6 +727,7 @@ def _reset_state() -> None:
         state.server_controls = None
         state.server_url = None
         state.api_key = None
+        state.api_key_header = None
         state.runtime_token_cache.clear()
         state.target_type = None
         state.target_id = None

--- a/sdks/python/src/agent_control/__init__.py
+++ b/sdks/python/src/agent_control/__init__.py
@@ -562,6 +562,7 @@ def init(
         state.current_agent = next_agent
         state.server_url = server_url or os.getenv('AGENT_CONTROL_URL') or 'http://localhost:8000'
         state.api_key = api_key
+        state.runtime_token_cache.clear()
         state.target_type = target_type
         state.target_id = target_id
 
@@ -597,7 +598,8 @@ def init(
             assert state.current_agent is not None
 
             async with AgentControlClient(
-                base_url=state.server_url, api_key=state.api_key
+                base_url=state.server_url,
+                api_key=state.api_key,
             ) as client:
                 # Check server health first
                 try:
@@ -715,6 +717,7 @@ def _reset_state() -> None:
         state.server_controls = None
         state.server_url = None
         state.api_key = None
+        state.runtime_token_cache.clear()
         state.target_type = None
         state.target_id = None
 

--- a/sdks/python/src/agent_control/__init__.py
+++ b/sdks/python/src/agent_control/__init__.py
@@ -542,6 +542,11 @@ def init(
         raise ValueError(
             "target_type and target_id must be supplied together."
         )
+    resolved_api_key_header = (
+        api_key_header
+        or os.getenv(AgentControlClient.API_KEY_HEADER_ENV_VAR)
+        or AgentControlClient.DEFAULT_API_KEY_HEADER
+    )
 
     # Re-init behavior: always stop the existing refresh loop before mutating
     # shared agent/session globals.
@@ -569,7 +574,7 @@ def init(
         state.current_agent = next_agent
         state.server_url = server_url or os.getenv('AGENT_CONTROL_URL') or 'http://localhost:8000'
         state.api_key = api_key
-        state.api_key_header = api_key_header
+        state.api_key_header = resolved_api_key_header
         state.runtime_token_cache.clear()
         state.target_type = target_type
         state.target_id = target_id

--- a/sdks/python/src/agent_control/__init__.py
+++ b/sdks/python/src/agent_control/__init__.py
@@ -215,6 +215,19 @@ def _run_coro_in_new_loop[T](coro: Coroutine[Any, Any, T]) -> T:
         asyncio.set_event_loop(None)
 
 
+def _ad_hoc_client(
+    *,
+    server_url: str,
+    api_key: str | None,
+    api_key_header: str | None,
+) -> AgentControlClient:
+    return AgentControlClient(
+        base_url=server_url,
+        api_key=api_key,
+        api_key_header=api_key_header if api_key_header is not None else state.api_key_header,
+    )
+
+
 def _snapshot_refresh_context() -> _RefreshContext:
     """Capture a consistent session snapshot for a refresh request."""
     with _session_lock:
@@ -770,6 +783,7 @@ async def get_agent(
     agent_name: str,
     server_url: str | None = None,
     api_key: str | None = None,
+    api_key_header: str | None = None,
 ) -> dict[str, Any]:
     """
     Get agent details from the server by name.
@@ -809,7 +823,11 @@ async def get_agent(
     """
     _final_server_url = server_url or os.getenv('AGENT_CONTROL_URL') or 'http://localhost:8000'
 
-    async with AgentControlClient(base_url=_final_server_url, api_key=api_key) as client:
+    async with _ad_hoc_client(
+        server_url=_final_server_url,
+        api_key=api_key,
+        api_key_header=api_key_header,
+    ) as client:
         return await agents.get_agent(client, agent_name)
 
 
@@ -833,6 +851,7 @@ def current_agent() -> Agent | None:
 async def list_agents(
     server_url: str | None = None,
     api_key: str | None = None,
+    api_key_header: str | None = None,
     cursor: str | None = None,
     limit: int = 20,
 ) -> dict[str, Any]:
@@ -873,7 +892,11 @@ async def list_agents(
     """
     _final_server_url = server_url or os.getenv('AGENT_CONTROL_URL') or 'http://localhost:8000'
 
-    async with AgentControlClient(base_url=_final_server_url, api_key=api_key) as client:
+    async with _ad_hoc_client(
+        server_url=_final_server_url,
+        api_key=api_key,
+        api_key_header=api_key_header,
+    ) as client:
         return await agents.list_agents(client, cursor=cursor, limit=limit)
 
 
@@ -887,10 +910,15 @@ async def add_agent_policy(
     policy_id: int,
     server_url: str | None = None,
     api_key: str | None = None,
+    api_key_header: str | None = None,
 ) -> dict[str, Any]:
     """Associate a policy with an agent (idempotent)."""
     _final_server_url = server_url or os.getenv('AGENT_CONTROL_URL') or 'http://localhost:8000'
-    async with AgentControlClient(base_url=_final_server_url, api_key=api_key) as client:
+    async with _ad_hoc_client(
+        server_url=_final_server_url,
+        api_key=api_key,
+        api_key_header=api_key_header,
+    ) as client:
         return await agents.add_agent_policy(client, agent_name, policy_id)
 
 
@@ -898,10 +926,15 @@ async def get_agent_policies(
     agent_name: str,
     server_url: str | None = None,
     api_key: str | None = None,
+    api_key_header: str | None = None,
 ) -> dict[str, Any]:
     """List policy IDs associated with an agent."""
     _final_server_url = server_url or os.getenv('AGENT_CONTROL_URL') or 'http://localhost:8000'
-    async with AgentControlClient(base_url=_final_server_url, api_key=api_key) as client:
+    async with _ad_hoc_client(
+        server_url=_final_server_url,
+        api_key=api_key,
+        api_key_header=api_key_header,
+    ) as client:
         return await agents.get_agent_policies(client, agent_name)
 
 
@@ -910,10 +943,15 @@ async def remove_agent_policy_association(
     policy_id: int,
     server_url: str | None = None,
     api_key: str | None = None,
+    api_key_header: str | None = None,
 ) -> dict[str, Any]:
     """Remove one policy association from an agent (idempotent)."""
     _final_server_url = server_url or os.getenv('AGENT_CONTROL_URL') or 'http://localhost:8000'
-    async with AgentControlClient(base_url=_final_server_url, api_key=api_key) as client:
+    async with _ad_hoc_client(
+        server_url=_final_server_url,
+        api_key=api_key,
+        api_key_header=api_key_header,
+    ) as client:
         return await agents.remove_agent_policy_association(client, agent_name, policy_id)
 
 
@@ -921,10 +959,15 @@ async def remove_all_agent_policies(
     agent_name: str,
     server_url: str | None = None,
     api_key: str | None = None,
+    api_key_header: str | None = None,
 ) -> dict[str, Any]:
     """Remove all policy associations from an agent."""
     _final_server_url = server_url or os.getenv('AGENT_CONTROL_URL') or 'http://localhost:8000'
-    async with AgentControlClient(base_url=_final_server_url, api_key=api_key) as client:
+    async with _ad_hoc_client(
+        server_url=_final_server_url,
+        api_key=api_key,
+        api_key_header=api_key_header,
+    ) as client:
         return await agents.remove_all_agent_policies(client, agent_name)
 
 
@@ -933,10 +976,15 @@ async def add_agent_control(
     control_id: int,
     server_url: str | None = None,
     api_key: str | None = None,
+    api_key_header: str | None = None,
 ) -> dict[str, Any]:
     """Associate a control with an agent (idempotent)."""
     _final_server_url = server_url or os.getenv('AGENT_CONTROL_URL') or 'http://localhost:8000'
-    async with AgentControlClient(base_url=_final_server_url, api_key=api_key) as client:
+    async with _ad_hoc_client(
+        server_url=_final_server_url,
+        api_key=api_key,
+        api_key_header=api_key_header,
+    ) as client:
         return await agents.add_agent_control(client, agent_name, control_id)
 
 
@@ -945,10 +993,15 @@ async def remove_agent_control(
     control_id: int,
     server_url: str | None = None,
     api_key: str | None = None,
+    api_key_header: str | None = None,
 ) -> dict[str, Any]:
     """Remove a direct control association from an agent (idempotent)."""
     _final_server_url = server_url or os.getenv('AGENT_CONTROL_URL') or 'http://localhost:8000'
-    async with AgentControlClient(base_url=_final_server_url, api_key=api_key) as client:
+    async with _ad_hoc_client(
+        server_url=_final_server_url,
+        api_key=api_key,
+        api_key_header=api_key_header,
+    ) as client:
         return await agents.remove_agent_control(client, agent_name, control_id)
 
 
@@ -960,6 +1013,7 @@ async def remove_agent_control(
 async def list_controls(
     server_url: str | None = None,
     api_key: str | None = None,
+    api_key_header: str | None = None,
     cursor: int | None = None,
     limit: int = 20,
     name: str | None = None,
@@ -1013,7 +1067,11 @@ async def list_controls(
     """
     _final_server_url = server_url or os.getenv('AGENT_CONTROL_URL') or 'http://localhost:8000'
 
-    async with AgentControlClient(base_url=_final_server_url, api_key=api_key) as client:
+    async with _ad_hoc_client(
+        server_url=_final_server_url,
+        api_key=api_key,
+        api_key_header=api_key_header,
+    ) as client:
         return await controls.list_controls(
             client,
             cursor=cursor,
@@ -1033,6 +1091,7 @@ async def create_control(
     data: dict[str, Any] | ControlDefinition | TemplateControlInput,
     server_url: str | None = None,
     api_key: str | None = None,
+    api_key_header: str | None = None,
 ) -> dict[str, Any]:
     """
     Create a new control with configuration.
@@ -1080,7 +1139,11 @@ async def create_control(
     """
     _final_server_url = server_url or os.getenv('AGENT_CONTROL_URL') or 'http://localhost:8000'
 
-    async with AgentControlClient(base_url=_final_server_url, api_key=api_key) as client:
+    async with _ad_hoc_client(
+        server_url=_final_server_url,
+        api_key=api_key,
+        api_key_header=api_key_header,
+    ) as client:
         return await controls.create_control(client, name, data=data)
 
 
@@ -1088,11 +1151,16 @@ async def validate_control_data(
     data: dict[str, Any] | ControlDefinition | TemplateControlInput,
     server_url: str | None = None,
     api_key: str | None = None,
+    api_key_header: str | None = None,
 ) -> dict[str, Any]:
     """Validate raw or template-backed control data without saving it."""
     _final_server_url = server_url or os.getenv('AGENT_CONTROL_URL') or 'http://localhost:8000'
 
-    async with AgentControlClient(base_url=_final_server_url, api_key=api_key) as client:
+    async with _ad_hoc_client(
+        server_url=_final_server_url,
+        api_key=api_key,
+        api_key_header=api_key_header,
+    ) as client:
         return await controls.validate_control_data(client, data=data)
 
 
@@ -1101,11 +1169,16 @@ async def render_control_template(
     template_values: dict[str, TemplateValue],
     server_url: str | None = None,
     api_key: str | None = None,
+    api_key_header: str | None = None,
 ) -> dict[str, Any]:
     """Render a template-backed control preview without persisting it."""
     _final_server_url = server_url or os.getenv('AGENT_CONTROL_URL') or 'http://localhost:8000'
 
-    async with AgentControlClient(base_url=_final_server_url, api_key=api_key) as client:
+    async with _ad_hoc_client(
+        server_url=_final_server_url,
+        api_key=api_key,
+        api_key_header=api_key_header,
+    ) as client:
         return await controls.render_control_template(
             client,
             template=template,
@@ -1117,6 +1190,7 @@ async def get_control(
     control_id: int,
     server_url: str | None = None,
     api_key: str | None = None,
+    api_key_header: str | None = None,
 ) -> dict[str, Any]:
     """
     Get a control by ID from the server.
@@ -1147,7 +1221,11 @@ async def get_control(
     """
     _final_server_url = server_url or os.getenv('AGENT_CONTROL_URL') or 'http://localhost:8000'
 
-    async with AgentControlClient(base_url=_final_server_url, api_key=api_key) as client:
+    async with _ad_hoc_client(
+        server_url=_final_server_url,
+        api_key=api_key,
+        api_key_header=api_key_header,
+    ) as client:
         return await controls.get_control(client, control_id)
 
 
@@ -1156,6 +1234,7 @@ async def delete_control(
     force: bool = False,
     server_url: str | None = None,
     api_key: str | None = None,
+    api_key_header: str | None = None,
 ) -> dict[str, Any]:
     """
     Delete a control from the server.
@@ -1192,7 +1271,11 @@ async def delete_control(
     """
     _final_server_url = server_url or os.getenv('AGENT_CONTROL_URL') or 'http://localhost:8000'
 
-    async with AgentControlClient(base_url=_final_server_url, api_key=api_key) as client:
+    async with _ad_hoc_client(
+        server_url=_final_server_url,
+        api_key=api_key,
+        api_key_header=api_key_header,
+    ) as client:
         return await controls.delete_control(client, control_id, force=force)
 
 
@@ -1202,6 +1285,7 @@ async def update_control(
     enabled: bool | None = None,
     server_url: str | None = None,
     api_key: str | None = None,
+    api_key_header: str | None = None,
 ) -> dict[str, Any]:
     """
     Update control metadata (name and/or enabled status).
@@ -1242,7 +1326,11 @@ async def update_control(
     """
     _final_server_url = server_url or os.getenv('AGENT_CONTROL_URL') or 'http://localhost:8000'
 
-    async with AgentControlClient(base_url=_final_server_url, api_key=api_key) as client:
+    async with _ad_hoc_client(
+        server_url=_final_server_url,
+        api_key=api_key,
+        api_key_header=api_key_header,
+    ) as client:
         return await controls.update_control(client, control_id, name=name, enabled=enabled)
 
 
@@ -1256,6 +1344,7 @@ async def add_control_to_policy(
     control_id: int,
     server_url: str | None = None,
     api_key: str | None = None,
+    api_key_header: str | None = None,
 ) -> dict[str, Any]:
     """
     Add a control to a policy.
@@ -1289,7 +1378,11 @@ async def add_control_to_policy(
     """
     _final_server_url = server_url or os.getenv('AGENT_CONTROL_URL') or 'http://localhost:8000'
 
-    async with AgentControlClient(base_url=_final_server_url, api_key=api_key) as client:
+    async with _ad_hoc_client(
+        server_url=_final_server_url,
+        api_key=api_key,
+        api_key_header=api_key_header,
+    ) as client:
         return await policies.add_control_to_policy(client, policy_id, control_id)
 
 
@@ -1298,6 +1391,7 @@ async def remove_control_from_policy(
     control_id: int,
     server_url: str | None = None,
     api_key: str | None = None,
+    api_key_header: str | None = None,
 ) -> dict[str, Any]:
     """
     Remove a control from a policy.
@@ -1331,7 +1425,11 @@ async def remove_control_from_policy(
     """
     _final_server_url = server_url or os.getenv('AGENT_CONTROL_URL') or 'http://localhost:8000'
 
-    async with AgentControlClient(base_url=_final_server_url, api_key=api_key) as client:
+    async with _ad_hoc_client(
+        server_url=_final_server_url,
+        api_key=api_key,
+        api_key_header=api_key_header,
+    ) as client:
         return await policies.remove_control_from_policy(client, policy_id, control_id)
 
 
@@ -1339,6 +1437,7 @@ async def list_policy_controls(
     policy_id: int,
     server_url: str | None = None,
     api_key: str | None = None,
+    api_key_header: str | None = None,
 ) -> dict[str, Any]:
     """
     List all controls associated with a policy.
@@ -1368,7 +1467,11 @@ async def list_policy_controls(
     """
     _final_server_url = server_url or os.getenv('AGENT_CONTROL_URL') or 'http://localhost:8000'
 
-    async with AgentControlClient(base_url=_final_server_url, api_key=api_key) as client:
+    async with _ad_hoc_client(
+        server_url=_final_server_url,
+        api_key=api_key,
+        api_key_header=api_key_header,
+    ) as client:
         return await policies.list_policy_controls(client, policy_id)
 
 

--- a/sdks/python/src/agent_control/_state.py
+++ b/sdks/python/src/agent_control/_state.py
@@ -26,6 +26,7 @@ class _StateContainer:
         self.server_controls: list[dict[str, Any]] | None = None
         self.server_url: str | None = None
         self.api_key: str | None = None
+        self.api_key_header: str | None = None
         self.runtime_token_cache = RuntimeTokenCache()
         # Optional target context fixed at init() time; both fields are set
         # together or both remain None.

--- a/sdks/python/src/agent_control/_state.py
+++ b/sdks/python/src/agent_control/_state.py
@@ -8,6 +8,8 @@ the same state object.
 
 from typing import TYPE_CHECKING, Any
 
+from .runtime_auth import RuntimeTokenCache
+
 if TYPE_CHECKING:
     from agent_control_models import Agent
 
@@ -24,6 +26,7 @@ class _StateContainer:
         self.server_controls: list[dict[str, Any]] | None = None
         self.server_url: str | None = None
         self.api_key: str | None = None
+        self.runtime_token_cache = RuntimeTokenCache()
         # Optional target context fixed at init() time; both fields are set
         # together or both remain None.
         self.target_type: str | None = None

--- a/sdks/python/src/agent_control/client.py
+++ b/sdks/python/src/agent_control/client.py
@@ -371,6 +371,12 @@ class AgentControlClient:
             )
         except httpx.RequestError:
             if self._runtime_auth_mode == "auto" and allow_auto_fallback:
+                _logger.debug(
+                    "Runtime token exchange request failed; falling back to normal request auth "
+                    "for %s/%s.",
+                    target_type,
+                    target_id,
+                )
                 self._runtime_token_cache.mark_jwt_unavailable(
                     server_url=self.base_url,
                     target_type=target_type,
@@ -384,6 +390,13 @@ class AgentControlClient:
             and allow_auto_fallback
             and response.status_code in _AUTO_RUNTIME_TOKEN_FALLBACK_STATUSES
         ):
+            _logger.debug(
+                "Runtime token exchange returned HTTP %s; falling back to normal request auth "
+                "for %s/%s.",
+                response.status_code,
+                target_type,
+                target_id,
+            )
             self._runtime_token_cache.mark_jwt_unavailable(
                 server_url=self.base_url,
                 target_type=target_type,

--- a/sdks/python/src/agent_control/client.py
+++ b/sdks/python/src/agent_control/client.py
@@ -27,16 +27,17 @@ _GLOBAL_RUNTIME_TOKEN_FALLBACK_STATUSES = {404, 503}
 class _AgentControlAuth(httpx.Auth):
     """Attach local API-key credentials unless a request already has Bearer auth."""
 
-    def __init__(self, api_key: str | None) -> None:
+    def __init__(self, api_key: str | None, header_name: str = "X-API-Key") -> None:
         self._api_key = api_key
+        self._header_name = header_name
 
     def auth_flow(
         self,
         request: httpx.Request,
     ) -> Generator[httpx.Request, httpx.Response, None]:
         if self._api_key and "Authorization" not in request.headers:
-            if "X-API-Key" not in request.headers:
-                request.headers["X-API-Key"] = self._api_key
+            if self._header_name not in request.headers:
+                request.headers[self._header_name] = self._api_key
         yield request
 
 
@@ -49,7 +50,9 @@ class AgentControlClient:
     agents, policies, controls, evaluation.
 
     Authentication:
-        The client supports API key authentication via the X-API-Key header.
+        The client supports API key authentication. By default the key is
+        sent on the ``X-API-Key`` header; set ``api_key_header`` (or the
+        ``AGENT_CONTROL_API_KEY_HEADER`` environment variable) to override.
         API key can be provided:
         1. Directly via the `api_key` parameter
         2. Via the AGENT_CONTROL_API_KEY environment variable
@@ -63,10 +66,20 @@ class AgentControlClient:
         os.environ["AGENT_CONTROL_API_KEY"] = "my-secret-key"
         async with AgentControlClient() as client:
             await client.health_check()
+
+        # Custom header name (e.g., when the upstream auth expects something
+        # other than X-API-Key). The header name applies to every request
+        # this client sends.
+        async with AgentControlClient(
+            api_key="my-secret-key", api_key_header="X-Custom-API-Key"
+        ) as client:
+            await client.health_check()
     """
 
     # Environment variable name for API key
     API_KEY_ENV_VAR = "AGENT_CONTROL_API_KEY"
+    API_KEY_HEADER_ENV_VAR = "AGENT_CONTROL_API_KEY_HEADER"
+    DEFAULT_API_KEY_HEADER = "X-API-Key"
     BASE_URL_ENV_VAR = "AGENT_CONTROL_URL"
 
     def __init__(
@@ -74,6 +87,7 @@ class AgentControlClient:
         base_url: str | None = None,
         timeout: float = 30.0,
         api_key: str | None = None,
+        api_key_header: str | None = None,
         runtime_auth_mode: RuntimeAuthMode | str | None = None,
         runtime_token_cache: RuntimeTokenCache | None = None,
         runtime_token_refresh_margin_seconds: int = (_DEFAULT_RUNTIME_TOKEN_REFRESH_MARGIN_SECONDS),
@@ -88,6 +102,10 @@ class AgentControlClient:
             timeout: Request timeout in seconds
             api_key: API key for authentication. If not provided, will attempt
                      to read from AGENT_CONTROL_API_KEY environment variable.
+            api_key_header: HTTP header name to send the API key on. Defaults
+                     to ``X-API-Key``; the AGENT_CONTROL_API_KEY_HEADER
+                     environment variable overrides the default. Useful when
+                     the configured upstream auth expects a different header.
             runtime_auth_mode: Runtime auth mode for evaluation requests. ``auto``
                 attempts target-bound JWT exchange and falls back to normal
                 request auth when the exchange endpoint is unavailable. ``jwt``
@@ -104,6 +122,11 @@ class AgentControlClient:
         self.base_url = resolved_base_url.rstrip("/")
         self.timeout = timeout
         self._api_key = api_key or os.environ.get(self.API_KEY_ENV_VAR)
+        self._api_key_header = (
+            api_key_header
+            or os.environ.get(self.API_KEY_HEADER_ENV_VAR)
+            or self.DEFAULT_API_KEY_HEADER
+        )
         configured_runtime_mode = runtime_auth_mode or os.environ.get(_RUNTIME_AUTH_MODE_ENV_VAR)
         self._runtime_auth_mode = normalize_runtime_auth_mode(configured_runtime_mode)
         if runtime_token_refresh_margin_seconds < 0:
@@ -118,6 +141,11 @@ class AgentControlClient:
     def api_key(self) -> str | None:
         """Get the configured API key (read-only)."""
         return self._api_key
+
+    @property
+    def api_key_header(self) -> str:
+        """Get the header name the API key is sent on (read-only)."""
+        return self._api_key_header
 
     @property
     def runtime_auth_mode(self) -> RuntimeAuthMode:
@@ -159,7 +187,7 @@ class AgentControlClient:
             base_url=self.base_url,
             timeout=self.timeout,
             headers=self._get_headers(),
-            auth=_AgentControlAuth(self._api_key),
+            auth=_AgentControlAuth(self._api_key, self._api_key_header),
             transport=self._transport,
             event_hooks={"response": [self._check_server_version]},
         )

--- a/sdks/python/src/agent_control/client.py
+++ b/sdks/python/src/agent_control/client.py
@@ -20,8 +20,8 @@ _logger = logging.getLogger(__name__)
 
 _RUNTIME_AUTH_MODE_ENV_VAR = "AGENT_CONTROL_RUNTIME_AUTH_MODE"
 _DEFAULT_RUNTIME_TOKEN_REFRESH_MARGIN_SECONDS = 30
-_AUTO_RUNTIME_TOKEN_FALLBACK_STATUSES = {404, 503}
-_GLOBAL_RUNTIME_TOKEN_FALLBACK_STATUSES = {404, 503}
+_AUTO_RUNTIME_TOKEN_FALLBACK_STATUSES = {404, 500, 502, 503, 504}
+_GLOBAL_RUNTIME_TOKEN_FALLBACK_STATUSES = {404}
 
 
 class _AgentControlAuth(httpx.Auth):
@@ -248,8 +248,10 @@ class AgentControlClient:
             headers=request_headers,
         )
 
-        if response.status_code == 401 and runtime_authorization is not None:
+        if _should_refresh_runtime_token(response) and runtime_authorization is not None:
             await response.aread()
+            if target_type is not None and target_id is not None:
+                self._runtime_token_cache.remove(self.base_url, target_type, target_id)
             runtime_authorization = await self._runtime_authorization(
                 target_type=target_type,
                 target_id=target_id,
@@ -262,6 +264,13 @@ class AgentControlClient:
                 json=json,
                 headers=request_headers,
             )
+            if (
+                _should_refresh_runtime_token(response)
+                and target_type is not None
+                and target_id is not None
+            ):
+                await response.aread()
+                self._runtime_token_cache.remove(self.base_url, target_type, target_id)
 
         return response
 
@@ -320,6 +329,14 @@ class AgentControlClient:
             target_id,
         )
         async with exchange_lock:
+            if (
+                self._runtime_auth_mode == "auto"
+                and not force_refresh
+                and self._runtime_token_cache.is_jwt_unavailable(
+                    self.base_url, target_type, target_id
+                )
+            ):
+                return None
             if not force_refresh:
                 cached = self._runtime_token_cache.get(
                     self.base_url,
@@ -347,10 +364,20 @@ class AgentControlClient:
         allow_auto_fallback: bool = True,
     ) -> str | None:
         """Exchange the configured credential for a target-bound runtime token."""
-        response = await self.http_client.post(
-            "/api/v1/auth/runtime-token-exchange",
-            json={"target_type": target_type, "target_id": target_id},
-        )
+        try:
+            response = await self.http_client.post(
+                "/api/v1/auth/runtime-token-exchange",
+                json={"target_type": target_type, "target_id": target_id},
+            )
+        except httpx.RequestError:
+            if self._runtime_auth_mode == "auto" and allow_auto_fallback:
+                self._runtime_token_cache.mark_jwt_unavailable(
+                    server_url=self.base_url,
+                    target_type=target_type,
+                    target_id=target_id,
+                )
+                return None
+            raise
 
         if (
             self._runtime_auth_mode == "auto"
@@ -373,5 +400,18 @@ class AgentControlClient:
             cast(dict[str, object], payload),
             server_url=self.base_url,
         )
+        if token.target_type != target_type or token.target_id != target_id:
+            raise RuntimeError(
+                "Runtime token exchange response target did not match the requested target."
+            )
         self._runtime_token_cache.set(token)
         return token.token
+
+
+def _should_refresh_runtime_token(response: httpx.Response) -> bool:
+    if response.status_code == 401:
+        return True
+    if response.status_code != 403:
+        return False
+    authenticate = response.headers.get("WWW-Authenticate", "")
+    return "invalid_token" in authenticate.lower()

--- a/sdks/python/src/agent_control/client.py
+++ b/sdks/python/src/agent_control/client.py
@@ -2,13 +2,42 @@
 
 import logging
 import os
+from collections.abc import Generator
 from types import TracebackType
+from typing import Any, cast
 
 import httpx
 
 from . import __version__ as sdk_version
+from .runtime_auth import (
+    RuntimeAuthMode,
+    RuntimeTokenCache,
+    normalize_runtime_auth_mode,
+    parse_runtime_token_exchange_response,
+)
 
 _logger = logging.getLogger(__name__)
+
+_RUNTIME_AUTH_MODE_ENV_VAR = "AGENT_CONTROL_RUNTIME_AUTH_MODE"
+_DEFAULT_RUNTIME_TOKEN_REFRESH_MARGIN_SECONDS = 30
+_AUTO_RUNTIME_TOKEN_FALLBACK_STATUSES = {404, 503}
+_GLOBAL_RUNTIME_TOKEN_FALLBACK_STATUSES = {404, 503}
+
+
+class _AgentControlAuth(httpx.Auth):
+    """Attach local API-key credentials unless a request already has Bearer auth."""
+
+    def __init__(self, api_key: str | None) -> None:
+        self._api_key = api_key
+
+    def auth_flow(
+        self,
+        request: httpx.Request,
+    ) -> Generator[httpx.Request, httpx.Response, None]:
+        if self._api_key and "Authorization" not in request.headers:
+            if "X-API-Key" not in request.headers:
+                request.headers["X-API-Key"] = self._api_key
+        yield request
 
 
 class AgentControlClient:
@@ -45,6 +74,10 @@ class AgentControlClient:
         base_url: str | None = None,
         timeout: float = 30.0,
         api_key: str | None = None,
+        runtime_auth_mode: RuntimeAuthMode | str | None = None,
+        runtime_token_cache: RuntimeTokenCache | None = None,
+        runtime_token_refresh_margin_seconds: int = (_DEFAULT_RUNTIME_TOKEN_REFRESH_MARGIN_SECONDS),
+        transport: httpx.AsyncBaseTransport | None = None,
     ):
         """
         Initialize the client.
@@ -55,6 +88,15 @@ class AgentControlClient:
             timeout: Request timeout in seconds
             api_key: API key for authentication. If not provided, will attempt
                      to read from AGENT_CONTROL_API_KEY environment variable.
+            runtime_auth_mode: Runtime auth mode for evaluation requests. ``auto``
+                attempts target-bound JWT exchange and falls back to normal
+                request auth when the exchange endpoint is unavailable. ``jwt``
+                requires a successful exchange. ``api_key`` and ``none`` keep
+                evaluation requests on the normal request-auth path.
+            runtime_token_cache: Optional cache shared across client instances.
+            runtime_token_refresh_margin_seconds: Refresh cached runtime tokens
+                before this many seconds of validity remain.
+            transport: Optional httpx transport, primarily for tests.
         """
         resolved_base_url = base_url or os.environ.get(
             self.BASE_URL_ENV_VAR, "http://localhost:8000"
@@ -62,6 +104,13 @@ class AgentControlClient:
         self.base_url = resolved_base_url.rstrip("/")
         self.timeout = timeout
         self._api_key = api_key or os.environ.get(self.API_KEY_ENV_VAR)
+        configured_runtime_mode = runtime_auth_mode or os.environ.get(_RUNTIME_AUTH_MODE_ENV_VAR)
+        self._runtime_auth_mode = normalize_runtime_auth_mode(configured_runtime_mode)
+        if runtime_token_refresh_margin_seconds < 0:
+            raise ValueError("runtime_token_refresh_margin_seconds must be >= 0.")
+        self._runtime_token_refresh_margin_seconds = runtime_token_refresh_margin_seconds
+        self._runtime_token_cache = runtime_token_cache or RuntimeTokenCache()
+        self._transport = transport
         self._client: httpx.AsyncClient | None = None
         self._server_version_warning_emitted = False
 
@@ -70,15 +119,17 @@ class AgentControlClient:
         """Get the configured API key (read-only)."""
         return self._api_key
 
+    @property
+    def runtime_auth_mode(self) -> RuntimeAuthMode:
+        """Get the configured runtime auth mode (read-only)."""
+        return self._runtime_auth_mode
+
     def _get_headers(self) -> dict[str, str]:
-        """Build request headers including authentication."""
-        headers: dict[str, str] = {
+        """Build base SDK metadata headers."""
+        return {
             "X-Agent-Control-SDK": "python",
             "X-Agent-Control-SDK-Version": sdk_version,
         }
-        if self._api_key:
-            headers["X-API-Key"] = self._api_key
-        return headers
 
     async def _check_server_version(self, response: httpx.Response) -> None:
         """Warn once when the server major version differs from the SDK major."""
@@ -108,6 +159,8 @@ class AgentControlClient:
             base_url=self.base_url,
             timeout=self.timeout,
             headers=self._get_headers(),
+            auth=_AgentControlAuth(self._api_key),
+            transport=self._transport,
             event_hooks={"response": [self._check_server_version]},
         )
         return self
@@ -137,6 +190,7 @@ class AgentControlClient:
         response = await self._client.get("/health")
         response.raise_for_status()
         from typing import cast
+
         return cast(dict[str, str], response.json())
 
     @property
@@ -145,3 +199,151 @@ class AgentControlClient:
         if self._client is None:
             raise RuntimeError("Client not initialized. Use 'async with' context manager.")
         return self._client
+
+    async def post_runtime_evaluation(
+        self,
+        *,
+        json: dict[str, Any],
+        headers: dict[str, str] | None = None,
+        target_type: str | None = None,
+        target_id: str | None = None,
+    ) -> httpx.Response:
+        """POST an evaluation request with runtime auth when configured."""
+        runtime_authorization = await self._runtime_authorization(
+            target_type=target_type,
+            target_id=target_id,
+        )
+        request_headers = self._merge_runtime_headers(headers, runtime_authorization)
+        response = await self.http_client.post(
+            "/api/v1/evaluation",
+            json=json,
+            headers=request_headers,
+        )
+
+        if response.status_code == 401 and runtime_authorization is not None:
+            await response.aread()
+            runtime_authorization = await self._runtime_authorization(
+                target_type=target_type,
+                target_id=target_id,
+                force_refresh=True,
+                allow_auto_fallback=False,
+            )
+            request_headers = self._merge_runtime_headers(headers, runtime_authorization)
+            response = await self.http_client.post(
+                "/api/v1/evaluation",
+                json=json,
+                headers=request_headers,
+            )
+
+        return response
+
+    def _merge_runtime_headers(
+        self,
+        headers: dict[str, str] | None,
+        runtime_authorization: str | None,
+    ) -> dict[str, str] | None:
+        """Merge caller headers with an optional Bearer token."""
+        if headers is None and runtime_authorization is None:
+            return None
+
+        merged = dict(headers or {})
+        if runtime_authorization is not None:
+            merged["Authorization"] = runtime_authorization
+        return merged
+
+    async def _runtime_authorization(
+        self,
+        *,
+        target_type: str | None,
+        target_id: str | None,
+        force_refresh: bool = False,
+        allow_auto_fallback: bool = True,
+    ) -> str | None:
+        """Return an Authorization header value for runtime evaluation."""
+        if self._runtime_auth_mode in {"none", "api_key"}:
+            return None
+
+        if target_type is None or target_id is None:
+            if self._runtime_auth_mode == "jwt":
+                raise RuntimeError(
+                    "runtime_auth_mode='jwt' requires target_type and target_id "
+                    "for evaluation requests."
+                )
+            return None
+
+        if self._runtime_auth_mode == "auto" and self._runtime_token_cache.is_jwt_unavailable(
+            self.base_url, target_type, target_id
+        ):
+            return None
+
+        if not force_refresh:
+            cached = self._runtime_token_cache.get(
+                self.base_url,
+                target_type,
+                target_id,
+                refresh_margin_seconds=self._runtime_token_refresh_margin_seconds,
+            )
+            if cached is not None:
+                return f"Bearer {cached.token}"
+
+        exchange_lock = self._runtime_token_cache.exchange_lock(
+            self.base_url,
+            target_type,
+            target_id,
+        )
+        async with exchange_lock:
+            if not force_refresh:
+                cached = self._runtime_token_cache.get(
+                    self.base_url,
+                    target_type,
+                    target_id,
+                    refresh_margin_seconds=self._runtime_token_refresh_margin_seconds,
+                )
+                if cached is not None:
+                    return f"Bearer {cached.token}"
+
+            token = await self._exchange_runtime_token(
+                target_type=target_type,
+                target_id=target_id,
+                allow_auto_fallback=allow_auto_fallback,
+            )
+        if token is None:
+            return None
+        return f"Bearer {token}"
+
+    async def _exchange_runtime_token(
+        self,
+        *,
+        target_type: str,
+        target_id: str,
+        allow_auto_fallback: bool = True,
+    ) -> str | None:
+        """Exchange the configured credential for a target-bound runtime token."""
+        response = await self.http_client.post(
+            "/api/v1/auth/runtime-token-exchange",
+            json={"target_type": target_type, "target_id": target_id},
+        )
+
+        if (
+            self._runtime_auth_mode == "auto"
+            and allow_auto_fallback
+            and response.status_code in _AUTO_RUNTIME_TOKEN_FALLBACK_STATUSES
+        ):
+            self._runtime_token_cache.mark_jwt_unavailable(
+                server_url=self.base_url,
+                target_type=target_type,
+                target_id=target_id,
+                globally=response.status_code in _GLOBAL_RUNTIME_TOKEN_FALLBACK_STATUSES,
+            )
+            return None
+
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise RuntimeError("Runtime token exchange response was not an object.")
+        token = parse_runtime_token_exchange_response(
+            cast(dict[str, object], payload),
+            server_url=self.base_url,
+        )
+        self._runtime_token_cache.set(token)
+        return token.token

--- a/sdks/python/src/agent_control/client.py
+++ b/sdks/python/src/agent_control/client.py
@@ -1,5 +1,6 @@
 """Base HTTP client for Agent Control server communication."""
 
+import hashlib
 import logging
 import os
 from collections.abc import Generator
@@ -22,6 +23,15 @@ _RUNTIME_AUTH_MODE_ENV_VAR = "AGENT_CONTROL_RUNTIME_AUTH_MODE"
 _DEFAULT_RUNTIME_TOKEN_REFRESH_MARGIN_SECONDS = 30
 _AUTO_RUNTIME_TOKEN_FALLBACK_STATUSES = {404, 500, 502, 503, 504}
 _GLOBAL_RUNTIME_TOKEN_FALLBACK_STATUSES = {404}
+
+
+def _runtime_cache_identity(api_key: str | None, api_key_header: str) -> str:
+    """Return a stable cache identity without storing the raw credential."""
+    normalized_header = api_key_header.lower()
+    if not api_key:
+        return f"api_key:{normalized_header}:anonymous"
+    digest = hashlib.sha256(api_key.encode("utf-8")).hexdigest()
+    return f"api_key:{normalized_header}:{digest}"
 
 
 class _AgentControlAuth(httpx.Auth):
@@ -127,6 +137,7 @@ class AgentControlClient:
             or os.environ.get(self.API_KEY_HEADER_ENV_VAR)
             or self.DEFAULT_API_KEY_HEADER
         )
+        self._runtime_cache_identity = _runtime_cache_identity(self._api_key, self._api_key_header)
         configured_runtime_mode = runtime_auth_mode or os.environ.get(_RUNTIME_AUTH_MODE_ENV_VAR)
         self._runtime_auth_mode = normalize_runtime_auth_mode(configured_runtime_mode)
         if runtime_token_refresh_margin_seconds < 0:
@@ -251,7 +262,12 @@ class AgentControlClient:
         if _should_refresh_runtime_token(response) and runtime_authorization is not None:
             await response.aread()
             if target_type is not None and target_id is not None:
-                self._runtime_token_cache.remove(self.base_url, target_type, target_id)
+                self._runtime_token_cache.remove(
+                    self.base_url,
+                    target_type,
+                    target_id,
+                    cache_identity=self._runtime_cache_identity,
+                )
             runtime_authorization = await self._runtime_authorization(
                 target_type=target_type,
                 target_id=target_id,
@@ -270,7 +286,12 @@ class AgentControlClient:
                 and target_id is not None
             ):
                 await response.aread()
-                self._runtime_token_cache.remove(self.base_url, target_type, target_id)
+                self._runtime_token_cache.remove(
+                    self.base_url,
+                    target_type,
+                    target_id,
+                    cache_identity=self._runtime_cache_identity,
+                )
 
         return response
 
@@ -308,8 +329,15 @@ class AgentControlClient:
                 )
             return None
 
-        if self._runtime_auth_mode == "auto" and self._runtime_token_cache.is_jwt_unavailable(
-            self.base_url, target_type, target_id
+        if (
+            self._runtime_auth_mode == "auto"
+            and not force_refresh
+            and self._runtime_token_cache.is_jwt_unavailable(
+                self.base_url,
+                target_type,
+                target_id,
+                cache_identity=self._runtime_cache_identity,
+            )
         ):
             return None
 
@@ -318,6 +346,7 @@ class AgentControlClient:
                 self.base_url,
                 target_type,
                 target_id,
+                cache_identity=self._runtime_cache_identity,
                 refresh_margin_seconds=self._runtime_token_refresh_margin_seconds,
             )
             if cached is not None:
@@ -327,13 +356,17 @@ class AgentControlClient:
             self.base_url,
             target_type,
             target_id,
+            cache_identity=self._runtime_cache_identity,
         )
         async with exchange_lock:
             if (
                 self._runtime_auth_mode == "auto"
                 and not force_refresh
                 and self._runtime_token_cache.is_jwt_unavailable(
-                    self.base_url, target_type, target_id
+                    self.base_url,
+                    target_type,
+                    target_id,
+                    cache_identity=self._runtime_cache_identity,
                 )
             ):
                 return None
@@ -342,6 +375,7 @@ class AgentControlClient:
                     self.base_url,
                     target_type,
                     target_id,
+                    cache_identity=self._runtime_cache_identity,
                     refresh_margin_seconds=self._runtime_token_refresh_margin_seconds,
                 )
                 if cached is not None:
@@ -381,6 +415,7 @@ class AgentControlClient:
                     server_url=self.base_url,
                     target_type=target_type,
                     target_id=target_id,
+                    cache_identity=self._runtime_cache_identity,
                 )
                 return None
             raise
@@ -401,6 +436,7 @@ class AgentControlClient:
                 server_url=self.base_url,
                 target_type=target_type,
                 target_id=target_id,
+                cache_identity=self._runtime_cache_identity,
                 globally=response.status_code in _GLOBAL_RUNTIME_TOKEN_FALLBACK_STATUSES,
             )
             return None
@@ -417,7 +453,7 @@ class AgentControlClient:
             raise RuntimeError(
                 "Runtime token exchange response target did not match the requested target."
             )
-        self._runtime_token_cache.set(token)
+        self._runtime_token_cache.set(token, cache_identity=self._runtime_cache_identity)
         return token.token
 
 

--- a/sdks/python/src/agent_control/control_decorators.py
+++ b/sdks/python/src/agent_control/control_decorators.py
@@ -40,7 +40,11 @@ from agent_control_telemetry import get_trace_context_from_provider
 
 from agent_control import AgentControlClient
 from agent_control._state import state
-from agent_control.evaluation import _resolve_session_target, check_evaluation_with_local
+from agent_control.evaluation import (
+    _post_evaluation_request,
+    _resolve_session_target,
+    check_evaluation_with_local,
+)
 from agent_control.observability import (
     get_logger,
     log_control_evaluation,
@@ -388,10 +392,12 @@ async def _evaluate(
             payload["target_type"] = target_type
             payload["target_id"] = target_id
 
-        response = await client.http_client.post(
-            "/api/v1/evaluation",
-            json=payload,
+        response = await _post_evaluation_request(
+            client,
+            request_payload=payload,
             headers=headers,
+            target_type=target_type,
+            target_id=target_id,
         )
         response.raise_for_status()
         result_dict: dict[str, Any] = response.json()

--- a/sdks/python/src/agent_control/control_decorators.py
+++ b/sdks/python/src/agent_control/control_decorators.py
@@ -39,7 +39,8 @@ from agent_control_models import Step, normalize_action
 from agent_control_telemetry import get_trace_context_from_provider
 
 from agent_control import AgentControlClient
-from agent_control.evaluation import check_evaluation_with_local
+from agent_control._state import state
+from agent_control.evaluation import _resolve_session_target, check_evaluation_with_local
 from agent_control.observability import (
     get_logger,
     log_control_evaluation,
@@ -269,7 +270,14 @@ async def _evaluate(
     if span_id:
         headers["X-Span-Id"] = span_id
 
-    async with AgentControlClient(base_url=server_url) as client:
+    target_type, target_id = _resolve_session_target(None, None)
+
+    async with AgentControlClient(
+        base_url=server_url,
+        api_key=state.api_key,
+        api_key_header=state.api_key_header,
+        runtime_token_cache=state.runtime_token_cache,
+    ) as client:
         # If we have controls, use local evaluation which handles both SDK and server controls
         if controls is not None:
             try:
@@ -282,6 +290,8 @@ async def _evaluate(
                     step=step_obj,
                     stage=stage,  # type: ignore
                     controls=controls,
+                    target_type=target_type,
+                    target_id=target_id,
                     trace_id=trace_id,
                     span_id=span_id,
                     event_agent_name=event_agent_name,
@@ -369,13 +379,18 @@ async def _evaluate(
                 )
 
         # Fallback: server-only evaluation
+        payload = {
+            "agent_name": str(agent_name),
+            "step": step,
+            "stage": stage,
+        }
+        if target_type is not None and target_id is not None:
+            payload["target_type"] = target_type
+            payload["target_id"] = target_id
+
         response = await client.http_client.post(
             "/api/v1/evaluation",
-            json={
-                "agent_name": str(agent_name),
-                "step": step,
-                "stage": stage
-            },
+            json=payload,
             headers=headers,
         )
         response.raise_for_status()

--- a/sdks/python/src/agent_control/evaluation.py
+++ b/sdks/python/src/agent_control/evaluation.py
@@ -1,8 +1,11 @@
 """Evaluation check operations for Agent Control SDK."""
 
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from inspect import iscoroutinefunction
 from typing import Any, Literal, cast
 
+import httpx
 from agent_control_engine import list_evaluators
 from agent_control_engine.core import ControlEngine
 from agent_control_models import (
@@ -21,6 +24,8 @@ from .evaluation_events import build_control_execution_events, enqueue_observabi
 from .observability import is_observability_enabled
 from .tracing import get_trace_and_span_ids
 from .validation import ensure_agent_name
+
+_RuntimePostEvaluation = Callable[..., Awaitable[httpx.Response]]
 
 
 @dataclass
@@ -43,12 +48,12 @@ def _resolve_session_target(
 ) -> tuple[str | None, str | None]:
     """Default per-call target from state, and reject mismatches.
 
-    The SDK supports one target per session, fixed at ``init()`` time —
+    The SDK supports one target per session, fixed at ``init()`` time -
     including no-target sessions, where the session target is
     ``(None, None)``. The cached controls (``state.server_controls``) are
     fetched for that session target. A per-call override that disagrees
-    with the session target — including supplying an explicit target on a
-    no-target session — would evaluate against the wrong cache and could
+    with the session target - including supplying an explicit target on a
+    no-target session - would evaluate against the wrong cache and could
     return safe without contacting the server. Reject the mismatch so
     callers re-init when they need to change targets.
 
@@ -118,7 +123,7 @@ def _has_applicable_prefiltered_server_controls(
     parsed_server_controls: list[_ControlAdapter] = []
 
     for control in server_control_payloads:
-        # Skip unrendered template controls — they have no condition to evaluate
+        # Skip unrendered template controls - they have no condition to evaluate
         # and should not trigger the server-call fallback.
         ctrl_data = control.get("control", {})
         if (
@@ -206,6 +211,41 @@ def _cached_server_control_lookup(
     return _build_server_control_lookup(state.server_controls)
 
 
+def _runtime_post_evaluation(client: Any) -> _RuntimePostEvaluation | None:
+    """Return a runtime-evaluation callable when the client exposes one."""
+    runtime_post = getattr(client, "post_runtime_evaluation", None)
+    if not callable(runtime_post) or not iscoroutinefunction(runtime_post):
+        return None
+    return cast(_RuntimePostEvaluation, runtime_post)
+
+
+async def _post_evaluation_request(
+    client: AgentControlClient,
+    *,
+    request_payload: dict[str, Any],
+    headers: dict[str, str] | None,
+    target_type: str | None,
+    target_id: str | None,
+) -> httpx.Response:
+    """Send an evaluation request, using runtime auth when the client supports it."""
+    runtime_post = None
+    if target_type is not None and target_id is not None:
+        runtime_post = _runtime_post_evaluation(client)
+    if runtime_post is not None:
+        return await runtime_post(
+            json=request_payload,
+            headers=headers,
+            target_type=target_type,
+            target_id=target_id,
+        )
+
+    return await client.http_client.post(
+        "/api/v1/evaluation",
+        json=request_payload,
+        headers=headers,
+    )
+
+
 async def check_evaluation(
     client: AgentControlClient,
     agent_name: str,
@@ -241,10 +281,12 @@ async def check_evaluation(
     )
     request_payload = request.model_dump(mode="json")
 
-    response = await client.http_client.post(
-        "/api/v1/evaluation",
-        json=request_payload,
+    response = await _post_evaluation_request(
+        client,
+        request_payload=request_payload,
         headers=None,
+        target_type=target_type,
+        target_id=target_id,
     )
     response.raise_for_status()
 
@@ -311,7 +353,7 @@ async def check_evaluation_with_local(
     for control in controls:
         control_data = control.get("control", {})
 
-        # Skip unrendered template controls — they cannot be evaluated.
+        # Skip unrendered template controls - they cannot be evaluated.
         if (
             isinstance(control_data, dict)
             and control_data.get("template") is not None
@@ -424,10 +466,12 @@ async def check_evaluation_with_local(
             headers["X-Span-Id"] = resolved_span_id
 
         try:
-            response = await client.http_client.post(
-                "/api/v1/evaluation",
-                json=request_payload,
+            response = await _post_evaluation_request(
+                client,
+                request_payload=request_payload,
                 headers=headers,
+                target_type=target_type,
+                target_id=target_id,
             )
             response.raise_for_status()
             server_result = EvaluationResponse.model_validate(response.json())
@@ -510,7 +554,11 @@ async def evaluate_controls(
     step_obj = Step(**step_dict)  # type: ignore[arg-type]
     resolved_controls = state.server_controls or []
 
-    async with AgentControlClient(base_url=state.server_url, api_key=state.api_key) as client:
+    async with AgentControlClient(
+        base_url=state.server_url,
+        api_key=state.api_key,
+        runtime_token_cache=state.runtime_token_cache,
+    ) as client:
         return await check_evaluation_with_local(
             client=client,
             agent_name=agent_name,

--- a/sdks/python/src/agent_control/evaluation.py
+++ b/sdks/python/src/agent_control/evaluation.py
@@ -557,6 +557,7 @@ async def evaluate_controls(
     async with AgentControlClient(
         base_url=state.server_url,
         api_key=state.api_key,
+        api_key_header=state.api_key_header,
         runtime_token_cache=state.runtime_token_cache,
     ) as client:
         return await check_evaluation_with_local(

--- a/sdks/python/src/agent_control/evaluation.py
+++ b/sdks/python/src/agent_control/evaluation.py
@@ -229,7 +229,7 @@ async def _post_evaluation_request(
 ) -> httpx.Response:
     """Send an evaluation request, using runtime auth when the client supports it."""
     runtime_post = None
-    if target_type is not None and target_id is not None:
+    if (target_type is not None and target_id is not None) or client.runtime_auth_mode == "jwt":
         runtime_post = _runtime_post_evaluation(client)
     if runtime_post is not None:
         return await runtime_post(

--- a/sdks/python/src/agent_control/evaluation.py
+++ b/sdks/python/src/agent_control/evaluation.py
@@ -229,7 +229,9 @@ async def _post_evaluation_request(
 ) -> httpx.Response:
     """Send an evaluation request, using runtime auth when the client supports it."""
     runtime_post = None
-    if (target_type is not None and target_id is not None) or client.runtime_auth_mode == "jwt":
+    if (target_type is not None and target_id is not None) or getattr(
+        client, "runtime_auth_mode", "auto"
+    ) == "jwt":
         runtime_post = _runtime_post_evaluation(client)
     if runtime_post is not None:
         return await runtime_post(

--- a/sdks/python/src/agent_control/integrations/google_adk/plugin.py
+++ b/sdks/python/src/agent_control/integrations/google_adk/plugin.py
@@ -853,7 +853,11 @@ class AgentControlPlugin(BasePlugin):
                 "with the same agent_name as AgentControlPlugin."
             )
 
-        async with AgentControlClient(base_url=state.server_url, api_key=state.api_key) as client:
+        async with AgentControlClient(
+            base_url=state.server_url,
+            api_key=state.api_key,
+            api_key_header=state.api_key_header,
+        ) as client:
             response = await agents.get_agent(client, self.agent_name)
             existing = GetAgentResponse.model_validate(response)
             existing_keys = {(step.type, step.name) for step in existing.steps}

--- a/sdks/python/src/agent_control/observability.py
+++ b/sdks/python/src/agent_control/observability.py
@@ -26,6 +26,9 @@ Event Batching Usage:
     await shutdown_observability()
 
 Configuration (Environment Variables):
+    # Server connection
+    AGENT_CONTROL_API_KEY_HEADER: API key header name (default: X-API-Key)
+
     # Observability (event batching)
     AGENT_CONTROL_OBSERVABILITY_ENABLED: Enable observability (default: true)
     AGENT_CONTROL_OBSERVABILITY_SINK_NAME: Selected control-event sink (default: default)
@@ -286,6 +289,7 @@ class EventBatcher:
     Attributes:
         server_url: Base URL of the Agent Control server
         api_key: API key for authentication
+        api_key_header: HTTP header used to send the API key
         batch_size: Maximum events per batch
         flush_interval: Seconds between automatic flushes
     """
@@ -294,6 +298,7 @@ class EventBatcher:
         self,
         server_url: str | None = None,
         api_key: str | None = None,
+        api_key_header: str | None = None,
         batch_size: int | None = None,
         flush_interval: float | None = None,
     ):
@@ -303,11 +308,13 @@ class EventBatcher:
         Args:
             server_url: Server URL (defaults to get_settings().url)
             api_key: API key (defaults to get_settings().api_key)
+            api_key_header: API key header (defaults to get_settings().api_key_header)
             batch_size: Max events per batch (defaults to get_settings().batch_size)
             flush_interval: Seconds between flushes (defaults to get_settings().flush_interval)
         """
         self.server_url = server_url or get_settings().url
         self.api_key = api_key or get_settings().api_key
+        self.api_key_header = api_key_header or get_settings().api_key_header
         self.batch_size = batch_size if batch_size is not None else get_settings().batch_size
         if flush_interval is not None:
             self.flush_interval = flush_interval
@@ -424,7 +431,7 @@ class EventBatcher:
         url = f"{self.server_url}/api/v1/observability/events"
         headers = {"Content-Type": "application/json"}
         if self.api_key:
-            headers["X-API-Key"] = self.api_key
+            headers[self.api_key_header] = self.api_key
         payload = {"events": [event.model_dump(mode="json") for event in events]}
         return url, headers, payload
 
@@ -1098,6 +1105,7 @@ def _get_custom_control_event_sinks_to_shutdown() -> tuple[ControlEventSink, ...
 def init_observability(
     server_url: str | None = None,
     api_key: str | None = None,
+    api_key_header: str | None = None,
     enabled: bool | None = None,
     sink_name: str | None = None,
     sink_config: JSONObject | None = None,
@@ -1110,6 +1118,7 @@ def init_observability(
     Args:
         server_url: Server URL for sending events
         api_key: API key for authentication
+        api_key_header: HTTP header used to send the API key
         enabled: Override AGENT_CONTROL_OBSERVABILITY_ENABLED
         sink_name: Override AGENT_CONTROL_OBSERVABILITY_SINK_NAME
         sink_config: Override AGENT_CONTROL_OBSERVABILITY_SINK_CONFIG
@@ -1157,7 +1166,11 @@ def init_observability(
         return _batcher
 
     # Create batcher
-    _batcher = EventBatcher(server_url=server_url, api_key=api_key)
+    _batcher = EventBatcher(
+        server_url=server_url,
+        api_key=api_key,
+        api_key_header=api_key_header,
+    )
     _batcher.start()
     _event_sink = _BatcherControlEventSink(_batcher)
 

--- a/sdks/python/src/agent_control/runtime_auth.py
+++ b/sdks/python/src/agent_control/runtime_auth.py
@@ -1,0 +1,194 @@
+"""Runtime-token cache helpers for the Agent Control SDK."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Literal
+
+RuntimeAuthMode = Literal["auto", "none", "api_key", "jwt"]
+
+_TokenKey = tuple[str, str, str]
+_DEFAULT_MAX_CACHE_ENTRIES = 256
+
+
+@dataclass(frozen=True)
+class RuntimeToken:
+    """Short-lived runtime token bound to one target."""
+
+    token: str
+    expires_at: datetime
+    server_url: str
+    target_type: str
+    target_id: str
+    scopes: tuple[str, ...]
+
+    def is_fresh(self, *, refresh_margin_seconds: int) -> bool:
+        """Return whether the token is usable beyond the refresh margin."""
+        refresh_at = datetime.now(UTC) + timedelta(seconds=refresh_margin_seconds)
+        return self.expires_at > refresh_at
+
+
+class RuntimeTokenCache:
+    """Thread-safe runtime token cache keyed by server and target."""
+
+    def __init__(self, *, max_entries: int = _DEFAULT_MAX_CACHE_ENTRIES) -> None:
+        if max_entries < 1:
+            raise ValueError("max_entries must be >= 1.")
+        self._max_entries = max_entries
+        self._tokens: dict[_TokenKey, RuntimeToken] = {}
+        self._jwt_unavailable = False
+        self._jwt_unavailable_targets: set[_TokenKey] = set()
+        self._exchange_locks: dict[_TokenKey, asyncio.Lock] = {}
+        self._lock = threading.Lock()
+
+    def get(
+        self,
+        server_url: str,
+        target_type: str,
+        target_id: str,
+        *,
+        refresh_margin_seconds: int,
+    ) -> RuntimeToken | None:
+        """Return a fresh cached token for the target, if present."""
+        key = (server_url, target_type, target_id)
+        with self._lock:
+            token = self._tokens.get(key)
+            if token is None:
+                return None
+            if token.is_fresh(refresh_margin_seconds=refresh_margin_seconds):
+                return token
+            self._tokens.pop(key, None)
+            return None
+
+    def set(self, token: RuntimeToken) -> None:
+        """Store a token and clear any fallback marker for its target."""
+        key = (token.server_url, token.target_type, token.target_id)
+        with self._lock:
+            if key not in self._tokens and len(self._tokens) >= self._max_entries:
+                oldest_key = next(iter(self._tokens))
+                self._tokens.pop(oldest_key, None)
+                self._jwt_unavailable_targets.discard(oldest_key)
+                self._exchange_locks.pop(oldest_key, None)
+            self._tokens[key] = token
+            self._jwt_unavailable_targets.discard(key)
+
+    def remove(self, server_url: str, target_type: str, target_id: str) -> None:
+        """Drop the cached token for one target."""
+        with self._lock:
+            self._tokens.pop((server_url, target_type, target_id), None)
+
+    def mark_jwt_unavailable(
+        self,
+        *,
+        server_url: str | None = None,
+        target_type: str | None = None,
+        target_id: str | None = None,
+        globally: bool = False,
+    ) -> None:
+        """Record that JWT runtime auth should not be attempted."""
+        with self._lock:
+            if globally:
+                self._jwt_unavailable = True
+                self._tokens.clear()
+                return
+            if server_url is not None and target_type is not None and target_id is not None:
+                key = (server_url, target_type, target_id)
+                if (
+                    key not in self._jwt_unavailable_targets
+                    and len(self._jwt_unavailable_targets) >= self._max_entries
+                ):
+                    evicted_key = self._jwt_unavailable_targets.pop()
+                    self._exchange_locks.pop(evicted_key, None)
+                self._jwt_unavailable_targets.add(key)
+                self._tokens.pop(key, None)
+
+    def is_jwt_unavailable(self, server_url: str, target_type: str, target_id: str) -> bool:
+        """Return whether JWT exchange is known unavailable for the target."""
+        key = (server_url, target_type, target_id)
+        with self._lock:
+            return self._jwt_unavailable or key in self._jwt_unavailable_targets
+
+    def clear(self) -> None:
+        """Clear every cached token and fallback marker."""
+        with self._lock:
+            self._tokens.clear()
+            self._jwt_unavailable = False
+            self._jwt_unavailable_targets.clear()
+            self._exchange_locks.clear()
+
+    def exchange_lock(self, server_url: str, target_type: str, target_id: str) -> asyncio.Lock:
+        """Return the async exchange lock for one server and target."""
+        key = (server_url, target_type, target_id)
+        with self._lock:
+            lock = self._exchange_locks.get(key)
+            if lock is None:
+                lock = asyncio.Lock()
+                self._exchange_locks[key] = lock
+            return lock
+
+
+def normalize_runtime_auth_mode(raw: str | None) -> RuntimeAuthMode:
+    """Normalize configured SDK runtime auth mode."""
+    if raw is None or not raw.strip():
+        return "auto"
+
+    mode = raw.strip().lower()
+    if mode in {"none", "no_auth"}:
+        return "none"
+    if mode in {"api_key", "header"}:
+        return "api_key"
+    if mode == "auto":
+        return "auto"
+    if mode == "jwt":
+        return "jwt"
+    raise ValueError("runtime_auth_mode must be one of 'auto', 'none', 'api_key', or 'jwt'.")
+
+
+def parse_runtime_token_exchange_response(
+    payload: Mapping[str, object],
+    *,
+    server_url: str,
+) -> RuntimeToken:
+    """Parse the runtime token exchange response payload."""
+    token = payload.get("token")
+    expires_at = payload.get("expires_at")
+    target_type = payload.get("target_type")
+    target_id = payload.get("target_id")
+    scopes = payload.get("scopes")
+
+    if not isinstance(token, str) or not token:
+        raise RuntimeError("Runtime token exchange response did not include a token.")
+    if not isinstance(expires_at, str) or not expires_at:
+        raise RuntimeError("Runtime token exchange response did not include expires_at.")
+    if not isinstance(target_type, str) or not target_type:
+        raise RuntimeError("Runtime token exchange response did not include target_type.")
+    if not isinstance(target_id, str) or not target_id:
+        raise RuntimeError("Runtime token exchange response did not include target_id.")
+    if not isinstance(scopes, Sequence) or isinstance(scopes, str):
+        raise RuntimeError("Runtime token exchange response did not include scopes.")
+
+    parsed_scopes: list[str] = []
+    for scope in scopes:
+        if not isinstance(scope, str):
+            raise RuntimeError("Runtime token exchange response included a non-string scope.")
+        parsed_scopes.append(scope)
+
+    normalized_expires_at = expires_at
+    if normalized_expires_at.endswith("Z"):
+        normalized_expires_at = f"{normalized_expires_at[:-1]}+00:00"
+    parsed_expires_at = datetime.fromisoformat(normalized_expires_at)
+    if parsed_expires_at.tzinfo is None:
+        parsed_expires_at = parsed_expires_at.replace(tzinfo=UTC)
+
+    return RuntimeToken(
+        token=token,
+        expires_at=parsed_expires_at.astimezone(UTC),
+        server_url=server_url,
+        target_type=target_type,
+        target_id=target_id,
+        scopes=tuple(parsed_scopes),
+    )

--- a/sdks/python/src/agent_control/runtime_auth.py
+++ b/sdks/python/src/agent_control/runtime_auth.py
@@ -5,21 +5,23 @@ from __future__ import annotations
 import asyncio
 import threading
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Literal
 
 RuntimeAuthMode = Literal["auto", "none", "api_key", "jwt"]
 
 _TokenKey = tuple[str, str, str]
+_LockKey = tuple[str, str, str, int]
 _DEFAULT_MAX_CACHE_ENTRIES = 256
+_DEFAULT_JWT_UNAVAILABLE_TTL_SECONDS = 30
 
 
 @dataclass(frozen=True)
 class RuntimeToken:
     """Short-lived runtime token bound to one target."""
 
-    token: str
+    token: str = field(repr=False)
     expires_at: datetime
     server_url: str
     target_type: str
@@ -41,8 +43,8 @@ class RuntimeTokenCache:
         self._max_entries = max_entries
         self._tokens: dict[_TokenKey, RuntimeToken] = {}
         self._jwt_unavailable = False
-        self._jwt_unavailable_targets: set[_TokenKey] = set()
-        self._exchange_locks: dict[_TokenKey, asyncio.Lock] = {}
+        self._jwt_unavailable_targets: dict[_TokenKey, datetime] = {}
+        self._exchange_locks: dict[_LockKey, asyncio.Lock] = {}
         self._lock = threading.Lock()
 
     def get(
@@ -71,10 +73,9 @@ class RuntimeTokenCache:
             if key not in self._tokens and len(self._tokens) >= self._max_entries:
                 oldest_key = next(iter(self._tokens))
                 self._tokens.pop(oldest_key, None)
-                self._jwt_unavailable_targets.discard(oldest_key)
-                self._exchange_locks.pop(oldest_key, None)
+                self._jwt_unavailable_targets.pop(oldest_key, None)
             self._tokens[key] = token
-            self._jwt_unavailable_targets.discard(key)
+            self._jwt_unavailable_targets.pop(key, None)
 
     def remove(self, server_url: str, target_type: str, target_id: str) -> None:
         """Drop the cached token for one target."""
@@ -88,6 +89,7 @@ class RuntimeTokenCache:
         target_type: str | None = None,
         target_id: str | None = None,
         globally: bool = False,
+        ttl_seconds: int = _DEFAULT_JWT_UNAVAILABLE_TTL_SECONDS,
     ) -> None:
         """Record that JWT runtime auth should not be attempted."""
         with self._lock:
@@ -101,16 +103,25 @@ class RuntimeTokenCache:
                     key not in self._jwt_unavailable_targets
                     and len(self._jwt_unavailable_targets) >= self._max_entries
                 ):
-                    evicted_key = self._jwt_unavailable_targets.pop()
-                    self._exchange_locks.pop(evicted_key, None)
-                self._jwt_unavailable_targets.add(key)
+                    self._jwt_unavailable_targets.pop(next(iter(self._jwt_unavailable_targets)))
+                self._jwt_unavailable_targets[key] = datetime.now(UTC) + timedelta(
+                    seconds=ttl_seconds
+                )
                 self._tokens.pop(key, None)
 
     def is_jwt_unavailable(self, server_url: str, target_type: str, target_id: str) -> bool:
         """Return whether JWT exchange is known unavailable for the target."""
         key = (server_url, target_type, target_id)
         with self._lock:
-            return self._jwt_unavailable or key in self._jwt_unavailable_targets
+            if self._jwt_unavailable:
+                return True
+            expires_at = self._jwt_unavailable_targets.get(key)
+            if expires_at is None:
+                return False
+            if expires_at > datetime.now(UTC):
+                return True
+            self._jwt_unavailable_targets.pop(key, None)
+            return False
 
     def clear(self) -> None:
         """Clear every cached token and fallback marker."""
@@ -118,11 +129,10 @@ class RuntimeTokenCache:
             self._tokens.clear()
             self._jwt_unavailable = False
             self._jwt_unavailable_targets.clear()
-            self._exchange_locks.clear()
 
     def exchange_lock(self, server_url: str, target_type: str, target_id: str) -> asyncio.Lock:
         """Return the async exchange lock for one server and target."""
-        key = (server_url, target_type, target_id)
+        key = (server_url, target_type, target_id, id(asyncio.get_running_loop()))
         with self._lock:
             lock = self._exchange_locks.get(key)
             if lock is None:

--- a/sdks/python/src/agent_control/runtime_auth.py
+++ b/sdks/python/src/agent_control/runtime_auth.py
@@ -11,8 +11,8 @@ from typing import Literal
 
 RuntimeAuthMode = Literal["auto", "none", "api_key", "jwt"]
 
-_TokenKey = tuple[str, str, str]
-_LockKey = tuple[str, str, str, asyncio.AbstractEventLoop]
+_TokenKey = tuple[str, str, str, str]
+_LockKey = tuple[str, str, str, str, asyncio.AbstractEventLoop]
 _DEFAULT_MAX_CACHE_ENTRIES = 256
 _DEFAULT_JWT_UNAVAILABLE_TTL_SECONDS = 30
 
@@ -62,10 +62,11 @@ class RuntimeTokenCache:
         target_type: str,
         target_id: str,
         *,
+        cache_identity: str = "",
         refresh_margin_seconds: int,
     ) -> RuntimeToken | None:
         """Return a fresh cached token for the target, if present."""
-        key = (server_url, target_type, target_id)
+        key = (server_url, cache_identity, target_type, target_id)
         with self._lock:
             token = self._tokens.get(key)
             if token is None:
@@ -75,9 +76,9 @@ class RuntimeTokenCache:
             self._tokens.pop(key, None)
             return None
 
-    def set(self, token: RuntimeToken) -> None:
+    def set(self, token: RuntimeToken, *, cache_identity: str = "") -> None:
         """Store a token and clear any fallback marker for its target."""
-        key = (token.server_url, token.target_type, token.target_id)
+        key = (token.server_url, cache_identity, token.target_type, token.target_id)
         with self._lock:
             if key not in self._tokens and len(self._tokens) >= self._max_entries:
                 oldest_key = next(iter(self._tokens))
@@ -87,10 +88,17 @@ class RuntimeTokenCache:
             self._jwt_unavailable_servers.pop(token.server_url, None)
             self._jwt_unavailable_targets.pop(key, None)
 
-    def remove(self, server_url: str, target_type: str, target_id: str) -> None:
+    def remove(
+        self,
+        server_url: str,
+        target_type: str,
+        target_id: str,
+        *,
+        cache_identity: str = "",
+    ) -> None:
         """Drop the cached token for one target."""
         with self._lock:
-            self._tokens.pop((server_url, target_type, target_id), None)
+            self._tokens.pop((server_url, cache_identity, target_type, target_id), None)
 
     def mark_jwt_unavailable(
         self,
@@ -98,6 +106,7 @@ class RuntimeTokenCache:
         server_url: str | None = None,
         target_type: str | None = None,
         target_id: str | None = None,
+        cache_identity: str = "",
         globally: bool = False,
         ttl_seconds: int | None = None,
     ) -> None:
@@ -125,7 +134,7 @@ class RuntimeTokenCache:
                 self._drop_server_entries_locked(server_url)
                 return
             if server_url is not None and target_type is not None and target_id is not None:
-                key = (server_url, target_type, target_id)
+                key = (server_url, cache_identity, target_type, target_id)
                 if (
                     key not in self._jwt_unavailable_targets
                     and len(self._jwt_unavailable_targets) >= self._max_entries
@@ -134,9 +143,16 @@ class RuntimeTokenCache:
                 self._jwt_unavailable_targets[key] = expires_at
                 self._tokens.pop(key, None)
 
-    def is_jwt_unavailable(self, server_url: str, target_type: str, target_id: str) -> bool:
+    def is_jwt_unavailable(
+        self,
+        server_url: str,
+        target_type: str,
+        target_id: str,
+        *,
+        cache_identity: str = "",
+    ) -> bool:
         """Return whether JWT exchange is known unavailable for the target."""
-        key = (server_url, target_type, target_id)
+        key = (server_url, cache_identity, target_type, target_id)
         with self._lock:
             self._prune_expired_unavailable_markers_locked()
             if self._jwt_unavailable_until is not None:
@@ -154,9 +170,16 @@ class RuntimeTokenCache:
             self._jwt_unavailable_servers.clear()
             self._jwt_unavailable_targets.clear()
 
-    def exchange_lock(self, server_url: str, target_type: str, target_id: str) -> asyncio.Lock:
+    def exchange_lock(
+        self,
+        server_url: str,
+        target_type: str,
+        target_id: str,
+        *,
+        cache_identity: str = "",
+    ) -> asyncio.Lock:
         """Return the async exchange lock for one server and target."""
-        key = (server_url, target_type, target_id, asyncio.get_running_loop())
+        key = (server_url, cache_identity, target_type, target_id, asyncio.get_running_loop())
         with self._lock:
             lock = self._exchange_locks.get(key)
             if lock is None:

--- a/sdks/python/src/agent_control/runtime_auth.py
+++ b/sdks/python/src/agent_control/runtime_auth.py
@@ -12,7 +12,7 @@ from typing import Literal
 RuntimeAuthMode = Literal["auto", "none", "api_key", "jwt"]
 
 _TokenKey = tuple[str, str, str]
-_LockKey = tuple[str, str, str, int]
+_LockKey = tuple[str, str, str, asyncio.AbstractEventLoop]
 _DEFAULT_MAX_CACHE_ENTRIES = 256
 _DEFAULT_JWT_UNAVAILABLE_TTL_SECONDS = 30
 
@@ -37,12 +37,21 @@ class RuntimeToken:
 class RuntimeTokenCache:
     """Thread-safe runtime token cache keyed by server and target."""
 
-    def __init__(self, *, max_entries: int = _DEFAULT_MAX_CACHE_ENTRIES) -> None:
+    def __init__(
+        self,
+        *,
+        max_entries: int = _DEFAULT_MAX_CACHE_ENTRIES,
+        jwt_unavailable_ttl_seconds: int = _DEFAULT_JWT_UNAVAILABLE_TTL_SECONDS,
+    ) -> None:
         if max_entries < 1:
             raise ValueError("max_entries must be >= 1.")
+        if jwt_unavailable_ttl_seconds < 0:
+            raise ValueError("jwt_unavailable_ttl_seconds must be >= 0.")
         self._max_entries = max_entries
+        self._jwt_unavailable_ttl_seconds = jwt_unavailable_ttl_seconds
         self._tokens: dict[_TokenKey, RuntimeToken] = {}
-        self._jwt_unavailable = False
+        self._jwt_unavailable_until: datetime | None = None
+        self._jwt_unavailable_servers: dict[str, datetime] = {}
         self._jwt_unavailable_targets: dict[_TokenKey, datetime] = {}
         self._exchange_locks: dict[_LockKey, asyncio.Lock] = {}
         self._lock = threading.Lock()
@@ -75,6 +84,7 @@ class RuntimeTokenCache:
                 self._tokens.pop(oldest_key, None)
                 self._jwt_unavailable_targets.pop(oldest_key, None)
             self._tokens[key] = token
+            self._jwt_unavailable_servers.pop(token.server_url, None)
             self._jwt_unavailable_targets.pop(key, None)
 
     def remove(self, server_url: str, target_type: str, target_id: str) -> None:
@@ -89,13 +99,30 @@ class RuntimeTokenCache:
         target_type: str | None = None,
         target_id: str | None = None,
         globally: bool = False,
-        ttl_seconds: int = _DEFAULT_JWT_UNAVAILABLE_TTL_SECONDS,
+        ttl_seconds: int | None = None,
     ) -> None:
         """Record that JWT runtime auth should not be attempted."""
+        ttl = self._jwt_unavailable_ttl_seconds if ttl_seconds is None else ttl_seconds
+        if ttl < 0:
+            raise ValueError("ttl_seconds must be >= 0.")
+        expires_at = datetime.now(UTC) + timedelta(seconds=ttl)
         with self._lock:
+            self._prune_expired_unavailable_markers_locked()
             if globally:
-                self._jwt_unavailable = True
-                self._tokens.clear()
+                if server_url is None:
+                    self._jwt_unavailable_until = expires_at
+                    self._tokens.clear()
+                    self._jwt_unavailable_servers.clear()
+                    self._jwt_unavailable_targets.clear()
+                    return
+
+                if (
+                    server_url not in self._jwt_unavailable_servers
+                    and len(self._jwt_unavailable_servers) >= self._max_entries
+                ):
+                    self._jwt_unavailable_servers.pop(next(iter(self._jwt_unavailable_servers)))
+                self._jwt_unavailable_servers[server_url] = expires_at
+                self._drop_server_entries_locked(server_url)
                 return
             if server_url is not None and target_type is not None and target_id is not None:
                 key = (server_url, target_type, target_id)
@@ -104,41 +131,69 @@ class RuntimeTokenCache:
                     and len(self._jwt_unavailable_targets) >= self._max_entries
                 ):
                     self._jwt_unavailable_targets.pop(next(iter(self._jwt_unavailable_targets)))
-                self._jwt_unavailable_targets[key] = datetime.now(UTC) + timedelta(
-                    seconds=ttl_seconds
-                )
+                self._jwt_unavailable_targets[key] = expires_at
                 self._tokens.pop(key, None)
 
     def is_jwt_unavailable(self, server_url: str, target_type: str, target_id: str) -> bool:
         """Return whether JWT exchange is known unavailable for the target."""
         key = (server_url, target_type, target_id)
         with self._lock:
-            if self._jwt_unavailable:
+            self._prune_expired_unavailable_markers_locked()
+            if self._jwt_unavailable_until is not None:
+                return True
+            if server_url in self._jwt_unavailable_servers:
                 return True
             expires_at = self._jwt_unavailable_targets.get(key)
-            if expires_at is None:
-                return False
-            if expires_at > datetime.now(UTC):
-                return True
-            self._jwt_unavailable_targets.pop(key, None)
-            return False
+            return expires_at is not None
 
     def clear(self) -> None:
         """Clear every cached token and fallback marker."""
         with self._lock:
             self._tokens.clear()
-            self._jwt_unavailable = False
+            self._jwt_unavailable_until = None
+            self._jwt_unavailable_servers.clear()
             self._jwt_unavailable_targets.clear()
 
     def exchange_lock(self, server_url: str, target_type: str, target_id: str) -> asyncio.Lock:
         """Return the async exchange lock for one server and target."""
-        key = (server_url, target_type, target_id, id(asyncio.get_running_loop()))
+        key = (server_url, target_type, target_id, asyncio.get_running_loop())
         with self._lock:
             lock = self._exchange_locks.get(key)
             if lock is None:
+                if len(self._exchange_locks) >= self._max_entries:
+                    self._evict_idle_exchange_lock_locked()
                 lock = asyncio.Lock()
                 self._exchange_locks[key] = lock
+            else:
+                # Preserve insertion order as a simple LRU for idle-lock eviction.
+                self._exchange_locks.pop(key)
+                self._exchange_locks[key] = lock
             return lock
+
+    def _drop_server_entries_locked(self, server_url: str) -> None:
+        for key in list(self._tokens):
+            if key[0] == server_url:
+                self._tokens.pop(key, None)
+        for key in list(self._jwt_unavailable_targets):
+            if key[0] == server_url:
+                self._jwt_unavailable_targets.pop(key, None)
+
+    def _prune_expired_unavailable_markers_locked(self) -> None:
+        now = datetime.now(UTC)
+        if self._jwt_unavailable_until is not None and self._jwt_unavailable_until <= now:
+            self._jwt_unavailable_until = None
+        for server_url, expires_at in list(self._jwt_unavailable_servers.items()):
+            if expires_at <= now:
+                self._jwt_unavailable_servers.pop(server_url, None)
+        for key, expires_at in list(self._jwt_unavailable_targets.items()):
+            if expires_at <= now:
+                self._jwt_unavailable_targets.pop(key, None)
+
+    def _evict_idle_exchange_lock_locked(self) -> None:
+        for key, lock in list(self._exchange_locks.items()):
+            if not lock.locked():
+                self._exchange_locks.pop(key, None)
+                return
 
 
 def normalize_runtime_auth_mode(raw: str | None) -> RuntimeAuthMode:

--- a/sdks/python/src/agent_control/settings.py
+++ b/sdks/python/src/agent_control/settings.py
@@ -56,6 +56,10 @@ class SDKSettings(BaseSettings):
         default="",
         description="API key for server authentication",
     )
+    api_key_header: str = Field(
+        default="X-API-Key",
+        description="HTTP header used to send the API key",
+    )
 
     # Observability (event batching)
     observability_enabled: bool = Field(

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 import httpx
 import pytest
 
 from agent_control.client import AgentControlClient, sdk_version
+from agent_control.runtime_auth import RuntimeTokenCache
 
 
 def test_client_uses_agent_control_url_env_var(
@@ -36,17 +39,482 @@ def test_explicit_base_url_overrides_env_var(
     assert client.base_url == "http://explicit.test:8000"
 
 
-def test_get_headers_include_sdk_metadata_and_api_key() -> None:
+def test_get_headers_include_sdk_metadata() -> None:
     # Given: a client configured with an API key
     client = AgentControlClient(api_key="test-key")
 
     # When: building request headers
     headers = client._get_headers()
 
-    # Then: SDK metadata and authentication headers are included
+    # Then: SDK metadata headers are included
     assert headers["X-Agent-Control-SDK"] == "python"
     assert headers["X-Agent-Control-SDK-Version"] == sdk_version
-    assert headers["X-API-Key"] == "test-key"
+    assert "X-API-Key" not in headers
+
+
+def test_client_rejects_negative_runtime_token_refresh_margin() -> None:
+    with pytest.raises(ValueError, match="runtime_token_refresh_margin_seconds"):
+        AgentControlClient(runtime_token_refresh_margin_seconds=-1)
+
+
+@pytest.mark.asyncio
+async def test_client_adds_api_key_auth_to_regular_requests() -> None:
+    seen_requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_requests.append(request)
+        return httpx.Response(200, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        transport=transport,
+    ) as client:
+        response = await client.http_client.get("/api/v1/agents")
+
+    assert response.status_code == 200
+    assert seen_requests[0].headers["X-API-Key"] == "test-key"
+
+
+@pytest.mark.asyncio
+async def test_runtime_evaluation_exchanges_and_caches_bearer_token() -> None:
+    exchange_calls = 0
+    evaluation_authorization_headers: list[str | None] = []
+    evaluation_api_key_headers: list[str | None] = []
+    expires_at = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal exchange_calls
+        if request.url.path == "/api/v1/auth/runtime-token-exchange":
+            exchange_calls += 1
+            assert request.headers["X-API-Key"] == "test-key"
+            return httpx.Response(
+                200,
+                json={
+                    "token": "runtime-token",
+                    "expires_at": expires_at,
+                    "target_type": "log_stream",
+                    "target_id": "ls-1",
+                    "scopes": ["runtime.use"],
+                },
+            )
+
+        evaluation_authorization_headers.append(request.headers.get("Authorization"))
+        evaluation_api_key_headers.append(request.headers.get("X-API-Key"))
+        return httpx.Response(200, json={"is_safe": True, "confidence": 1.0})
+
+    transport = httpx.MockTransport(handler)
+
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        runtime_auth_mode="auto",
+        transport=transport,
+    ) as client:
+        for _ in range(2):
+            response = await client.post_runtime_evaluation(
+                json={"target_type": "log_stream", "target_id": "ls-1"},
+                target_type="log_stream",
+                target_id="ls-1",
+            )
+            assert response.status_code == 200
+
+    assert exchange_calls == 1
+    assert evaluation_authorization_headers == ["Bearer runtime-token", "Bearer runtime-token"]
+    assert evaluation_api_key_headers == [None, None]
+
+
+@pytest.mark.asyncio
+async def test_runtime_evaluation_single_flights_cold_cache_exchange() -> None:
+    exchange_calls = 0
+    evaluation_authorization_headers: list[str | None] = []
+    expires_at = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal exchange_calls
+        if request.url.path == "/api/v1/auth/runtime-token-exchange":
+            exchange_calls += 1
+            await asyncio.sleep(0.01)
+            return httpx.Response(
+                200,
+                json={
+                    "token": "runtime-token",
+                    "expires_at": expires_at,
+                    "target_type": "log_stream",
+                    "target_id": "ls-1",
+                    "scopes": ["runtime.use"],
+                },
+            )
+
+        evaluation_authorization_headers.append(request.headers.get("Authorization"))
+        return httpx.Response(200, json={"is_safe": True, "confidence": 1.0})
+
+    transport = httpx.MockTransport(handler)
+
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        runtime_auth_mode="jwt",
+        transport=transport,
+    ) as client:
+        responses = await asyncio.gather(
+            *(
+                client.post_runtime_evaluation(
+                    json={"target_type": "log_stream", "target_id": "ls-1"},
+                    target_type="log_stream",
+                    target_id="ls-1",
+                )
+                for _ in range(5)
+            )
+        )
+
+    assert [response.status_code for response in responses] == [200, 200, 200, 200, 200]
+    assert exchange_calls == 1
+    assert evaluation_authorization_headers == ["Bearer runtime-token"] * 5
+
+
+@pytest.mark.asyncio
+async def test_runtime_evaluation_refreshes_token_before_expiry() -> None:
+    exchange_tokens = ["short-token", "fresh-token"]
+    exchange_expiries = [
+        (datetime.now(UTC) + timedelta(seconds=5)).isoformat(),
+        (datetime.now(UTC) + timedelta(minutes=5)).isoformat(),
+    ]
+    evaluation_authorization_headers: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/v1/auth/runtime-token-exchange":
+            return httpx.Response(
+                200,
+                json={
+                    "token": exchange_tokens.pop(0),
+                    "expires_at": exchange_expiries.pop(0),
+                    "target_type": "log_stream",
+                    "target_id": "ls-1",
+                    "scopes": ["runtime.use"],
+                },
+            )
+
+        evaluation_authorization_headers.append(request.headers.get("Authorization"))
+        return httpx.Response(200, json={"is_safe": True, "confidence": 1.0})
+
+    transport = httpx.MockTransport(handler)
+
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        runtime_auth_mode="jwt",
+        runtime_token_refresh_margin_seconds=30,
+        transport=transport,
+    ) as client:
+        for _ in range(2):
+            response = await client.post_runtime_evaluation(
+                json={"target_type": "log_stream", "target_id": "ls-1"},
+                target_type="log_stream",
+                target_id="ls-1",
+            )
+            assert response.status_code == 200
+
+    assert exchange_tokens == []
+    assert evaluation_authorization_headers == [
+        "Bearer short-token",
+        "Bearer fresh-token",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runtime_token_cache_is_scoped_to_server_url() -> None:
+    exchange_paths: list[str] = []
+    authorization_headers: list[str | None] = []
+    expires_at = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+    cache = RuntimeTokenCache()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        server_url = f"{request.url.scheme}://{request.url.host}"
+        if request.url.path == "/api/v1/auth/runtime-token-exchange":
+            exchange_paths.append(server_url)
+            return httpx.Response(
+                200,
+                json={
+                    "token": f"{request.url.host}-token",
+                    "expires_at": expires_at,
+                    "target_type": "log_stream",
+                    "target_id": "ls-1",
+                    "scopes": ["runtime.use"],
+                },
+            )
+
+        authorization_headers.append(request.headers.get("Authorization"))
+        return httpx.Response(200, json={"is_safe": True, "confidence": 1.0})
+
+    transport = httpx.MockTransport(handler)
+
+    for base_url in ("https://server-a.test", "https://server-b.test"):
+        async with AgentControlClient(
+            base_url=base_url,
+            api_key="test-key",
+            runtime_auth_mode="jwt",
+            runtime_token_cache=cache,
+            transport=transport,
+        ) as client:
+            response = await client.post_runtime_evaluation(
+                json={"target_type": "log_stream", "target_id": "ls-1"},
+                target_type="log_stream",
+                target_id="ls-1",
+            )
+            assert response.status_code == 200
+
+    assert exchange_paths == ["https://server-a.test", "https://server-b.test"]
+    assert authorization_headers == [
+        "Bearer server-a.test-token",
+        "Bearer server-b.test-token",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runtime_evaluation_auto_falls_back_to_api_key_when_exchange_unavailable() -> None:
+    exchange_calls = 0
+    evaluation_api_key_headers: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal exchange_calls
+        if request.url.path == "/api/v1/auth/runtime-token-exchange":
+            exchange_calls += 1
+            return httpx.Response(503, json={"detail": "runtime auth disabled"})
+
+        evaluation_api_key_headers.append(request.headers.get("X-API-Key"))
+        return httpx.Response(200, json={"is_safe": True, "confidence": 1.0})
+
+    transport = httpx.MockTransport(handler)
+
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        runtime_auth_mode="auto",
+        transport=transport,
+    ) as client:
+        for _ in range(2):
+            response = await client.post_runtime_evaluation(
+                json={"target_type": "log_stream", "target_id": "ls-1"},
+                target_type="log_stream",
+                target_id="ls-1",
+            )
+            assert response.status_code == 200
+
+    assert exchange_calls == 1
+    assert evaluation_api_key_headers == ["test-key", "test-key"]
+
+
+@pytest.mark.asyncio
+async def test_runtime_evaluation_auto_without_target_uses_api_key_path() -> None:
+    exchange_calls = 0
+    evaluation_api_key_headers: list[str | None] = []
+    evaluation_authorization_headers: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal exchange_calls
+        if request.url.path == "/api/v1/auth/runtime-token-exchange":
+            exchange_calls += 1
+            return httpx.Response(200, json={})
+
+        evaluation_api_key_headers.append(request.headers.get("X-API-Key"))
+        evaluation_authorization_headers.append(request.headers.get("Authorization"))
+        return httpx.Response(200, json={"is_safe": True, "confidence": 1.0})
+
+    transport = httpx.MockTransport(handler)
+
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        runtime_auth_mode="auto",
+        transport=transport,
+    ) as client:
+        response = await client.post_runtime_evaluation(json={})
+
+    assert response.status_code == 200
+    assert exchange_calls == 0
+    assert evaluation_api_key_headers == ["test-key"]
+    assert evaluation_authorization_headers == [None]
+
+
+@pytest.mark.asyncio
+async def test_runtime_evaluation_retries_once_after_unauthorized_token() -> None:
+    exchange_tokens = ["expired-token", "fresh-token"]
+    evaluation_authorization_headers: list[str | None] = []
+    expires_at = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/v1/auth/runtime-token-exchange":
+            token = exchange_tokens.pop(0)
+            return httpx.Response(
+                200,
+                json={
+                    "token": token,
+                    "expires_at": expires_at,
+                    "target_type": "log_stream",
+                    "target_id": "ls-1",
+                    "scopes": ["runtime.use"],
+                },
+            )
+
+        authorization = request.headers.get("Authorization")
+        evaluation_authorization_headers.append(authorization)
+        if authorization == "Bearer expired-token":
+            return httpx.Response(401, json={"detail": "expired"})
+        return httpx.Response(200, json={"is_safe": True, "confidence": 1.0})
+
+    transport = httpx.MockTransport(handler)
+
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        runtime_auth_mode="jwt",
+        transport=transport,
+    ) as client:
+        response = await client.post_runtime_evaluation(
+            json={"target_type": "log_stream", "target_id": "ls-1"},
+            target_type="log_stream",
+            target_id="ls-1",
+        )
+
+    assert response.status_code == 200
+    assert evaluation_authorization_headers == [
+        "Bearer expired-token",
+        "Bearer fresh-token",
+    ]
+    assert exchange_tokens == []
+
+
+@pytest.mark.asyncio
+async def test_runtime_evaluation_does_not_auto_fallback_after_unauthorized_token() -> None:
+    exchange_attempt = 0
+    evaluation_authorization_headers: list[str | None] = []
+    evaluation_api_key_headers: list[str | None] = []
+    expires_at = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal exchange_attempt
+        if request.url.path == "/api/v1/auth/runtime-token-exchange":
+            exchange_attempt += 1
+            if exchange_attempt == 1:
+                return httpx.Response(
+                    200,
+                    json={
+                        "token": "expired-token",
+                        "expires_at": expires_at,
+                        "target_type": "log_stream",
+                        "target_id": "ls-1",
+                        "scopes": ["runtime.use"],
+                    },
+                )
+            return httpx.Response(503, json={"detail": "runtime auth disabled"})
+
+        evaluation_authorization_headers.append(request.headers.get("Authorization"))
+        evaluation_api_key_headers.append(request.headers.get("X-API-Key"))
+        return httpx.Response(401, json={"detail": "expired"})
+
+    transport = httpx.MockTransport(handler)
+
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        runtime_auth_mode="auto",
+        transport=transport,
+    ) as client:
+        with pytest.raises(httpx.HTTPStatusError) as exc_info:
+            await client.post_runtime_evaluation(
+                json={"target_type": "log_stream", "target_id": "ls-1"},
+                target_type="log_stream",
+                target_id="ls-1",
+            )
+
+    assert exc_info.value.response.status_code == 503
+    assert exchange_attempt == 2
+    assert evaluation_authorization_headers == ["Bearer expired-token"]
+    assert evaluation_api_key_headers == [None]
+
+
+@pytest.mark.asyncio
+async def test_runtime_evaluation_returns_second_unauthorized_response() -> None:
+    exchange_tokens = ["expired-token", "still-expired-token"]
+    evaluation_authorization_headers: list[str | None] = []
+    expires_at = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/v1/auth/runtime-token-exchange":
+            return httpx.Response(
+                200,
+                json={
+                    "token": exchange_tokens.pop(0),
+                    "expires_at": expires_at,
+                    "target_type": "log_stream",
+                    "target_id": "ls-1",
+                    "scopes": ["runtime.use"],
+                },
+            )
+
+        evaluation_authorization_headers.append(request.headers.get("Authorization"))
+        return httpx.Response(401, json={"detail": "expired"})
+
+    transport = httpx.MockTransport(handler)
+
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        runtime_auth_mode="jwt",
+        transport=transport,
+    ) as client:
+        response = await client.post_runtime_evaluation(
+            json={"target_type": "log_stream", "target_id": "ls-1"},
+            target_type="log_stream",
+            target_id="ls-1",
+        )
+
+    assert response.status_code == 401
+    assert exchange_tokens == []
+    assert evaluation_authorization_headers == [
+        "Bearer expired-token",
+        "Bearer still-expired-token",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runtime_evaluation_jwt_mode_requires_target_context() -> None:
+    transport = httpx.MockTransport(lambda request: httpx.Response(200, json={"ok": True}))
+
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        runtime_auth_mode="jwt",
+        transport=transport,
+    ) as client:
+        with pytest.raises(RuntimeError, match="requires target_type and target_id"):
+            await client.post_runtime_evaluation(json={})
+
+
+@pytest.mark.asyncio
+async def test_runtime_exchange_rejects_non_object_response() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/v1/auth/runtime-token-exchange":
+            return httpx.Response(200, json=["not", "an", "object"])
+        return httpx.Response(200, json={"is_safe": True, "confidence": 1.0})
+
+    transport = httpx.MockTransport(handler)
+
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        runtime_auth_mode="jwt",
+        transport=transport,
+    ) as client:
+        with pytest.raises(RuntimeError, match="response was not an object"):
+            await client.post_runtime_evaluation(
+                json={"target_type": "log_stream", "target_id": "ls-1"},
+                target_type="log_stream",
+                target_id="ls-1",
+            )
 
 
 @pytest.mark.asyncio

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 import httpx
 import pytest
 
+import agent_control
 from agent_control.client import AgentControlClient, sdk_version
 from agent_control.runtime_auth import RuntimeTokenCache
 
@@ -138,6 +139,43 @@ def test_client_exposes_default_api_key_header() -> None:
 
     # Then: the property reports the documented default
     assert client.api_key_header == "X-API-Key"
+
+
+@pytest.mark.asyncio
+async def test_get_agent_convenience_forwards_api_key_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_client_kwargs: dict[str, object] = {}
+
+    class FakeClient:
+        def __init__(self, **kwargs: object) -> None:
+            captured_client_kwargs.update(kwargs)
+
+        async def __aenter__(self) -> FakeClient:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+    async def fake_get_agent(client: object, agent_name: str) -> dict[str, object]:
+        return {"client": client, "agent_name": agent_name}
+
+    monkeypatch.setattr(agent_control, "AgentControlClient", FakeClient)
+    monkeypatch.setattr(agent_control.agents, "get_agent", fake_get_agent)
+
+    result = await agent_control.get_agent(
+        "agent-a",
+        server_url="https://agent-control.test",
+        api_key="test-key",
+        api_key_header="X-Custom-API-Key",
+    )
+
+    assert result["agent_name"] == "agent-a"
+    assert captured_client_kwargs == {
+        "base_url": "https://agent-control.test",
+        "api_key": "test-key",
+        "api_key_header": "X-Custom-API-Key",
+    }
 
 
 @pytest.mark.asyncio
@@ -332,6 +370,55 @@ async def test_runtime_token_cache_is_scoped_to_server_url() -> None:
     assert authorization_headers == [
         "Bearer server-a.test-token",
         "Bearer server-b.test-token",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runtime_token_cache_is_scoped_to_api_key_identity() -> None:
+    exchange_api_key_headers: list[str | None] = []
+    authorization_headers: list[str | None] = []
+    expires_at = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+    cache = RuntimeTokenCache()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/v1/auth/runtime-token-exchange":
+            api_key = request.headers.get("X-API-Key")
+            exchange_api_key_headers.append(api_key)
+            return httpx.Response(
+                200,
+                json={
+                    "token": f"runtime-token-for-{api_key}",
+                    "expires_at": expires_at,
+                    "target_type": "log_stream",
+                    "target_id": "ls-1",
+                    "scopes": ["runtime.use"],
+                },
+            )
+
+        authorization_headers.append(request.headers.get("Authorization"))
+        return httpx.Response(200, json={"is_safe": True, "confidence": 1.0})
+
+    transport = httpx.MockTransport(handler)
+
+    for api_key in ("key-a", "key-b"):
+        async with AgentControlClient(
+            base_url="https://agent-control.test",
+            api_key=api_key,
+            runtime_auth_mode="jwt",
+            runtime_token_cache=cache,
+            transport=transport,
+        ) as client:
+            response = await client.post_runtime_evaluation(
+                json={"target_type": "log_stream", "target_id": "ls-1"},
+                target_type="log_stream",
+                target_id="ls-1",
+            )
+            assert response.status_code == 200
+
+    assert exchange_api_key_headers == ["key-a", "key-b"]
+    assert authorization_headers == [
+        "Bearer runtime-token-for-key-a",
+        "Bearer runtime-token-for-key-b",
     ]
 
 
@@ -666,6 +753,67 @@ async def test_runtime_evaluation_does_not_auto_fallback_after_unauthorized_toke
     assert exchange_attempt == 2
     assert evaluation_authorization_headers == ["Bearer expired-token"]
     assert evaluation_api_key_headers == [None]
+
+
+@pytest.mark.asyncio
+async def test_runtime_evaluation_forced_refresh_ignores_fallback_marker() -> None:
+    exchange_tokens = ["expired-token", "fresh-token"]
+    evaluation_authorization_headers: list[str | None] = []
+    evaluation_api_key_headers: list[str | None] = []
+    expires_at = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+    cache = RuntimeTokenCache()
+    client_identity = ""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal client_identity
+        if request.url.path == "/api/v1/auth/runtime-token-exchange":
+            return httpx.Response(
+                200,
+                json={
+                    "token": exchange_tokens.pop(0),
+                    "expires_at": expires_at,
+                    "target_type": "log_stream",
+                    "target_id": "ls-1",
+                    "scopes": ["runtime.use"],
+                },
+            )
+
+        authorization = request.headers.get("Authorization")
+        evaluation_authorization_headers.append(authorization)
+        evaluation_api_key_headers.append(request.headers.get("X-API-Key"))
+        if authorization == "Bearer expired-token":
+            cache.mark_jwt_unavailable(
+                server_url="https://agent-control.test",
+                target_type="log_stream",
+                target_id="ls-1",
+                cache_identity=client_identity,
+            )
+            return httpx.Response(401, json={"detail": "expired"})
+        return httpx.Response(200, json={"is_safe": True, "confidence": 1.0})
+
+    transport = httpx.MockTransport(handler)
+
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        runtime_auth_mode="auto",
+        runtime_token_cache=cache,
+        transport=transport,
+    ) as client:
+        client_identity = client._runtime_cache_identity
+        response = await client.post_runtime_evaluation(
+            json={"target_type": "log_stream", "target_id": "ls-1"},
+            target_type="log_stream",
+            target_id="ls-1",
+        )
+
+    assert response.status_code == 200
+    assert exchange_tokens == []
+    assert evaluation_authorization_headers == [
+        "Bearer expired-token",
+        "Bearer fresh-token",
+    ]
+    assert evaluation_api_key_headers == [None, None]
 
 
 @pytest.mark.asyncio

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -370,6 +370,57 @@ async def test_runtime_evaluation_auto_falls_back_to_api_key_when_exchange_unava
 
 
 @pytest.mark.asyncio
+async def test_runtime_evaluation_auto_404_fallback_recovers_after_ttl() -> None:
+    exchange_calls = 0
+    evaluation_authorization_headers: list[str | None] = []
+    evaluation_api_key_headers: list[str | None] = []
+    expires_at = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+    cache = RuntimeTokenCache(jwt_unavailable_ttl_seconds=0)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal exchange_calls
+        if request.url.path == "/api/v1/auth/runtime-token-exchange":
+            exchange_calls += 1
+            if exchange_calls == 1:
+                return httpx.Response(404, json={"detail": "not found"})
+            return httpx.Response(
+                200,
+                json={
+                    "token": "runtime-token",
+                    "expires_at": expires_at,
+                    "target_type": "log_stream",
+                    "target_id": "ls-1",
+                    "scopes": ["runtime.use"],
+                },
+            )
+
+        evaluation_authorization_headers.append(request.headers.get("Authorization"))
+        evaluation_api_key_headers.append(request.headers.get("X-API-Key"))
+        return httpx.Response(200, json={"is_safe": True, "confidence": 1.0})
+
+    transport = httpx.MockTransport(handler)
+
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        runtime_auth_mode="auto",
+        runtime_token_cache=cache,
+        transport=transport,
+    ) as client:
+        for _ in range(2):
+            response = await client.post_runtime_evaluation(
+                json={"target_type": "log_stream", "target_id": "ls-1"},
+                target_type="log_stream",
+                target_id="ls-1",
+            )
+            assert response.status_code == 200
+
+    assert exchange_calls == 2
+    assert evaluation_authorization_headers == [None, "Bearer runtime-token"]
+    assert evaluation_api_key_headers == ["test-key", None]
+
+
+@pytest.mark.asyncio
 async def test_runtime_evaluation_auto_503_fallback_is_target_scoped() -> None:
     exchange_targets: list[str] = []
     evaluation_authorization_headers: list[str | None] = []

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -79,6 +79,67 @@ async def test_client_adds_api_key_auth_to_regular_requests() -> None:
 
 
 @pytest.mark.asyncio
+async def test_client_uses_configured_api_key_header_name() -> None:
+    # Given: a client configured to send the API key on a custom header
+    seen_requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_requests.append(request)
+        return httpx.Response(200, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        api_key_header="X-Custom-API-Key",
+        transport=transport,
+    ) as client:
+        # When: making a request
+        response = await client.http_client.get("/api/v1/agents")
+
+    # Then: the key is on the configured header and the default is absent
+    assert response.status_code == 200
+    assert seen_requests[0].headers["X-Custom-API-Key"] == "test-key"
+    assert "X-API-Key" not in seen_requests[0].headers
+
+
+@pytest.mark.asyncio
+async def test_client_reads_api_key_header_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given: AGENT_CONTROL_API_KEY_HEADER set in the environment
+    monkeypatch.setenv("AGENT_CONTROL_API_KEY_HEADER", "X-Custom-API-Key")
+    seen_requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_requests.append(request)
+        return httpx.Response(200, json={"ok": True})
+
+    transport = httpx.MockTransport(handler)
+
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        transport=transport,
+    ) as client:
+        # When: no api_key_header is passed to the constructor
+        response = await client.http_client.get("/api/v1/agents")
+
+    # Then: the env-var value is used
+    assert response.status_code == 200
+    assert seen_requests[0].headers["X-Custom-API-Key"] == "test-key"
+
+
+def test_client_exposes_default_api_key_header() -> None:
+    # Given: a client with no explicit header override
+    client = AgentControlClient(api_key="test-key")
+
+    # Then: the property reports the documented default
+    assert client.api_key_header == "X-API-Key"
+
+
+@pytest.mark.asyncio
 async def test_runtime_evaluation_exchanges_and_caches_bearer_token() -> None:
     exchange_calls = 0
     evaluation_authorization_headers: list[str | None] = []

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
@@ -369,6 +370,89 @@ async def test_runtime_evaluation_auto_falls_back_to_api_key_when_exchange_unava
 
 
 @pytest.mark.asyncio
+async def test_runtime_evaluation_auto_503_fallback_is_target_scoped() -> None:
+    exchange_targets: list[str] = []
+    evaluation_authorization_headers: list[str | None] = []
+    evaluation_api_key_headers: list[str | None] = []
+    expires_at = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/v1/auth/runtime-token-exchange":
+            target_id = json.loads(request.content.decode())["target_id"]
+            exchange_targets.append(target_id)
+            if target_id == "ls-1":
+                return httpx.Response(503, json={"detail": "temporary unavailable"})
+            return httpx.Response(
+                200,
+                json={
+                    "token": "runtime-token",
+                    "expires_at": expires_at,
+                    "target_type": "log_stream",
+                    "target_id": target_id,
+                    "scopes": ["runtime.use"],
+                },
+            )
+
+        evaluation_authorization_headers.append(request.headers.get("Authorization"))
+        evaluation_api_key_headers.append(request.headers.get("X-API-Key"))
+        return httpx.Response(200, json={"is_safe": True, "confidence": 1.0})
+
+    transport = httpx.MockTransport(handler)
+
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        runtime_auth_mode="auto",
+        transport=transport,
+    ) as client:
+        first = await client.post_runtime_evaluation(
+            json={"target_type": "log_stream", "target_id": "ls-1"},
+            target_type="log_stream",
+            target_id="ls-1",
+        )
+        second = await client.post_runtime_evaluation(
+            json={"target_type": "log_stream", "target_id": "ls-2"},
+            target_type="log_stream",
+            target_id="ls-2",
+        )
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert exchange_targets == ["ls-1", "ls-2"]
+    assert evaluation_authorization_headers == [None, "Bearer runtime-token"]
+    assert evaluation_api_key_headers == ["test-key", None]
+
+
+@pytest.mark.asyncio
+async def test_runtime_evaluation_auto_falls_back_on_exchange_transport_error() -> None:
+    evaluation_api_key_headers: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/v1/auth/runtime-token-exchange":
+            raise httpx.ConnectError("unreachable", request=request)
+
+        evaluation_api_key_headers.append(request.headers.get("X-API-Key"))
+        return httpx.Response(200, json={"is_safe": True, "confidence": 1.0})
+
+    transport = httpx.MockTransport(handler)
+
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        runtime_auth_mode="auto",
+        transport=transport,
+    ) as client:
+        response = await client.post_runtime_evaluation(
+            json={"target_type": "log_stream", "target_id": "ls-1"},
+            target_type="log_stream",
+            target_id="ls-1",
+        )
+
+    assert response.status_code == 200
+    assert evaluation_api_key_headers == ["test-key"]
+
+
+@pytest.mark.asyncio
 async def test_runtime_evaluation_auto_without_target_uses_api_key_path() -> None:
     exchange_calls = 0
     evaluation_api_key_headers: list[str | None] = []
@@ -393,6 +477,42 @@ async def test_runtime_evaluation_auto_without_target_uses_api_key_path() -> Non
         transport=transport,
     ) as client:
         response = await client.post_runtime_evaluation(json={})
+
+    assert response.status_code == 200
+    assert exchange_calls == 0
+    assert evaluation_api_key_headers == ["test-key"]
+    assert evaluation_authorization_headers == [None]
+
+
+@pytest.mark.asyncio
+async def test_runtime_evaluation_none_mode_uses_normal_request_auth() -> None:
+    exchange_calls = 0
+    evaluation_api_key_headers: list[str | None] = []
+    evaluation_authorization_headers: list[str | None] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal exchange_calls
+        if request.url.path == "/api/v1/auth/runtime-token-exchange":
+            exchange_calls += 1
+            return httpx.Response(200, json={})
+
+        evaluation_api_key_headers.append(request.headers.get("X-API-Key"))
+        evaluation_authorization_headers.append(request.headers.get("Authorization"))
+        return httpx.Response(200, json={"is_safe": True, "confidence": 1.0})
+
+    transport = httpx.MockTransport(handler)
+
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        runtime_auth_mode="none",
+        transport=transport,
+    ) as client:
+        response = await client.post_runtime_evaluation(
+            json={"target_type": "log_stream", "target_id": "ls-1"},
+            target_type="log_stream",
+            target_id="ls-1",
+        )
 
     assert response.status_code == 200
     assert exchange_calls == 0
@@ -502,6 +622,7 @@ async def test_runtime_evaluation_returns_second_unauthorized_response() -> None
     exchange_tokens = ["expired-token", "still-expired-token"]
     evaluation_authorization_headers: list[str | None] = []
     expires_at = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+    cache = RuntimeTokenCache()
 
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path == "/api/v1/auth/runtime-token-exchange":
@@ -525,6 +646,7 @@ async def test_runtime_evaluation_returns_second_unauthorized_response() -> None
         base_url="https://agent-control.test",
         api_key="test-key",
         runtime_auth_mode="jwt",
+        runtime_token_cache=cache,
         transport=transport,
     ) as client:
         response = await client.post_runtime_evaluation(
@@ -539,6 +661,108 @@ async def test_runtime_evaluation_returns_second_unauthorized_response() -> None
         "Bearer expired-token",
         "Bearer still-expired-token",
     ]
+    assert (
+        cache.get(
+            "https://agent-control.test",
+            "log_stream",
+            "ls-1",
+            refresh_margin_seconds=0,
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_runtime_evaluation_refreshes_on_forbidden_invalid_token() -> None:
+    exchange_tokens = ["revoked-token", "fresh-token"]
+    evaluation_authorization_headers: list[str | None] = []
+    expires_at = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/v1/auth/runtime-token-exchange":
+            return httpx.Response(
+                200,
+                json={
+                    "token": exchange_tokens.pop(0),
+                    "expires_at": expires_at,
+                    "target_type": "log_stream",
+                    "target_id": "ls-1",
+                    "scopes": ["runtime.use"],
+                },
+            )
+
+        authorization = request.headers.get("Authorization")
+        evaluation_authorization_headers.append(authorization)
+        if authorization == "Bearer revoked-token":
+            return httpx.Response(
+                403,
+                headers={"WWW-Authenticate": 'Bearer error="invalid_token"'},
+                json={"detail": "revoked"},
+            )
+        return httpx.Response(200, json={"is_safe": True, "confidence": 1.0})
+
+    transport = httpx.MockTransport(handler)
+
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        runtime_auth_mode="jwt",
+        transport=transport,
+    ) as client:
+        response = await client.post_runtime_evaluation(
+            json={"target_type": "log_stream", "target_id": "ls-1"},
+            target_type="log_stream",
+            target_id="ls-1",
+        )
+
+    assert response.status_code == 200
+    assert evaluation_authorization_headers == [
+        "Bearer revoked-token",
+        "Bearer fresh-token",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_runtime_evaluation_does_not_refresh_on_policy_forbidden() -> None:
+    exchange_calls = 0
+    evaluation_authorization_headers: list[str | None] = []
+    expires_at = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal exchange_calls
+        if request.url.path == "/api/v1/auth/runtime-token-exchange":
+            exchange_calls += 1
+            return httpx.Response(
+                200,
+                json={
+                    "token": "runtime-token",
+                    "expires_at": expires_at,
+                    "target_type": "log_stream",
+                    "target_id": "ls-1",
+                    "scopes": ["runtime.use"],
+                },
+            )
+
+        evaluation_authorization_headers.append(request.headers.get("Authorization"))
+        return httpx.Response(403, json={"detail": "policy denied"})
+
+    transport = httpx.MockTransport(handler)
+
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        runtime_auth_mode="jwt",
+        transport=transport,
+    ) as client:
+        response = await client.post_runtime_evaluation(
+            json={"target_type": "log_stream", "target_id": "ls-1"},
+            target_type="log_stream",
+            target_id="ls-1",
+        )
+
+    assert response.status_code == 403
+    assert exchange_calls == 1
+    assert evaluation_authorization_headers == ["Bearer runtime-token"]
 
 
 @pytest.mark.asyncio
@@ -571,6 +795,38 @@ async def test_runtime_exchange_rejects_non_object_response() -> None:
         transport=transport,
     ) as client:
         with pytest.raises(RuntimeError, match="response was not an object"):
+            await client.post_runtime_evaluation(
+                json={"target_type": "log_stream", "target_id": "ls-1"},
+                target_type="log_stream",
+                target_id="ls-1",
+            )
+
+
+@pytest.mark.asyncio
+async def test_runtime_exchange_rejects_target_mismatch_response() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/v1/auth/runtime-token-exchange":
+            return httpx.Response(
+                200,
+                json={
+                    "token": "runtime-token",
+                    "expires_at": (datetime.now(UTC) + timedelta(minutes=5)).isoformat(),
+                    "target_type": "log_stream",
+                    "target_id": "different",
+                    "scopes": ["runtime.use"],
+                },
+            )
+        return httpx.Response(200, json={"is_safe": True, "confidence": 1.0})
+
+    transport = httpx.MockTransport(handler)
+
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        runtime_auth_mode="jwt",
+        transport=transport,
+    ) as client:
+        with pytest.raises(RuntimeError, match="target did not match"):
             await client.post_runtime_evaluation(
                 json={"target_type": "log_stream", "target_id": "ls-1"},
                 target_type="log_stream",

--- a/sdks/python/tests/test_control_decorators.py
+++ b/sdks/python/tests/test_control_decorators.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 from agent_control_telemetry import clear_trace_context_provider, set_trace_context_provider
 
@@ -850,6 +851,67 @@ class TestEvaluateSessionContext:
         assert captured_client_kwargs["runtime_token_cache"] is runtime_token_cache
         assert captured_eval_kwargs["target_type"] == "env"
         assert captured_eval_kwargs["target_id"] == "prod"
+
+    @pytest.mark.asyncio
+    async def test_fallback_server_evaluation_uses_runtime_path(self):
+        from agent_control.control_decorators import _evaluate
+        from agent_control.runtime_auth import RuntimeTokenCache
+
+        captured_post_kwargs = {}
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+        async def failing_local_evaluation(**kwargs):
+            raise RuntimeError("local failure")
+
+        async def fake_post_evaluation_request(client, **kwargs):
+            del client
+            captured_post_kwargs.update(kwargs)
+            request = httpx.Request("POST", "https://agent-control.test/api/v1/evaluation")
+            return httpx.Response(
+                200,
+                json={"is_safe": True, "confidence": 1.0},
+                request=request,
+            )
+
+        with (
+            patch("agent_control.control_decorators.AgentControlClient", FakeClient),
+            patch(
+                "agent_control.control_decorators.check_evaluation_with_local",
+                side_effect=failing_local_evaluation,
+            ),
+            patch(
+                "agent_control.control_decorators._post_evaluation_request",
+                side_effect=fake_post_evaluation_request,
+            ),
+            patch("agent_control.control_decorators.state.api_key", "session-key"),
+            patch("agent_control.control_decorators.state.api_key_header", "X-Custom-Key"),
+            patch(
+                "agent_control.control_decorators.state.runtime_token_cache",
+                RuntimeTokenCache(),
+            ),
+            patch("agent_control.control_decorators.state.target_type", "env"),
+            patch("agent_control.control_decorators.state.target_id", "prod"),
+        ):
+            result = await _evaluate(
+                agent_name="agent",
+                step={"type": "llm", "name": "chat", "input": "hello"},
+                stage="pre",
+                server_url="http://server.test",
+                controls=[{"id": 1, "name": "control", "control": {}}],
+            )
+
+        assert result["is_safe"] is True
+        assert captured_post_kwargs["target_type"] == "env"
+        assert captured_post_kwargs["target_id"] == "prod"
 
 
 # =============================================================================

--- a/sdks/python/tests/test_control_decorators.py
+++ b/sdks/python/tests/test_control_decorators.py
@@ -793,6 +793,65 @@ class TestStepName:
             assert captured_steps[0]["type"] == "tool"
 
 
+class TestEvaluateSessionContext:
+    """Tests for session context forwarding in the decorator evaluation path."""
+
+    @pytest.mark.asyncio
+    async def test_evaluate_forwards_session_target_and_client_state(self):
+        """The decorator path should use the same session target as evaluate_controls()."""
+        from agent_control.control_decorators import _evaluate
+        from agent_control.runtime_auth import RuntimeTokenCache
+        from agent_control_models import EvaluationResult
+
+        captured_client_kwargs = {}
+        captured_eval_kwargs = {}
+        runtime_token_cache = RuntimeTokenCache()
+
+        class FakeClient:
+            def __init__(self, **kwargs):
+                captured_client_kwargs.update(kwargs)
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return None
+
+        async def fake_check_evaluation_with_local(**kwargs):
+            captured_eval_kwargs.update(kwargs)
+            return EvaluationResult(is_safe=True, confidence=1.0)
+
+        with (
+            patch("agent_control.control_decorators.AgentControlClient", FakeClient),
+            patch(
+                "agent_control.control_decorators.check_evaluation_with_local",
+                side_effect=fake_check_evaluation_with_local,
+            ),
+            patch("agent_control.control_decorators.state.api_key", "session-key"),
+            patch("agent_control.control_decorators.state.api_key_header", "X-Custom-Key"),
+            patch(
+                "agent_control.control_decorators.state.runtime_token_cache",
+                runtime_token_cache,
+            ),
+            patch("agent_control.control_decorators.state.target_type", "env"),
+            patch("agent_control.control_decorators.state.target_id", "prod"),
+        ):
+            result = await _evaluate(
+                agent_name="agent",
+                step={"type": "llm", "name": "chat", "input": "hello"},
+                stage="pre",
+                server_url="http://server.test",
+                controls=[{"id": 1, "name": "control", "control": {}}],
+            )
+
+        assert result["is_safe"] is True
+        assert captured_client_kwargs["api_key"] == "session-key"
+        assert captured_client_kwargs["api_key_header"] == "X-Custom-Key"
+        assert captured_client_kwargs["runtime_token_cache"] is runtime_token_cache
+        assert captured_eval_kwargs["target_type"] == "env"
+        assert captured_eval_kwargs["target_id"] == "prod"
+
+
 # =============================================================================
 # STEERING CONTEXT TESTS
 # =============================================================================

--- a/sdks/python/tests/test_evaluation.py
+++ b/sdks/python/tests/test_evaluation.py
@@ -4,10 +4,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import UUID
 
 import pytest
-from pydantic import ValidationError
-
 from agent_control import evaluation
 from agent_control.evaluation import EvaluationResult
+from pydantic import ValidationError
 
 
 @pytest.mark.asyncio
@@ -124,6 +123,27 @@ async def test_evaluate_controls_with_context(monkeypatch):
             )
 
     assert mock_check.call_args is not None
+
+
+@pytest.mark.asyncio
+async def test_evaluate_controls_uses_session_api_key_header(monkeypatch):
+    """evaluate_controls should pass init's API-key header into the client."""
+    mock_result = EvaluationResult(is_safe=True, confidence=1.0)
+    mock_check = AsyncMock(return_value=mock_result)
+    monkeypatch.setattr(evaluation, "check_evaluation_with_local", mock_check)
+
+    with patch("agent_control.state.server_url", "http://localhost:8000"), patch(
+        "agent_control.state.api_key", "test-key"
+    ), patch("agent_control.state.api_key_header", "Galileo-API-Key"):
+        await evaluation.evaluate_controls(
+            step_name="chat",
+            input="hello",
+            stage="pre",
+            agent_name="test-bot",
+        )
+
+    client = mock_check.call_args.kwargs["client"]
+    assert client.api_key_header == "Galileo-API-Key"
 
 
 @pytest.mark.asyncio

--- a/sdks/python/tests/test_init_step_merge.py
+++ b/sdks/python/tests/test_init_step_merge.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Generator
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import ANY, AsyncMock, patch
 from uuid import uuid4
 
@@ -219,6 +219,47 @@ def test_init_omits_merge_events_from_public_signature() -> None:
     assert "merge_events" not in signature.parameters
 
 
+def test_init_passes_api_key_header_to_client_and_state() -> None:
+    register_agent_mock = AsyncMock(return_value={"created": True, "controls": []})
+    health_check_mock = AsyncMock(return_value={"status": "healthy"})
+    client_init_kwargs: list[dict[str, Any]] = []
+    original_init = agent_control.AgentControlClient.__init__
+
+    def recording_init(
+        self: agent_control.AgentControlClient,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        client_init_kwargs.append(dict(kwargs))
+        original_init(self, *args, **kwargs)
+
+    with patch.object(
+        agent_control.AgentControlClient,
+        "__init__",
+        new=recording_init,
+    ), patch(
+        "agent_control.__init__.AgentControlClient.health_check",
+        new=health_check_mock,
+    ), patch(
+        "agent_control.__init__.agents.register_agent",
+        new=register_agent_mock,
+    ), patch.object(
+        agent_control,
+        "init_observability",
+        return_value=None,
+    ) as observability_mock:
+        agent_control.init(
+            agent_name=f"agent-{uuid4().hex[:12]}",
+            api_key="test-key",
+            api_key_header="Galileo-API-Key",
+            policy_refresh_interval_seconds=0,
+        )
+
+    assert agent_control.state.api_key_header == "Galileo-API-Key"
+    assert client_init_kwargs[0]["api_key_header"] == "Galileo-API-Key"
+    assert observability_mock.call_args.kwargs["api_key_header"] == "Galileo-API-Key"
+
+
 @pytest.mark.asyncio
 async def test_refresh_controls_calls_agent_controls_endpoint() -> None:
     # Given: an initialized SDK agent session with network-facing calls mocked.
@@ -238,6 +279,7 @@ async def test_refresh_controls_calls_agent_controls_endpoint() -> None:
     ):
         agent_control.init(
             agent_name=f"agent-{uuid4().hex[:12]}",
+            api_key_header="Galileo-API-Key",
             policy_refresh_interval_seconds=0,
         )
 
@@ -255,4 +297,5 @@ async def test_refresh_controls_calls_agent_controls_endpoint() -> None:
         target_type=None,
         target_id=None,
     )
+    assert agent_control.state.api_key_header == "Galileo-API-Key"
     assert register_agent_mock.await_count == 0

--- a/sdks/python/tests/test_init_step_merge.py
+++ b/sdks/python/tests/test_init_step_merge.py
@@ -8,8 +8,9 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import ANY, AsyncMock, patch
 from uuid import uuid4
 
-import agent_control
 import pytest
+
+import agent_control
 from agent_control._control_registry import clear, register
 
 if TYPE_CHECKING:
@@ -258,6 +259,48 @@ def test_init_passes_api_key_header_to_client_and_state() -> None:
     assert agent_control.state.api_key_header == "Galileo-API-Key"
     assert client_init_kwargs[0]["api_key_header"] == "Galileo-API-Key"
     assert observability_mock.call_args.kwargs["api_key_header"] == "Galileo-API-Key"
+
+
+def test_init_stores_resolved_default_api_key_header(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AGENT_CONTROL_API_KEY_HEADER", raising=False)
+    register_agent_mock = AsyncMock(return_value={"created": True, "controls": []})
+    health_check_mock = AsyncMock(return_value={"status": "healthy"})
+    client_init_kwargs: list[dict[str, Any]] = []
+    original_init = agent_control.AgentControlClient.__init__
+
+    def recording_init(
+        self: agent_control.AgentControlClient,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        client_init_kwargs.append(dict(kwargs))
+        original_init(self, *args, **kwargs)
+
+    with patch.object(
+        agent_control.AgentControlClient,
+        "__init__",
+        new=recording_init,
+    ), patch(
+        "agent_control.__init__.AgentControlClient.health_check",
+        new=health_check_mock,
+    ), patch(
+        "agent_control.__init__.agents.register_agent",
+        new=register_agent_mock,
+    ), patch.object(
+        agent_control,
+        "init_observability",
+        return_value=None,
+    ):
+        agent_control.init(
+            agent_name=f"agent-{uuid4().hex[:12]}",
+            api_key="test-key",
+            policy_refresh_interval_seconds=0,
+        )
+
+    assert agent_control.state.api_key_header == "X-API-Key"
+    assert client_init_kwargs[0]["api_key_header"] == "X-API-Key"
 
 
 @pytest.mark.asyncio

--- a/sdks/python/tests/test_local_evaluation.py
+++ b/sdks/python/tests/test_local_evaluation.py
@@ -11,6 +11,7 @@ These tests verify the check_evaluation_with_local function:
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from agent_control.client import AgentControlClient
 from agent_control.evaluation import (
@@ -417,6 +418,41 @@ class TestCheckEvaluationWithLocal:
         assert result.is_safe is True
         client.post_runtime_evaluation.assert_awaited_once()
         client.http_client.post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_jwt_runtime_client_without_target_raises(
+        self,
+        agent_name,
+        llm_payload,
+    ) -> None:
+        """JWT runtime mode requires target context through local evaluation."""
+        controls = [
+            make_control_dict(1, "server_ctrl", execution="server"),
+        ]
+        sent_requests: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            sent_requests.append(request)
+            return httpx.Response(200, json={"is_safe": True, "confidence": 1.0})
+
+        transport = httpx.MockTransport(handler)
+
+        async with AgentControlClient(
+            base_url="https://agent-control.test",
+            api_key="test-key",
+            runtime_auth_mode="jwt",
+            transport=transport,
+        ) as client:
+            with pytest.raises(RuntimeError, match="requires target_type and target_id"):
+                await check_evaluation_with_local(
+                    client=client,
+                    agent_name=agent_name,
+                    step=llm_payload,
+                    stage="pre",
+                    controls=controls,
+                )
+
+        assert sent_requests == []
 
     @pytest.mark.asyncio
     async def test_server_only_template_backed_controls_still_call_server(

--- a/sdks/python/tests/test_local_evaluation.py
+++ b/sdks/python/tests/test_local_evaluation.py
@@ -13,16 +13,17 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
-from agent_control.client import AgentControlClient
-from agent_control.evaluation import (
-    _merge_results,
-    check_evaluation_with_local,
-)
 from agent_control_models import (
     ControlMatch,
     EvaluationResponse,
     EvaluatorResult,
     Step,
+)
+
+from agent_control.client import AgentControlClient
+from agent_control.evaluation import (
+    _merge_results,
+    check_evaluation_with_local,
 )
 
 # =============================================================================
@@ -58,6 +59,19 @@ class _RuntimeAuthDuckClient:
             }
         )
         return self.response
+
+
+class _HttpOnlyDuckClient:
+    """Minimal custom client that exposes the normal HTTP evaluation path."""
+
+    base_url = "https://agent-control.test"
+
+    def __init__(self) -> None:
+        self.response = MagicMock()
+        self.response.json.return_value = {"is_safe": True, "confidence": 1.0}
+        self.response.raise_for_status = MagicMock()
+        self.http_client = MagicMock()
+        self.http_client.post = AsyncMock(return_value=self.response)
 
 
 @pytest.fixture
@@ -386,6 +400,26 @@ class TestCheckEvaluationWithLocal:
         assert client.runtime_requests[0]["target_id"] == "ls-1"
         assert client.runtime_requests[0]["json"]["target_type"] == "log_stream"
         assert client.runtime_requests[0]["json"]["target_id"] == "ls-1"
+
+    @pytest.mark.asyncio
+    async def test_custom_http_client_without_runtime_mode_uses_normal_path(
+        self, agent_name, llm_payload
+    ) -> None:
+        controls = [
+            make_control_dict(1, "server_ctrl", execution="server"),
+        ]
+        client = _HttpOnlyDuckClient()
+
+        result = await check_evaluation_with_local(
+            client=client,  # type: ignore[arg-type]
+            agent_name=agent_name,
+            step=llm_payload,
+            stage="pre",
+            controls=controls,
+        )
+
+        assert result.is_safe is True
+        client.http_client.post.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_mock_client_with_runtime_method_uses_runtime_auth_path(

--- a/sdks/python/tests/test_local_evaluation.py
+++ b/sdks/python/tests/test_local_evaluation.py
@@ -29,6 +29,36 @@ from agent_control_models import (
 # =============================================================================
 
 
+class _RuntimeAuthDuckClient:
+    """Minimal custom client that exposes the runtime-auth evaluation method."""
+
+    base_url = "https://agent-control.test"
+
+    def __init__(self) -> None:
+        self.runtime_requests: list[dict[str, Any]] = []
+        self.response = MagicMock()
+        self.response.json.return_value = {"is_safe": True, "confidence": 1.0}
+        self.response.raise_for_status = MagicMock()
+
+    async def post_runtime_evaluation(
+        self,
+        *,
+        json: dict[str, Any],
+        headers: dict[str, str] | None = None,
+        target_type: str | None = None,
+        target_id: str | None = None,
+    ) -> MagicMock:
+        self.runtime_requests.append(
+            {
+                "json": json,
+                "headers": headers,
+                "target_type": target_type,
+                "target_id": target_id,
+            }
+        )
+        return self.response
+
+
 @pytest.fixture
 def agent_name() -> str:
     """Test agent name."""
@@ -328,6 +358,65 @@ class TestCheckEvaluationWithLocal:
         assert "/api/v1/evaluation" in str(client.http_client.post.call_args)
 
         assert result.is_safe is True
+
+    @pytest.mark.asyncio
+    async def test_custom_client_with_runtime_method_uses_runtime_auth_path(
+        self, agent_name, llm_payload
+    ) -> None:
+        """Custom clients can opt into runtime auth with post_runtime_evaluation."""
+        controls = [
+            make_control_dict(1, "server_ctrl", execution="server"),
+        ]
+        client = _RuntimeAuthDuckClient()
+
+        result = await check_evaluation_with_local(
+            client=client,  # type: ignore[arg-type]
+            agent_name=agent_name,
+            step=llm_payload,
+            stage="pre",
+            controls=controls,
+            target_type="log_stream",
+            target_id="ls-1",
+        )
+
+        assert result.is_safe is True
+        assert len(client.runtime_requests) == 1
+        assert client.runtime_requests[0]["target_type"] == "log_stream"
+        assert client.runtime_requests[0]["target_id"] == "ls-1"
+        assert client.runtime_requests[0]["json"]["target_type"] == "log_stream"
+        assert client.runtime_requests[0]["json"]["target_id"] == "ls-1"
+
+    @pytest.mark.asyncio
+    async def test_mock_client_with_runtime_method_uses_runtime_auth_path(
+        self,
+        agent_name,
+        llm_payload,
+    ) -> None:
+        """Configured mock clients can exercise the runtime-auth path."""
+        controls = [
+            make_control_dict(1, "server_ctrl", execution="server"),
+        ]
+        client = MagicMock(spec=AgentControlClient)
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"is_safe": True, "confidence": 1.0}
+        mock_response.raise_for_status = MagicMock()
+        client.http_client = AsyncMock()
+        client.http_client.post = AsyncMock()
+        client.post_runtime_evaluation = AsyncMock(return_value=mock_response)
+
+        result = await check_evaluation_with_local(
+            client=client,
+            agent_name=agent_name,
+            step=llm_payload,
+            stage="pre",
+            controls=controls,
+            target_type="log_stream",
+            target_id="ls-1",
+        )
+
+        assert result.is_safe is True
+        client.post_runtime_evaluation.assert_awaited_once()
+        client.http_client.post.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_server_only_template_backed_controls_still_call_server(

--- a/sdks/python/tests/test_observability.py
+++ b/sdks/python/tests/test_observability.py
@@ -120,6 +120,7 @@ def reset_observability_state() -> None:
         observability_enabled=True,
         observability_sink_name=DEFAULT_CONTROL_EVENT_SINK_NAME,
         observability_sink_config={},
+        api_key_header="X-API-Key",
     )
     with obs._used_custom_event_sinks_lock:
         obs._used_custom_event_sinks.clear()
@@ -136,6 +137,7 @@ class TestEventBatcherInit:
     def test_init_default_values(self):
         """Test EventBatcher initializes with default values."""
         batcher = EventBatcher()
+        assert batcher.api_key_header == get_settings().api_key_header
         assert batcher.batch_size == get_settings().batch_size
         assert batcher.flush_interval == get_settings().flush_interval
         assert batcher.shutdown_join_timeout == get_settings().shutdown_join_timeout
@@ -149,11 +151,13 @@ class TestEventBatcherInit:
         batcher = EventBatcher(
             server_url="http://custom:9000",
             api_key="test-key",
+            api_key_header="X-Custom-API-Key",
             batch_size=50,
             flush_interval=5.0,
         )
         assert batcher.server_url == "http://custom:9000"
         assert batcher.api_key == "test-key"
+        assert batcher.api_key_header == "X-Custom-API-Key"
         assert batcher.batch_size == 50
         assert batcher.flush_interval == 5.0
 
@@ -161,20 +165,23 @@ class TestEventBatcherInit:
         """Test EventBatcher reads from settings."""
         from agent_control.settings import configure_settings
 
-        # Save original values
-        original_url = get_settings().url
-        original_api_key = get_settings().api_key
+        original_settings = get_settings().model_dump()
 
         try:
             # Configure settings programmatically
-            configure_settings(url="http://configured-server:8080", api_key="configured-api-key")
+            configure_settings(
+                url="http://configured-server:8080",
+                api_key="configured-api-key",
+                api_key_header="X-Custom-API-Key",
+            )
 
             batcher = EventBatcher()
             assert batcher.server_url == "http://configured-server:8080"
             assert batcher.api_key == "configured-api-key"
+            assert batcher.api_key_header == "X-Custom-API-Key"
         finally:
             # Restore original settings
-            configure_settings(url=original_url, api_key=original_api_key)
+            configure_settings(**original_settings)
 
 
 class TestEventBatcherStartStop:
@@ -557,6 +564,46 @@ class TestEventBatcherSendBatchSync:
         assert result is True
         client_ctor.assert_called_once_with(timeout=30.0)
         client.post.assert_called_once()
+        assert client.post.call_args.kwargs["headers"]["X-API-Key"] == "test-key"
+
+    def test_send_batch_sync_uses_configured_api_key_header(self):
+        batcher = EventBatcher(
+            server_url="http://test:8000",
+            api_key="test-key",
+            api_key_header="X-Custom-API-Key",
+        )
+        response = MagicMock(status_code=202, text="accepted")
+        client = MagicMock()
+        client.post.return_value = response
+        client_context = MagicMock()
+        client_context.__enter__.return_value = client
+
+        with patch(
+            "agent_control.observability.httpx.Client",
+            return_value=client_context,
+        ):
+            result = batcher._send_batch_sync([create_mock_event()])
+
+        assert result is True
+        headers = client.post.call_args.kwargs["headers"]
+        assert headers["X-Custom-API-Key"] == "test-key"
+        assert "X-API-Key" not in headers
+
+    def test_build_batch_request_uses_settings_api_key_header(self):
+        original_settings = get_settings().model_dump()
+        try:
+            configure_settings(
+                api_key="settings-key",
+                api_key_header="X-Custom-API-Key",
+            )
+            batcher = EventBatcher()
+
+            _, headers, _ = batcher._build_batch_request([create_mock_event()])
+
+            assert headers["X-Custom-API-Key"] == "settings-key"
+            assert "X-API-Key" not in headers
+        finally:
+            configure_settings(**original_settings)
 
     def test_send_batch_sync_returns_false_on_401_without_retry(self):
         batcher = EventBatcher()
@@ -1069,10 +1116,12 @@ class TestInitObservability:
             result = init_observability(
                 server_url="http://test:8000",
                 api_key="test-key",
+                api_key_header="X-Custom-API-Key",
                 enabled=True,
             )
             assert result is not None
             assert isinstance(result, EventBatcher)
+            assert result.api_key_header == "X-Custom-API-Key"
             assert result._running is True
             assert get_event_sink() is not None
 

--- a/sdks/python/tests/test_runtime_auth.py
+++ b/sdks/python/tests/test_runtime_auth.py
@@ -50,6 +50,54 @@ def test_runtime_token_cache_is_keyed_by_server_and_target() -> None:
     )
 
 
+def test_runtime_token_cache_is_keyed_by_client_identity() -> None:
+    cache = RuntimeTokenCache()
+    token = _runtime_token()
+
+    cache.set(token, cache_identity="client-a")
+
+    assert (
+        cache.get(
+            "https://server-a.test",
+            "log_stream",
+            "ls-1",
+            cache_identity="client-a",
+            refresh_margin_seconds=0,
+        )
+        == token
+    )
+    assert (
+        cache.get(
+            "https://server-a.test",
+            "log_stream",
+            "ls-1",
+            cache_identity="client-b",
+            refresh_margin_seconds=0,
+        )
+        is None
+    )
+
+    cache.mark_jwt_unavailable(
+        server_url="https://server-a.test",
+        target_type="log_stream",
+        target_id="ls-1",
+        cache_identity="client-b",
+    )
+
+    assert not cache.is_jwt_unavailable(
+        "https://server-a.test",
+        "log_stream",
+        "ls-1",
+        cache_identity="client-a",
+    )
+    assert cache.is_jwt_unavailable(
+        "https://server-a.test",
+        "log_stream",
+        "ls-1",
+        cache_identity="client-b",
+    )
+
+
 def test_runtime_token_repr_redacts_jwt() -> None:
     token = _runtime_token(token="raw-jwt-value")
 

--- a/sdks/python/tests/test_runtime_auth.py
+++ b/sdks/python/tests/test_runtime_auth.py
@@ -1,0 +1,232 @@
+"""Tests for Agent Control SDK runtime auth helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from agent_control.runtime_auth import (
+    RuntimeToken,
+    RuntimeTokenCache,
+    normalize_runtime_auth_mode,
+    parse_runtime_token_exchange_response,
+)
+
+
+def _runtime_token(
+    *,
+    token: str = "token",
+    server_url: str = "https://server-a.test",
+    target_type: str = "log_stream",
+    target_id: str = "ls-1",
+    expires_at: datetime | None = None,
+) -> RuntimeToken:
+    return RuntimeToken(
+        token=token,
+        expires_at=expires_at or datetime.now(UTC) + timedelta(minutes=5),
+        server_url=server_url,
+        target_type=target_type,
+        target_id=target_id,
+        scopes=("runtime.use",),
+    )
+
+
+def test_runtime_token_cache_is_keyed_by_server_and_target() -> None:
+    cache = RuntimeTokenCache()
+    token = _runtime_token()
+
+    cache.set(token)
+
+    assert (
+        cache.get("https://server-a.test", "log_stream", "ls-1", refresh_margin_seconds=0) == token
+    )
+    assert (
+        cache.get("https://server-b.test", "log_stream", "ls-1", refresh_margin_seconds=0) is None
+    )
+    assert (
+        cache.get("https://server-a.test", "log_stream", "ls-2", refresh_margin_seconds=0) is None
+    )
+
+
+def test_runtime_token_cache_drops_stale_tokens() -> None:
+    cache = RuntimeTokenCache()
+    cache.set(_runtime_token(expires_at=datetime.now(UTC) + timedelta(seconds=5)))
+
+    assert (
+        cache.get("https://server-a.test", "log_stream", "ls-1", refresh_margin_seconds=30) is None
+    )
+    assert (
+        cache.get("https://server-a.test", "log_stream", "ls-1", refresh_margin_seconds=0) is None
+    )
+
+
+def test_runtime_token_cache_tracks_jwt_unavailable_by_server_and_target() -> None:
+    cache = RuntimeTokenCache()
+
+    cache.mark_jwt_unavailable(
+        server_url="https://server-a.test",
+        target_type="log_stream",
+        target_id="ls-1",
+    )
+
+    assert cache.is_jwt_unavailable("https://server-a.test", "log_stream", "ls-1")
+    assert not cache.is_jwt_unavailable("https://server-b.test", "log_stream", "ls-1")
+
+    cache.set(_runtime_token())
+
+    assert not cache.is_jwt_unavailable("https://server-a.test", "log_stream", "ls-1")
+
+
+def test_runtime_token_cache_global_unavailable_clears_cache() -> None:
+    cache = RuntimeTokenCache()
+    cache.set(_runtime_token())
+
+    cache.mark_jwt_unavailable(globally=True)
+
+    assert cache.is_jwt_unavailable("https://server-a.test", "log_stream", "ls-1")
+    assert (
+        cache.get("https://server-a.test", "log_stream", "ls-1", refresh_margin_seconds=0) is None
+    )
+
+    cache.clear()
+
+    assert not cache.is_jwt_unavailable("https://server-a.test", "log_stream", "ls-1")
+
+
+def test_runtime_token_cache_remove_drops_one_token() -> None:
+    cache = RuntimeTokenCache()
+    cache.set(_runtime_token(target_id="ls-1"))
+    token_2 = _runtime_token(token="token-2", target_id="ls-2")
+    cache.set(token_2)
+
+    cache.remove("https://server-a.test", "log_stream", "ls-1")
+
+    assert (
+        cache.get("https://server-a.test", "log_stream", "ls-1", refresh_margin_seconds=0) is None
+    )
+    assert (
+        cache.get("https://server-a.test", "log_stream", "ls-2", refresh_margin_seconds=0)
+        == token_2
+    )
+
+
+def test_runtime_token_cache_evicts_oldest_token_when_full() -> None:
+    cache = RuntimeTokenCache(max_entries=1)
+    token_1 = _runtime_token(target_id="ls-1")
+    token_2 = _runtime_token(token="token-2", target_id="ls-2")
+
+    cache.set(token_1)
+    cache.set(token_2)
+
+    assert (
+        cache.get("https://server-a.test", "log_stream", "ls-1", refresh_margin_seconds=0) is None
+    )
+    assert (
+        cache.get("https://server-a.test", "log_stream", "ls-2", refresh_margin_seconds=0)
+        == token_2
+    )
+
+
+def test_runtime_token_cache_rejects_empty_capacity() -> None:
+    with pytest.raises(ValueError, match="max_entries"):
+        RuntimeTokenCache(max_entries=0)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (None, "auto"),
+        ("", "auto"),
+        (" NO_AUTH ", "none"),
+        ("header", "api_key"),
+        ("api_key", "api_key"),
+        ("jwt", "jwt"),
+    ],
+)
+def test_normalize_runtime_auth_mode(raw: str | None, expected: str) -> None:
+    assert normalize_runtime_auth_mode(raw) == expected
+
+
+def test_normalize_runtime_auth_mode_rejects_unknown_mode() -> None:
+    with pytest.raises(ValueError, match="runtime_auth_mode must be one of"):
+        normalize_runtime_auth_mode("cookie")
+
+
+def test_parse_runtime_token_exchange_response_normalizes_zulu_expiry() -> None:
+    token = parse_runtime_token_exchange_response(
+        {
+            "token": "runtime-token",
+            "expires_at": "2026-05-07T15:00:00Z",
+            "target_type": "log_stream",
+            "target_id": "ls-1",
+            "scopes": ["runtime.use"],
+        },
+        server_url="https://server-a.test",
+    )
+
+    assert token.token == "runtime-token"
+    assert token.expires_at == datetime(2026, 5, 7, 15, 0, tzinfo=UTC)
+    assert token.server_url == "https://server-a.test"
+    assert token.target_type == "log_stream"
+    assert token.target_id == "ls-1"
+    assert token.scopes == ("runtime.use",)
+
+
+def test_parse_runtime_token_exchange_response_treats_naive_expiry_as_utc() -> None:
+    token = parse_runtime_token_exchange_response(
+        {
+            "token": "runtime-token",
+            "expires_at": "2026-05-07T15:00:00",
+            "target_type": "log_stream",
+            "target_id": "ls-1",
+            "scopes": ["runtime.use"],
+        },
+        server_url="https://server-a.test",
+    )
+
+    assert token.expires_at == datetime(2026, 5, 7, 15, 0, tzinfo=UTC)
+
+
+@pytest.mark.parametrize(
+    ("payload", "match"),
+    [
+        ({}, "token"),
+        ({"token": "runtime-token"}, "expires_at"),
+        ({"token": "runtime-token", "expires_at": "2026-05-07T15:00:00Z"}, "target_type"),
+        (
+            {
+                "token": "runtime-token",
+                "expires_at": "2026-05-07T15:00:00Z",
+                "target_type": "log_stream",
+            },
+            "target_id",
+        ),
+        (
+            {
+                "token": "runtime-token",
+                "expires_at": "2026-05-07T15:00:00Z",
+                "target_type": "log_stream",
+                "target_id": "ls-1",
+                "scopes": "runtime.use",
+            },
+            "scopes",
+        ),
+        (
+            {
+                "token": "runtime-token",
+                "expires_at": "2026-05-07T15:00:00Z",
+                "target_type": "log_stream",
+                "target_id": "ls-1",
+                "scopes": ["runtime.use", 1],
+            },
+            "non-string scope",
+        ),
+    ],
+)
+def test_parse_runtime_token_exchange_response_rejects_invalid_payloads(
+    payload: dict[str, object],
+    match: str,
+) -> None:
+    with pytest.raises(RuntimeError, match=match):
+        parse_runtime_token_exchange_response(payload, server_url="https://server-a.test")

--- a/sdks/python/tests/test_runtime_auth.py
+++ b/sdks/python/tests/test_runtime_auth.py
@@ -98,18 +98,37 @@ def test_runtime_token_cache_target_unavailable_marker_expires() -> None:
     assert not cache.is_jwt_unavailable("https://server-a.test", "log_stream", "ls-1")
 
 
-def test_runtime_token_cache_global_unavailable_clears_cache() -> None:
+def test_runtime_token_cache_server_unavailable_clears_server_cache() -> None:
     cache = RuntimeTokenCache()
     cache.set(_runtime_token())
+    token_2 = _runtime_token(
+        token="token-2",
+        server_url="https://server-b.test",
+        target_id="ls-2",
+    )
+    cache.set(token_2)
 
-    cache.mark_jwt_unavailable(globally=True)
+    cache.mark_jwt_unavailable(server_url="https://server-a.test", globally=True)
 
     assert cache.is_jwt_unavailable("https://server-a.test", "log_stream", "ls-1")
+    assert not cache.is_jwt_unavailable("https://server-b.test", "log_stream", "ls-2")
     assert (
         cache.get("https://server-a.test", "log_stream", "ls-1", refresh_margin_seconds=0) is None
     )
+    assert (
+        cache.get("https://server-b.test", "log_stream", "ls-2", refresh_margin_seconds=0)
+        == token_2
+    )
 
     cache.clear()
+
+    assert not cache.is_jwt_unavailable("https://server-a.test", "log_stream", "ls-1")
+
+
+def test_runtime_token_cache_server_unavailable_marker_expires() -> None:
+    cache = RuntimeTokenCache(jwt_unavailable_ttl_seconds=0)
+
+    cache.mark_jwt_unavailable(server_url="https://server-a.test", globally=True)
 
     assert not cache.is_jwt_unavailable("https://server-a.test", "log_stream", "ls-1")
 
@@ -159,6 +178,16 @@ async def test_runtime_token_cache_token_eviction_preserves_exchange_lock() -> N
     assert cache.exchange_lock("https://server-a.test", "log_stream", "ls-1") is lock
 
 
+@pytest.mark.asyncio
+async def test_runtime_token_cache_evicts_idle_exchange_locks() -> None:
+    cache = RuntimeTokenCache(max_entries=1)
+    first = cache.exchange_lock("https://server-a.test", "log_stream", "ls-1")
+
+    cache.exchange_lock("https://server-a.test", "log_stream", "ls-2")
+
+    assert cache.exchange_lock("https://server-a.test", "log_stream", "ls-1") is not first
+
+
 def test_runtime_token_cache_exchange_locks_are_loop_scoped(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -178,6 +207,18 @@ def test_runtime_token_cache_exchange_locks_are_loop_scoped(
 def test_runtime_token_cache_rejects_empty_capacity() -> None:
     with pytest.raises(ValueError, match="max_entries"):
         RuntimeTokenCache(max_entries=0)
+
+
+def test_runtime_token_cache_rejects_negative_unavailable_ttl() -> None:
+    with pytest.raises(ValueError, match="jwt_unavailable_ttl_seconds"):
+        RuntimeTokenCache(jwt_unavailable_ttl_seconds=-1)
+
+
+def test_runtime_token_cache_rejects_negative_marker_ttl() -> None:
+    cache = RuntimeTokenCache()
+
+    with pytest.raises(ValueError, match="ttl_seconds"):
+        cache.mark_jwt_unavailable(ttl_seconds=-1)
 
 
 @pytest.mark.parametrize(

--- a/sdks/python/tests/test_runtime_auth.py
+++ b/sdks/python/tests/test_runtime_auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -49,6 +50,12 @@ def test_runtime_token_cache_is_keyed_by_server_and_target() -> None:
     )
 
 
+def test_runtime_token_repr_redacts_jwt() -> None:
+    token = _runtime_token(token="raw-jwt-value")
+
+    assert "raw-jwt-value" not in repr(token)
+
+
 def test_runtime_token_cache_drops_stale_tokens() -> None:
     cache = RuntimeTokenCache()
     cache.set(_runtime_token(expires_at=datetime.now(UTC) + timedelta(seconds=5)))
@@ -74,6 +81,19 @@ def test_runtime_token_cache_tracks_jwt_unavailable_by_server_and_target() -> No
     assert not cache.is_jwt_unavailable("https://server-b.test", "log_stream", "ls-1")
 
     cache.set(_runtime_token())
+
+    assert not cache.is_jwt_unavailable("https://server-a.test", "log_stream", "ls-1")
+
+
+def test_runtime_token_cache_target_unavailable_marker_expires() -> None:
+    cache = RuntimeTokenCache()
+
+    cache.mark_jwt_unavailable(
+        server_url="https://server-a.test",
+        target_type="log_stream",
+        target_id="ls-1",
+        ttl_seconds=0,
+    )
 
     assert not cache.is_jwt_unavailable("https://server-a.test", "log_stream", "ls-1")
 
@@ -126,6 +146,33 @@ def test_runtime_token_cache_evicts_oldest_token_when_full() -> None:
         cache.get("https://server-a.test", "log_stream", "ls-2", refresh_margin_seconds=0)
         == token_2
     )
+
+
+@pytest.mark.asyncio
+async def test_runtime_token_cache_token_eviction_preserves_exchange_lock() -> None:
+    cache = RuntimeTokenCache(max_entries=1)
+    lock = cache.exchange_lock("https://server-a.test", "log_stream", "ls-1")
+
+    cache.set(_runtime_token(target_id="ls-1"))
+    cache.set(_runtime_token(token="token-2", target_id="ls-2"))
+
+    assert cache.exchange_lock("https://server-a.test", "log_stream", "ls-1") is lock
+
+
+def test_runtime_token_cache_exchange_locks_are_loop_scoped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache = RuntimeTokenCache()
+    loop_1 = object()
+    loop_2 = object()
+
+    monkeypatch.setattr(asyncio, "get_running_loop", lambda: loop_1)
+    first = cache.exchange_lock("https://server-a.test", "log_stream", "ls-1")
+
+    monkeypatch.setattr(asyncio, "get_running_loop", lambda: loop_2)
+    second = cache.exchange_lock("https://server-a.test", "log_stream", "ls-1")
+
+    assert first != second
 
 
 def test_runtime_token_cache_rejects_empty_capacity() -> None:

--- a/sdks/python/tests/test_shutdown.py
+++ b/sdks/python/tests/test_shutdown.py
@@ -9,10 +9,9 @@ import threading
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
-
 import agent_control
 import agent_control.observability as obs_mod
+import pytest
 from agent_control._state import state
 from agent_control.observability import EventBatcher
 
@@ -64,6 +63,7 @@ class TestShutdownSync:
         state.server_controls = [{"name": "test"}]
         state.server_url = "http://localhost:8000"
         state.api_key = "key"
+        state.api_key_header = "X-Custom-API-Key"
 
         agent_control.shutdown()
 
@@ -72,6 +72,7 @@ class TestShutdownSync:
         assert state.server_controls is None
         assert state.server_url is None
         assert state.api_key is None
+        assert state.api_key_header is None
 
     def test_shutdown_idempotent(self):
         agent_control.shutdown()


### PR DESCRIPTION
## Summary

- Add Python SDK runtime auth modes: `auto`, `none`, `api_key`, and `jwt`.
- Exchange target-bound runtime tokens for target-bearing evaluation requests.
- Cache runtime tokens per target, refresh before expiry, and retry once after a rejected runtime JWT.
- Keep no-target, no-auth, and API-key evaluation paths unchanged.
- Make the API-key header name configurable.

## Stack

- Based on #214.

## Testing

- `make prepush`
