### PR TITLE
fix(examples): declare local SDK workspace deps

### DIFF
--- a/examples/cisco_ai_defense/pyproject.toml
+++ b/examples/cisco_ai_defense/pyproject.toml
@@ -8,10 +8,11 @@ dependencies = [
     "httpx>=0.24.0",
     # Use the local SDK for decorator-based example
     "agent-control-sdk>=5.2.0",
-    # When using SDK from path/editable, engine and models are not vendored
+    # When using SDK from path/editable, engine, models, and telemetry are not vendored
     "agent-control-engine>=5.2.0",
     "agent-control-models>=5.2.0",
     "agent-control-evaluators>=5.2.0",
+    "agent-control-telemetry>=5.2.0",
 ]
 
 [project.optional-dependencies]
@@ -38,3 +39,4 @@ agent-control-sdk = { path = "../../sdks/python", editable = true }
 agent-control-models = { path = "../../models", editable = true }
 agent-control-engine = { path = "../../engine", editable = true }
 agent-control-evaluators = { path = "../../evaluators/builtin", editable = true }
+agent-control-telemetry = { path = "../../telemetry", editable = true }

--- a/examples/google_adk_callbacks/pyproject.toml
+++ b/examples/google_adk_callbacks/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "agent-control-engine",
     "agent-control-evaluators",
     "agent-control-models",
+    "agent-control-telemetry",
     "agent-control-sdk",
     "google-adk>=1.0.0,<2.0.0",
     "google-genai>=1.0.0",
@@ -26,3 +27,4 @@ agent-control-sdk = { path = "../../sdks/python", editable = true }
 agent-control-models = { path = "../../models", editable = true }
 agent-control-engine = { path = "../../engine", editable = true }
 agent-control-evaluators = { path = "../../evaluators/builtin", editable = true }
+agent-control-telemetry = { path = "../../telemetry", editable = true }

--- a/examples/google_adk_decorator/pyproject.toml
+++ b/examples/google_adk_decorator/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "agent-control-engine",
     "agent-control-evaluators",
     "agent-control-models",
+    "agent-control-telemetry",
     "agent-control-sdk",
     "google-adk>=1.0.0,<2.0.0",
     "google-genai>=1.0.0",
@@ -26,3 +27,4 @@ agent-control-sdk = { path = "../../sdks/python", editable = true }
 agent-control-models = { path = "../../models", editable = true }
 agent-control-engine = { path = "../../engine", editable = true }
 agent-control-evaluators = { path = "../../evaluators/builtin", editable = true }
+agent-control-telemetry = { path = "../../telemetry", editable = true }

--- a/examples/google_adk_plugin/pyproject.toml
+++ b/examples/google_adk_plugin/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "agent-control-engine",
     "agent-control-evaluators",
     "agent-control-models",
+    "agent-control-telemetry",
     "agent-control-sdk",
     "google-adk>=1.0.0,<2.0.0",
     "google-genai>=1.0.0",
@@ -26,3 +27,4 @@ agent-control-sdk = { path = "../../sdks/python", editable = true }
 agent-control-models = { path = "../../models", editable = true }
 agent-control-engine = { path = "../../engine", editable = true }
 agent-control-evaluators = { path = "../../evaluators/builtin", editable = true }
+agent-control-telemetry = { path = "../../telemetry", editable = true }

--- a/examples/langchain/pyproject.toml
+++ b/examples/langchain/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "agent-control-engine",
     "agent-control-models",
     "agent-control-evaluators",
+    "agent-control-telemetry",
     "agent-control-sdk",
     "langchain>=0.3.0",
     "langchain-community>=0.3.0",
@@ -43,3 +44,4 @@ agent-control-sdk = { path = "../../sdks/python", editable = true }
 agent-control-models = { path = "../../models", editable = true }
 agent-control-engine = { path = "../../engine", editable = true }
 agent-control-evaluators = { path = "../../evaluators/builtin", editable = true }
+agent-control-telemetry = { path = "../../telemetry", editable = true }

--- a/examples/steer_action_demo/pyproject.toml
+++ b/examples/steer_action_demo/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "agent-control-engine",
     "agent-control-models",
     "agent-control-evaluators",
+    "agent-control-telemetry",
     "agent-control-sdk",
     "langchain>=0.3.0",
     "langchain-community>=0.3.0",
@@ -38,3 +39,4 @@ agent-control-sdk = { path = "../../sdks/python", editable = true }
 agent-control-models = { path = "../../models", editable = true }
 agent-control-engine = { path = "../../engine", editable = true }
 agent-control-evaluators = { path = "../../evaluators/builtin", editable = true }
+agent-control-telemetry = { path = "../../telemetry", editable = true }

--- a/examples/strands_agents/pyproject.toml
+++ b/examples/strands_agents/pyproject.toml
@@ -6,6 +6,9 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "agent-control-sdk[strands-agents]>=6.3.0",
+    "agent-control-engine>=6.3.0",
+    "agent-control-evaluators>=6.3.0",
+    "agent-control-models>=6.3.0",
     "agent-control-telemetry>=6.3.0",
     "openai>=1.0.0",
     "python-dotenv>=1.0.0",
@@ -42,4 +45,7 @@ python_files = ["*_test.py", "test_*.py"]
 
 [tool.uv.sources]
 agent-control-sdk = { path = "../../sdks/python", editable = true }
+agent-control-models = { path = "../../models", editable = true }
+agent-control-engine = { path = "../../engine", editable = true }
+agent-control-evaluators = { path = "../../evaluators/builtin", editable = true }
 agent-control-telemetry = { path = "../../telemetry", editable = true }

--- a/examples/strands_agents/pyproject.toml
+++ b/examples/strands_agents/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "agent-control-sdk[strands-agents]>=6.3.0",
+    "agent-control-telemetry>=6.3.0",
     "openai>=1.0.0",
     "python-dotenv>=1.0.0",
     "httpx>=0.24.0",
@@ -41,3 +42,4 @@ python_files = ["*_test.py", "test_*.py"]
 
 [tool.uv.sources]
 agent-control-sdk = { path = "../../sdks/python", editable = true }
+agent-control-telemetry = { path = "../../telemetry", editable = true }


### PR DESCRIPTION
## Summary

Fix example projects that install `agent-control-sdk` from the local workspace path.

Published SDK wheels bundle the SDK's internal sibling packages where appropriate, but local path installs bypass that wheel bundling. These examples therefore need to declare the sibling workspace packages they import through the SDK.

## Changes

- Adds `agent-control-telemetry` to examples that already use local `agent-control-sdk` path sources.
- Makes `examples/strands_agents` consistent with the other local SDK examples by declaring the local `agent-control-engine`, `agent-control-evaluators`, `agent-control-models`, and `agent-control-telemetry` sources.

## Verification

- `git diff --check`
- From `examples/strands_agents`:

```bash
uv run python -c "import agent_control; from agent_control_telemetry.trace_context import TraceContext; print('ok')"
```

