### PR TITLE
fix(server): scope auth upstream CA to HTTP provider

### DIFF
--- a/server/src/agent_control_server/auth_framework/config.py
+++ b/server/src/agent_control_server/auth_framework/config.py
@@ -48,6 +48,7 @@ _UPSTREAM_TIMEOUT_ENV = "AGENT_CONTROL_AUTH_UPSTREAM_TIMEOUT_SECONDS"
 _UPSTREAM_TOKEN_ENV = "AGENT_CONTROL_AUTH_UPSTREAM_SERVICE_TOKEN"
 _UPSTREAM_TOKEN_HEADER_ENV = "AGENT_CONTROL_AUTH_UPSTREAM_SERVICE_TOKEN_HEADER"
 _UPSTREAM_EXTRA_FORWARD_HEADERS_ENV = "AGENT_CONTROL_AUTH_UPSTREAM_EXTRA_FORWARD_HEADERS"
+_UPSTREAM_CA_FILE_ENV = "AGENT_CONTROL_AUTH_UPSTREAM_CA_FILE"
 
 # Runtime flow.
 _RUNTIME_MODE_ENV = "AGENT_CONTROL_RUNTIME_AUTH_MODE"
@@ -216,6 +217,7 @@ def _build_default_provider() -> RequestAuthorizer:
         extra_forward_headers = _parse_extra_forward_headers(
             os.environ.get(_UPSTREAM_EXTRA_FORWARD_HEADERS_ENV)
         )
+        ca_file = (os.environ.get(_UPSTREAM_CA_FILE_ENV) or "").strip() or None
         _logger.info("Default auth provider: http_upstream url=%s", url)
         return HttpUpstreamAuthProvider(
             HttpUpstreamConfig(
@@ -224,6 +226,7 @@ def _build_default_provider() -> RequestAuthorizer:
                 service_token=token,
                 service_token_header=token_header,
                 extra_forward_headers=extra_forward_headers,
+                ca_file=ca_file,
             )
         )
     raise RuntimeError(

--- a/server/src/agent_control_server/auth_framework/config.py
+++ b/server/src/agent_control_server/auth_framework/config.py
@@ -26,6 +26,7 @@ The framework supports two flows:
 from __future__ import annotations
 
 import os
+import ssl
 from dataclasses import dataclass
 
 from ..config import auth_settings
@@ -219,16 +220,21 @@ def _build_default_provider() -> RequestAuthorizer:
         )
         ca_file = (os.environ.get(_UPSTREAM_CA_FILE_ENV) or "").strip() or None
         _logger.info("Default auth provider: http_upstream url=%s", url)
-        return HttpUpstreamAuthProvider(
-            HttpUpstreamConfig(
-                url=url,
-                timeout_seconds=timeout,
-                service_token=token,
-                service_token_header=token_header,
-                extra_forward_headers=extra_forward_headers,
-                ca_file=ca_file,
+        try:
+            return HttpUpstreamAuthProvider(
+                HttpUpstreamConfig(
+                    url=url,
+                    timeout_seconds=timeout,
+                    service_token=token,
+                    service_token_header=token_header,
+                    extra_forward_headers=extra_forward_headers,
+                    ca_file=ca_file,
+                )
             )
-        )
+        except (OSError, ssl.SSLError) as exc:
+            raise RuntimeError(
+                f"{_UPSTREAM_CA_FILE_ENV}={ca_file!r} not found or unreadable."
+            ) from exc
     raise RuntimeError(
         f"Unknown {_MODE_ENV}={mode!r}; expected 'none', 'api_key', 'header', "
         "or 'http_upstream'."

--- a/server/src/agent_control_server/auth_framework/providers/http_upstream.py
+++ b/server/src/agent_control_server/auth_framework/providers/http_upstream.py
@@ -41,6 +41,7 @@ from local auth setup failures.
 
 from __future__ import annotations
 
+import ssl
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
@@ -150,6 +151,9 @@ class HttpUpstreamConfig:
     dropped. Names duplicating the default set or each other (after
     case-folding) are deduplicated."""
 
+    ca_file: str | None = None
+    """Optional CA bundle path used only when verifying the auth upstream."""
+
     def __post_init__(self) -> None:
         if self.service_token is None:
             return
@@ -174,7 +178,16 @@ class HttpUpstreamAuthProvider(RequestAuthorizer):
     ) -> None:
         self._config = config
         self._owns_client = client is None
-        self._client = client or httpx.AsyncClient(timeout=config.timeout_seconds)
+        if client is not None:
+            self._client = client
+        elif config.ca_file is not None:
+            ssl_context = ssl.create_default_context(cafile=config.ca_file)
+            self._client = httpx.AsyncClient(
+                timeout=config.timeout_seconds,
+                verify=ssl_context,
+            )
+        else:
+            self._client = httpx.AsyncClient(timeout=config.timeout_seconds)
 
     async def aclose(self) -> None:
         """Release the HTTP client if this provider created it."""

--- a/server/tests/test_auth_framework.py
+++ b/server/tests/test_auth_framework.py
@@ -7,7 +7,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
-
 from agent_control_server.auth_framework.core import (
     Operation,
     Principal,
@@ -227,6 +226,33 @@ def _build_upstream(
     return HttpUpstreamAuthProvider(config, client=client)
 
 
+def _patch_owned_upstream_client(monkeypatch) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+    ssl_context = object()
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+        async def aclose(self) -> None:
+            captured["closed"] = True
+
+    def fake_create_default_context(*, cafile: str | None = None) -> object:
+        captured["cafile"] = cafile
+        return ssl_context
+
+    monkeypatch.setattr(
+        "agent_control_server.auth_framework.providers.http_upstream.httpx.AsyncClient",
+        FakeAsyncClient,
+    )
+    monkeypatch.setattr(
+        "agent_control_server.auth_framework.providers.http_upstream.ssl.create_default_context",
+        fake_create_default_context,
+    )
+    captured["ssl_context"] = ssl_context
+    return captured
+
+
 @pytest.mark.asyncio
 async def test_http_upstream_returns_principal_on_200():
     captured: dict[str, Any] = {}
@@ -289,6 +315,26 @@ def test_http_upstream_rejects_extra_forwarded_service_token_header_collision():
             service_token_header="X-Custom-Auth",
             extra_forward_headers=("x-custom-auth",),
         )
+
+
+@pytest.mark.asyncio
+async def test_http_upstream_uses_ca_file_for_owned_client(monkeypatch):
+    captured = _patch_owned_upstream_client(monkeypatch)
+
+    provider = HttpUpstreamAuthProvider(
+        HttpUpstreamConfig(
+            url="https://upstream.example/check",
+            timeout_seconds=2.5,
+            ca_file="/etc/agent-control/auth-upstream-ca/ca.crt",
+        )
+    )
+
+    await provider.aclose()
+
+    assert captured["timeout"] == 2.5
+    assert captured["cafile"] == "/etc/agent-control/auth-upstream-ca/ca.crt"
+    assert captured["verify"] is captured["ssl_context"]
+    assert captured["closed"] is True
 
 
 @pytest.mark.asyncio
@@ -772,7 +818,6 @@ def test_runtime_token_rejects_empty_required_claims(kwargs, message):
 def test_runtime_token_rejects_management_token_passed_to_runtime_verify():
     """A token without ``domain=runtime`` must be rejected by runtime verify."""
     import jwt
-
     from agent_control_server.auth_framework.runtime_token import (
         RuntimeTokenError,
         verify_runtime_token,
@@ -1418,6 +1463,31 @@ async def test_configure_http_upstream_extra_forward_headers_env(monkeypatch):
             "X-Deployer-Auth",
             "X-Deployer-Trace",
         )
+    finally:
+        await auth_config.teardown_auth()
+
+
+@pytest.mark.asyncio
+async def test_configure_http_upstream_ca_file_env(monkeypatch):
+    from agent_control_server.auth_framework import config as auth_config
+
+    clear_authorizers()
+    captured = _patch_owned_upstream_client(monkeypatch)
+
+    monkeypatch.setenv("AGENT_CONTROL_AUTH_MODE", "http_upstream")
+    monkeypatch.setenv("AGENT_CONTROL_AUTH_UPSTREAM_URL", "https://auth.example.test/check")
+    monkeypatch.setenv(
+        "AGENT_CONTROL_AUTH_UPSTREAM_CA_FILE",
+        " /etc/agent-control/auth-upstream-ca/ca.crt ",
+    )
+
+    try:
+        auth_config.configure_auth_from_env()
+        provider = get_authorizer(Operation.CONTROLS_READ)
+        assert isinstance(provider, HttpUpstreamAuthProvider)
+        assert provider._config.ca_file == "/etc/agent-control/auth-upstream-ca/ca.crt"
+        assert captured["cafile"] == "/etc/agent-control/auth-upstream-ca/ca.crt"
+        assert captured["verify"] is captured["ssl_context"]
     finally:
         await auth_config.teardown_auth()
 

--- a/server/tests/test_auth_framework.py
+++ b/server/tests/test_auth_framework.py
@@ -1492,6 +1492,35 @@ async def test_configure_http_upstream_ca_file_env(monkeypatch):
         await auth_config.teardown_auth()
 
 
+@pytest.mark.asyncio
+async def test_configure_http_upstream_ca_file_env_reports_bad_path(monkeypatch):
+    from agent_control_server.auth_framework import config as auth_config
+
+    def fake_create_default_context(*, cafile: str | None = None) -> object:
+        raise FileNotFoundError(cafile or "")
+
+    clear_authorizers()
+    monkeypatch.setattr(
+        "agent_control_server.auth_framework.providers.http_upstream.ssl.create_default_context",
+        fake_create_default_context,
+    )
+    monkeypatch.setenv("AGENT_CONTROL_AUTH_MODE", "http_upstream")
+    monkeypatch.setenv("AGENT_CONTROL_AUTH_UPSTREAM_URL", "https://auth.example.test/check")
+    monkeypatch.setenv(
+        "AGENT_CONTROL_AUTH_UPSTREAM_CA_FILE",
+        "/etc/agent-control/auth-upstream-ca/missing-ca.crt",
+    )
+
+    try:
+        with pytest.raises(
+            RuntimeError,
+            match=r"AGENT_CONTROL_AUTH_UPSTREAM_CA_FILE=.*missing-ca\.crt.*not found or unreadable",
+        ):
+            auth_config.configure_auth_from_env()
+    finally:
+        await auth_config.teardown_auth()
+
+
 def test_configure_runtime_jwt_requires_secret(monkeypatch):
     from agent_control_server.auth_framework import config as auth_config
 


### PR DESCRIPTION
## Summary
- add AGENT_CONTROL_AUTH_UPSTREAM_CA_FILE for http_upstream auth
- build an upstream-specific SSLContext instead of relying on process-wide SSL_CERT_FILE
- cover provider and env wiring behavior in auth framework tests

## Testing
- uv run --package agent-control-server pytest server/tests/test_auth_framework.py -q
- uv run --package agent-control-server ruff check --config pyproject.toml server/src/agent_control_server/auth_framework server/tests/test_auth_framework.py
- uv run --package agent-control-server mypy --config-file pyproject.toml server/src/agent_control_server/auth_framework
- pre-push hook ran make lint and make typecheck