### PR TITLE
fix(server): prevent migration lock transactions

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -27,6 +27,21 @@ Postgres container exposed on a different host port, set
 `AGENT_CONTROL_DB_HOST_PORT` and point the server at the same value with
 `AGENT_CONTROL_DB_PORT`.
 
+## Database migrations
+
+The server package includes the `agent-control-migrate` command for bundled
+Alembic migrations.
+
+In production, migrations are serialized with a Postgres advisory lock. Alembic
+runs each migration revision in its own transaction, so if an upgrade across
+multiple revisions fails, earlier revisions may already be committed. Check the
+current revision before retrying:
+
+```bash
+agent-control-migrate current
+agent-control-migrate upgrade head
+```
+
 ## Configuration
 
 Server configuration is driven by environment variables (database, auth, observability, evaluators). For the full list and examples, see the docs.

--- a/server/alembic/env.py
+++ b/server/alembic/env.py
@@ -1,9 +1,8 @@
 import os
 import sys
 
-from sqlalchemy import create_engine, pool
-
 from alembic import context
+from sqlalchemy import create_engine, pool
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 
@@ -30,6 +29,7 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         compare_type=True,
+        transaction_per_migration=True,
     )
     with context.begin_transaction():
         context.run_migrations()
@@ -39,7 +39,12 @@ def run_migrations_online() -> None:
     url = _get_migration_url()
     connectable = create_engine(url, future=True, poolclass=pool.NullPool)
     with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata, compare_type=True)
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            compare_type=True,
+            transaction_per_migration=True,
+        )
         with context.begin_transaction():
             context.run_migrations()
 

--- a/server/src/agent_control_server/migrate.py
+++ b/server/src/agent_control_server/migrate.py
@@ -137,7 +137,7 @@ def _serialized_migration(cfg: Config, *, enabled: bool) -> Iterator[None]:
         yield
         return
 
-    engine = create_engine(url, future=True, poolclass=NullPool)
+    engine = create_engine(url, future=True, poolclass=NullPool, isolation_level="AUTOCOMMIT")
     try:
         with engine.connect() as connection:
             _acquire_migration_lock(connection, _migration_lock_timeout_seconds())

--- a/server/tests/test_migrate.py
+++ b/server/tests/test_migrate.py
@@ -94,13 +94,19 @@ def test_serialized_migration_acquires_and_releases_postgres_lock(monkeypatch) -
     connection = _FakeConnection([False, True])
     engine = _FakeEngine(connection)
     sleeps: list[float] = []
+    create_engine_kwargs: dict[str, object] = {}
 
-    monkeypatch.setattr(migrate, "create_engine", lambda *args, **kwargs: engine)
+    def fake_create_engine(*args: object, **kwargs: object) -> _FakeEngine:
+        create_engine_kwargs.update(kwargs)
+        return engine
+
+    monkeypatch.setattr(migrate, "create_engine", fake_create_engine)
     monkeypatch.setattr(migrate.time, "sleep", lambda seconds: sleeps.append(seconds))
 
     with migrate._serialized_migration(cfg, enabled=True):
         pass
 
+    assert create_engine_kwargs["isolation_level"] == "AUTOCOMMIT"
     assert connection.statements == [
         "SELECT pg_try_advisory_lock(:class_id, :object_id)",
         "SELECT pg_try_advisory_lock(:class_id, :object_id)",


### PR DESCRIPTION
## Summary
- run Alembic with transaction_per_migration to match Galileo API migration behavior
- keep the migration advisory-lock connection in AUTOCOMMIT so it does not block CREATE INDEX CONCURRENTLY
- assert the advisory-lock engine is created with AUTOCOMMIT

## Validation
- uv run --package agent-control-server pytest server/tests/test_migrate.py -q
- uv run ruff check --config pyproject.toml server/alembic/env.py server/src/agent_control_server/migrate.py server/tests/test_migrate.py
- git diff --check