### PR TITLE
fix(server): use plain psycopg with OS libpq

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,11 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@v4
 
+      - name: Install libpq runtime
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libpq5
+
       - name: Show versions
         run: |
           uv --version

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,8 +54,17 @@ jobs:
           context: .
           file: server/Dockerfile
           platforms: linux/amd64
+          load: ${{ github.event_name == 'pull_request' }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Smoke test psycopg runtime
+        if: github.event_name == 'pull_request'
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          image="$(printf '%s\n' "$IMAGE_TAGS" | head -n 1)"
+          docker run --rm --entrypoint python "$image" -c 'import os; import psycopg; from psycopg import pq; assert os.environ["PSYCOPG_IMPL"] == "python"; assert pq.version() > 0; print(f"psycopg {psycopg.__version__}, libpq {pq.version()}")'

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -28,6 +28,10 @@ FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
 
 WORKDIR /app
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+
 # Configure uv environment variables
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE=copy
@@ -75,6 +79,7 @@ ENV PATH="/app/.venv/bin:$PATH"
 # Set default environment variables
 ENV AGENT_CONTROL_HOST=0.0.0.0
 ENV AGENT_CONTROL_PORT=8000
+ENV PSYCOPG_IMPL=python
 
 # Expose the port
 EXPOSE 8000

--- a/server/README.md
+++ b/server/README.md
@@ -42,6 +42,16 @@ agent-control-migrate current
 agent-control-migrate upgrade head
 ```
 
+## PostgreSQL driver runtime
+
+`agent-control-server` depends on plain `psycopg`. The published Docker image
+installs Debian `libpq5` and sets `PSYCOPG_IMPL=python` so the server uses
+psycopg's Python implementation with the OS libpq library.
+
+For wheel-based deployments outside Docker, either install the OS libpq runtime
+package for your platform, or install `agent-control-server[binary]` if you want
+psycopg's bundled binary package.
+
 ## Configuration
 
 Server configuration is driven by environment variables (database, auth, observability, evaluators). For the full list and examples, see the docs.

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pydantic>=2.5.0",
     "pydantic-settings>=2.1.0",
     "SQLAlchemy>=2.0.0",
-    "psycopg[binary]>=3.1",
+    "psycopg>=3.1",
     "asyncpg>=0.29.0",
     "greenlet>=3.0",
     "alembic>=1.13.0",
@@ -34,6 +34,8 @@ license = {text = "Apache-2.0"}
 
 [project.optional-dependencies]
 galileo = ["agent-control-evaluator-galileo>=7.5.0"]
+binary = ["psycopg[binary]>=3.1"]
+c = ["psycopg[c]>=3.1"]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary
- Change `agent-control-server` to depend on plain `psycopg` instead of `psycopg[binary]`.
- Expose optional `binary` and `c` extras for applications that intentionally choose those psycopg implementations.
- Install Debian `libpq5` in the published server Docker image and set `PSYCOPG_IMPL=python`.
- Install `libpq5` in Python CI and add a Docker smoke test that verifies psycopg can load libpq inside the image.

## Why
The server package should not force bundled native psycopg libraries into downstream applications. Plain `psycopg` gives consumers control over the runtime implementation, while the published Docker image remains self-contained by shipping OS `libpq`.

## Validation
- GitHub checks passing: `ci`, `sdk-ts-ci`, `ui-ci`, `build-and-push-server`, `validate`, `codecov/patch`.
- `git diff --check`
- Parsed `.github/workflows/ci.yml` and `.github/workflows/docker-publish.yml`.
- `uv run --package agent-control-server ruff check --config pyproject.toml server/src server/tests/test_init_agent.py`
