### PR TITLE
fix(evaluators): use SQLGlot native extra without direct sqlglotc pin

### DIFF
--- a/evaluators/builtin/pyproject.toml
+++ b/evaluators/builtin/pyproject.toml
@@ -11,8 +11,7 @@ dependencies = [
     "pydantic>=2.12.4",
     "google-re2>=1.1",
     "jsonschema>=4.0.0",
-    "sqlglot[c]>=29.0.0,<29.1.0",
-    "sqlglotc>=29.0.0,<29.1.0",
+    "sqlglot[c]>=30.11.0,<30.12.0",
 ]
 
 [project.optional-dependencies]

--- a/evaluators/builtin/src/agent_control_evaluators/sql/evaluator.py
+++ b/evaluators/builtin/src/agent_control_evaluators/sql/evaluator.py
@@ -7,7 +7,7 @@ import asyncio
 import hashlib
 import logging
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, cast
 
 import sqlglot
 from agent_control_models import EvaluatorResult
@@ -239,7 +239,8 @@ class SQLEvaluator(Evaluator[SQLEvaluatorConfig]):
         top_level_where = top_level_select.find(exp.Where) if top_level_select else None
 
         # Single tree walk to collect all metrics
-        for node in stmt.walk():
+        for raw_node in stmt.walk():
+            node = cast(exp.Expression, raw_node)
             # Collect operations
             op_name = self._get_operation_name(node)
             if op_name:
@@ -310,7 +311,7 @@ class SQLEvaluator(Evaluator[SQLEvaluatorConfig]):
             # If we hit a SELECT node before the target, node is in a subquery
             if isinstance(current, exp.Select) and current is not target_node:
                 return False
-            current = current.parent
+            current = cast(exp.Expression | None, current.parent)
         return False
 
     def _is_in_where_clause(self, column: exp.Column) -> bool:
@@ -319,7 +320,7 @@ class SQLEvaluator(Evaluator[SQLEvaluatorConfig]):
         while current:
             if isinstance(current, exp.Where):
                 return True
-            current = current.parent
+            current = cast(exp.Expression | None, current.parent)
         return False
 
     def _is_in_top_level_select(
@@ -339,12 +340,12 @@ class SQLEvaluator(Evaluator[SQLEvaluatorConfig]):
             # If we hit another SELECT before the top-level, we're in a subquery
             if isinstance(current, exp.Select) and current is not top_level_select:
                 return False
-            current = current.parent
+            current = cast(exp.Expression | None, current.parent)
         return False
 
     def _is_in_select_clause(self, column: exp.Column) -> bool:
         """Check if column is in any SELECT clause (including subqueries)."""
-        current: exp.Expression | None = column.parent
+        current = cast(exp.Expression | None, column.parent)
         while current:
             # Check if this column is in a SELECT's expressions
             if isinstance(current, exp.Select):
@@ -352,7 +353,7 @@ class SQLEvaluator(Evaluator[SQLEvaluatorConfig]):
                     if self._is_descendant_of(column, select_expr):
                         return True
                 return False
-            current = current.parent
+            current = cast(exp.Expression | None, current.parent)
         return False
 
     def _is_descendant_of(
@@ -363,7 +364,7 @@ class SQLEvaluator(Evaluator[SQLEvaluatorConfig]):
         while current:
             if current is potential_ancestor:
                 return True
-            current = current.parent
+            current = cast(exp.Expression | None, current.parent)
         return False
 
     def _is_top_level_select(self, select_node: exp.Select) -> bool:
@@ -1106,7 +1107,9 @@ class SQLEvaluator(Evaluator[SQLEvaluatorConfig]):
                 metadata=self._create_query_metadata(query),
             )
 
-        parsed_statements = [stmt for stmt in parsed if stmt is not None]
+        parsed_statements = [
+            cast(exp.Expression, stmt) for stmt in parsed if stmt is not None
+        ]
 
         # 2. Check multi-statements
         if not self.config.allow_multi_statements or self.config.max_statements:

--- a/evaluators/builtin/tests/sql/test_sqlglot_runtime.py
+++ b/evaluators/builtin/tests/sql/test_sqlglot_runtime.py
@@ -1,0 +1,17 @@
+"""SQLGlot runtime integration tests."""
+
+from sqlglot import exp
+
+from agent_control_evaluators.sql import SQLEvaluator, SQLEvaluatorConfig
+
+
+def test_sqlglot_public_imports_support_sql_evaluator():
+    """SQLGlot's public API should remain importable with the native extra installed."""
+    # Given: the SQL evaluator package imports SQLGlot's public expression module
+    assert exp.Select is not None
+
+    # When: constructing the SQL evaluator
+    evaluator = SQLEvaluator(SQLEvaluatorConfig(blocked_operations=["DROP"]))
+
+    # Then: the evaluator can be created without SQLGlot import shadowing failures
+    assert evaluator.metadata.name == "sql"

--- a/examples/crewai/content_publishing_flow/pyproject.toml
+++ b/examples/crewai/content_publishing_flow/pyproject.toml
@@ -7,8 +7,7 @@ dependencies = [
     "crewai[tools]>=1.10.1",
     "openai>=1.0.0",
     "python-dotenv>=1.0.0",
-    "sqlglot[c]>=29.0.0,<29.1.0",
-    "sqlglotc>=29.0.0,<29.1.0",
+    "sqlglot[c]>=30.11.0,<30.12.0",
 ]
 
 [project.scripts]

--- a/examples/crewai/evaluator_showcase/pyproject.toml
+++ b/examples/crewai/evaluator_showcase/pyproject.toml
@@ -7,8 +7,7 @@ dependencies = [
     "crewai[tools]>=1.10.1",
     "openai>=1.0.0",
     "python-dotenv>=1.0.0",
-    "sqlglot[c]>=29.0.0,<29.1.0",
-    "sqlglotc>=29.0.0,<29.1.0",
+    "sqlglot[c]>=30.11.0,<30.12.0",
 ]
 
 [project.optional-dependencies]

--- a/examples/crewai/secure_research_crew/pyproject.toml
+++ b/examples/crewai/secure_research_crew/pyproject.toml
@@ -7,8 +7,7 @@ dependencies = [
     "crewai[tools]>=1.10.1",
     "openai>=1.0.0",
     "python-dotenv>=1.0.0",
-    "sqlglot[c]>=29.0.0,<29.1.0",
-    "sqlglotc>=29.0.0,<29.1.0",
+    "sqlglot[c]>=30.11.0,<30.12.0",
 ]
 
 [project.scripts]

--- a/examples/crewai/steering_financial_agent/pyproject.toml
+++ b/examples/crewai/steering_financial_agent/pyproject.toml
@@ -7,8 +7,7 @@ dependencies = [
     "crewai[tools]>=1.10.1",
     "openai>=1.0.0",
     "python-dotenv>=1.0.0",
-    "sqlglot[c]>=29.0.0,<29.1.0",
-    "sqlglotc>=29.0.0,<29.1.0",
+    "sqlglot[c]>=30.11.0,<30.12.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- Upgrade the builtin SQL evaluator dependency to `sqlglot[c]>=30.11.0,<30.12.0`.
- Remove the direct `sqlglotc` dependency so SQLGlot owns the matching native runtime package.
- Update CrewAI examples to use the same dependency contract.
- Add a regression test for SQLGlot public imports and SQL evaluator construction.
- Adapt SQL evaluator typing to SQLGlot 30 stubs without changing runtime behavior.

## Context
`sqlglotc` contributes native modules under the public `sqlglot` package namespace. Keeping both `sqlglot[c]` and a separate direct `sqlglotc` pin works in normal pip-style installs, but it is fragile for build systems that model wheels separately. This keeps the public dependency contract on `sqlglot[c]` and lets SQLGlot select the matching native package.

This keeps Agent Control installable as a generic OSS package while preserving the low-latency SQL evaluator path for environments that install SQLGlot with native extensions.

## Validation
- `UV_NO_CONFIG=1 UV_DEFAULT_INDEX=https://pypi.org/simple make sync`
- `UV_NO_CONFIG=1 UV_DEFAULT_INDEX=https://pypi.org/simple uv run --package agent-control-evaluators pytest evaluators/builtin/tests/sql/test_sqlglot_runtime.py -q`
- `UV_NO_CONFIG=1 UV_DEFAULT_INDEX=https://pypi.org/simple uv run --package agent-control-evaluators pytest evaluators/builtin/tests/sql -q`
- `UV_NO_CONFIG=1 UV_DEFAULT_INDEX=https://pypi.org/simple make evaluators-test`
- `UV_NO_CONFIG=1 UV_DEFAULT_INDEX=https://pypi.org/simple make evaluators-lint`
- `UV_NO_CONFIG=1 UV_DEFAULT_INDEX=https://pypi.org/simple make evaluators-typecheck`
- `git diff --check`
