### PR TITLE
fix(examples/langchain): add agent-control-telemetry workspace dep

### DIFF
--- a/examples/langchain/pyproject.toml
+++ b/examples/langchain/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "agent-control-models",
     "agent-control-evaluators",
     "agent-control-sdk",
+    "agent-control-telemetry",
     "langchain>=0.3.0",
     "langchain-community>=0.3.0",
     "langchain-openai>=0.2.0",
@@ -43,3 +44,4 @@ agent-control-sdk = { path = "../../sdks/python", editable = true }
 agent-control-models = { path = "../../models", editable = true }
 agent-control-engine = { path = "../../engine", editable = true }
 agent-control-evaluators = { path = "../../evaluators/builtin", editable = true }
+agent-control-telemetry = { path = "../../telemetry", editable = true }


### PR DESCRIPTION
## Summary

- `examples/langchain` fails to import `agent_control` because the SDK's `__init__.py` unconditionally imports `agent_control_telemetry` (added in #177), but the example's editable install via `[tool.uv.sources]` never pulls that workspace package into its venv.
- Adds `agent-control-telemetry` to `dependencies` and a matching `[tool.uv.sources]` entry pointing at `../../telemetry`, mirroring the pattern used for the other workspace packages (`-models`, `-engine`, `-evaluators`).
- Same shape of fix as `fix/steer-action-demo-missing-telemetry-dep`. Several other examples (galileo, cisco_ai_defense, strands_agents, google_adk_*, deepeval, crewai/*) likely need the same patch but are out of scope here.

## Repro (before this PR)

```
cd examples/langchain
uv run python setup_sql_controls.py
# ModuleNotFoundError: No module named 'agent_control_telemetry'
```

## Test plan

- [ ] `cd examples/langchain && uv sync` resolves cleanly (locally: 82 packages, telemetry built from `../../telemetry`)
- [ ] `uv run python -c "from agent_control import Agent, AgentControlClient, agents, controls"` succeeds
- [ ] `uv run python setup_sql_controls.py` reaches the server and registers controls
- [ ] `uv run python sql_agent_protection.py` runs end-to-end against the Agent Control server

🤖 Generated with [Claude Code](https://claude.com/claude-code)