### PR TITLE
feat(evaluators): add defenseclaw evaluator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,9 @@ server/.generated/
 tmp/
 temp/
 *.tmp
+.codex-doc-qa/
+.codex-doc-work/
+.pnpm-store/
 
 # OS
 .DS_Store

--- a/evaluators/builtin/pyproject.toml
+++ b/evaluators/builtin/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 galileo = ["agent-control-evaluator-galileo>=7.5.0"]
 budget = ["agent-control-evaluator-budget>=7.5.0"]
 cisco = ["agent-control-evaluator-cisco>=7.5.0"]
+defenseclaw = ["agent-control-evaluator-defenseclaw>=8.2.0"]
 dev = ["pytest>=8.0.0", "pytest-asyncio>=0.23.0"]
 
 [project.entry-points."agent_control.evaluators"]
@@ -39,3 +40,4 @@ agent-control-models = { workspace = true }
 agent-control-evaluator-galileo = { path = "../contrib/galileo", editable = true }
 agent-control-evaluator-budget = { path = "../contrib/budget", editable = true }
 agent-control-evaluator-cisco = { path = "../contrib/cisco", editable = true }
+agent-control-evaluator-defenseclaw = { path = "../contrib/defenseclaw", editable = true }

--- a/evaluators/builtin/tests/test_contrib_packages.py
+++ b/evaluators/builtin/tests/test_contrib_packages.py
@@ -39,6 +39,7 @@ def test_discover_contrib_packages_returns_expected_metadata() -> None:
     assert [(package.name, package.package, package.extra) for package in packages] == [
         ("budget", "agent-control-evaluator-budget", "budget"),
         ("cisco", "agent-control-evaluator-cisco", "cisco"),
+        ("defenseclaw", "agent-control-evaluator-defenseclaw", "defenseclaw"),
         ("galileo", "agent-control-evaluator-galileo", "galileo"),
     ]
 

--- a/evaluators/contrib/defenseclaw/Makefile
+++ b/evaluators/contrib/defenseclaw/Makefile
@@ -1,0 +1,33 @@
+.PHONY: help sync test lint lint-fix typecheck check build
+
+PACKAGE := agent-control-evaluator-defenseclaw
+
+help:
+	@echo "Agent Control Evaluator - DefenseClaw - Makefile commands"
+	@echo "  make sync       - sync package dependencies"
+	@echo "  make test       - run pytest"
+	@echo "  make lint       - run ruff check"
+	@echo "  make lint-fix   - run ruff check --fix"
+	@echo "  make typecheck  - run mypy"
+	@echo "  make check      - run tests, lint, and typecheck"
+	@echo "  make build      - build package"
+
+sync:
+	uv sync
+
+test:
+	uv run --with pytest --with pytest-asyncio --with pytest-cov --package $(PACKAGE) pytest tests --cov=src --cov-report=xml:../../../coverage-evaluators-defenseclaw.xml -q
+
+lint:
+	uv run --with ruff --package $(PACKAGE) ruff check --config ../../../pyproject.toml src/ tests/
+
+lint-fix:
+	uv run --with ruff --package $(PACKAGE) ruff check --config ../../../pyproject.toml --fix src/ tests/
+
+typecheck:
+	uv run --with mypy --package $(PACKAGE) mypy --config-file ../../../pyproject.toml src/
+
+check: test lint typecheck
+
+build:
+	uv build

--- a/evaluators/contrib/defenseclaw/README.md
+++ b/evaluators/contrib/defenseclaw/README.md
@@ -1,0 +1,16 @@
+# DefenseClaw evaluators
+
+This package exposes two global external evaluators for Agent Control:
+
+- `defenseclaw.rule_pack` validates a versioned DefenseClaw rule pack.
+- `defenseclaw.opa_policy` validates a versioned DefenseClaw OPA policy configuration.
+
+Install both evaluators with:
+
+```bash
+pip install "agent-control-evaluators[defenseclaw]"
+```
+
+The configuration contracts and JSON Schemas are implemented and discoverable. Both evaluator
+classes intentionally execute as no-ops: they return `matched=False` without contacting or
+installing any DefenseClaw runtime or OSS package.

--- a/evaluators/contrib/defenseclaw/pyproject.toml
+++ b/evaluators/contrib/defenseclaw/pyproject.toml
@@ -1,0 +1,42 @@
+[project]
+name = "agent-control-evaluator-defenseclaw"
+version = "8.2.0"
+description = "DefenseClaw evaluators for agent-control"
+readme = "README.md"
+requires-python = ">=3.12"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Agent Control Team" }]
+dependencies = [
+    "agent-control-evaluators>=8.2.0",
+    "agent-control-models>=8.2.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+    "pytest-cov>=4.0.0",
+    "ruff>=0.1.0",
+    "mypy>=1.8.0",
+]
+
+[project.entry-points."agent_control.evaluators"]
+"defenseclaw.rule_pack" = "agent_control_evaluator_defenseclaw.rule_pack:DefenseClawRulePackEvaluator"
+"defenseclaw.opa_policy" = "agent_control_evaluator_defenseclaw.opa_policy:DefenseClawOpaPolicyEvaluator"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agent_control_evaluator_defenseclaw"]
+
+[tool.uv.sources]
+agent-control-evaluators = { path = "../../builtin", editable = true }
+agent-control-models = { path = "../../../models", editable = true }
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+    "pytest-asyncio>=1.3.0",
+]

--- a/evaluators/contrib/defenseclaw/src/agent_control_evaluator_defenseclaw/__init__.py
+++ b/evaluators/contrib/defenseclaw/src/agent_control_evaluator_defenseclaw/__init__.py
@@ -1,0 +1,28 @@
+"""Agent Control DefenseClaw external evaluators."""
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("agent-control-evaluator-defenseclaw")
+except PackageNotFoundError:
+    __version__ = "0.0.0.dev"
+
+from .common import Severity
+from .opa_policy import DefenseClawOpaPolicyConfig, DefenseClawOpaPolicyEvaluator, OpaPolicy
+from .rule_pack import (
+    DefenseClawRulePackConfig,
+    DefenseClawRulePackEvaluator,
+    RuleConfig,
+    RulePack,
+)
+
+__all__ = [
+    "DefenseClawOpaPolicyConfig",
+    "DefenseClawOpaPolicyEvaluator",
+    "DefenseClawRulePackConfig",
+    "DefenseClawRulePackEvaluator",
+    "OpaPolicy",
+    "RuleConfig",
+    "RulePack",
+    "Severity",
+]

--- a/evaluators/contrib/defenseclaw/src/agent_control_evaluator_defenseclaw/common.py
+++ b/evaluators/contrib/defenseclaw/src/agent_control_evaluator_defenseclaw/common.py
@@ -1,0 +1,22 @@
+"""Shared DefenseClaw evaluator types and runtime behavior."""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from agent_control_models import EvaluatorResult
+from pydantic import ConfigDict, StringConstraints
+
+Severity = Literal["LOW", "MEDIUM", "HIGH", "CRITICAL"]
+NonEmptyString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+STRICT_PROVIDER_CONFIG = ConfigDict(extra="forbid")
+
+
+def no_op_result() -> EvaluatorResult:
+    """Return the intentional no-op evaluation result."""
+    return EvaluatorResult(
+        matched=False,
+        confidence=1.0,
+        message="DefenseClaw configuration accepted; evaluator execution is a no-op",
+    )

--- a/evaluators/contrib/defenseclaw/src/agent_control_evaluator_defenseclaw/opa_policy/__init__.py
+++ b/evaluators/contrib/defenseclaw/src/agent_control_evaluator_defenseclaw/opa_policy/__init__.py
@@ -1,0 +1,6 @@
+"""DefenseClaw OPA-policy evaluator exports."""
+
+from .config import DefenseClawOpaPolicyConfig, OpaPolicy
+from .evaluator import DefenseClawOpaPolicyEvaluator
+
+__all__ = ["DefenseClawOpaPolicyConfig", "DefenseClawOpaPolicyEvaluator", "OpaPolicy"]

--- a/evaluators/contrib/defenseclaw/src/agent_control_evaluator_defenseclaw/opa_policy/config.py
+++ b/evaluators/contrib/defenseclaw/src/agent_control_evaluator_defenseclaw/opa_policy/config.py
@@ -11,7 +11,10 @@ from ..common import STRICT_PROVIDER_CONFIG, Severity
 
 
 class OpaPolicy(BaseModel):
-    """DefenseClaw OPA policy settings supported by the v1 contract."""
+    """DefenseClaw OPA policy settings supported by the v1 contract.
+
+    See https://cisco-ai-defense.github.io/docs/defenseclaw/policy for the policy contract.
+    """
 
     model_config = STRICT_PROVIDER_CONFIG
 
@@ -24,6 +27,7 @@ class OpaPolicy(BaseModel):
 class DefenseClawOpaPolicyConfig(EvaluatorConfig):
     """Configuration envelope for `defenseclaw.opa_policy`."""
 
+    # Reject unknown configuration fields so malformed DefenseClaw payloads fail validation.
     model_config = STRICT_PROVIDER_CONFIG
 
     schema_version: Literal[1] = 1

--- a/evaluators/contrib/defenseclaw/src/agent_control_evaluator_defenseclaw/opa_policy/config.py
+++ b/evaluators/contrib/defenseclaw/src/agent_control_evaluator_defenseclaw/opa_policy/config.py
@@ -1,0 +1,30 @@
+"""Typed configuration for the DefenseClaw OPA-policy evaluator."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from agent_control_evaluators import EvaluatorConfig
+from pydantic import BaseModel
+
+from ..common import STRICT_PROVIDER_CONFIG, Severity
+
+
+class OpaPolicy(BaseModel):
+    """DefenseClaw OPA policy settings supported by the v1 contract."""
+
+    model_config = STRICT_PROVIDER_CONFIG
+
+    domain: Literal["guardrail"] = "guardrail"
+    block_at: Severity = "HIGH"
+    alert_at: Severity = "MEDIUM"
+    cisco_trust_level: Literal["full"] = "full"
+
+
+class DefenseClawOpaPolicyConfig(EvaluatorConfig):
+    """Configuration envelope for `defenseclaw.opa_policy`."""
+
+    model_config = STRICT_PROVIDER_CONFIG
+
+    schema_version: Literal[1] = 1
+    policy: OpaPolicy

--- a/evaluators/contrib/defenseclaw/src/agent_control_evaluator_defenseclaw/opa_policy/evaluator.py
+++ b/evaluators/contrib/defenseclaw/src/agent_control_evaluator_defenseclaw/opa_policy/evaluator.py
@@ -1,0 +1,35 @@
+"""DefenseClaw OPA-policy evaluator."""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any
+
+from agent_control_evaluators import Evaluator, EvaluatorMetadata, register_evaluator
+from agent_control_models import EvaluatorResult
+
+from ..common import no_op_result
+from .config import DefenseClawOpaPolicyConfig
+
+
+def _resolve_package_version() -> str:
+    try:
+        return version("agent-control-evaluator-defenseclaw")
+    except PackageNotFoundError:
+        return "0.0.0.dev"
+
+
+@register_evaluator
+class DefenseClawOpaPolicyEvaluator(Evaluator[DefenseClawOpaPolicyConfig]):
+    """Evaluate selected data with a typed DefenseClaw OPA policy."""
+
+    metadata = EvaluatorMetadata(
+        name="defenseclaw.opa_policy",
+        version=_resolve_package_version(),
+        description="DefenseClaw OPA-policy evaluation",
+    )
+    config_model = DefenseClawOpaPolicyConfig
+
+    async def evaluate(self, data: Any) -> EvaluatorResult:
+        """Return the intentional no-op result for all selected data."""
+        return no_op_result()

--- a/evaluators/contrib/defenseclaw/src/agent_control_evaluator_defenseclaw/rule_pack/__init__.py
+++ b/evaluators/contrib/defenseclaw/src/agent_control_evaluator_defenseclaw/rule_pack/__init__.py
@@ -1,0 +1,11 @@
+"""DefenseClaw rule-pack evaluator exports."""
+
+from .config import DefenseClawRulePackConfig, RuleConfig, RulePack
+from .evaluator import DefenseClawRulePackEvaluator
+
+__all__ = [
+    "DefenseClawRulePackConfig",
+    "DefenseClawRulePackEvaluator",
+    "RuleConfig",
+    "RulePack",
+]

--- a/evaluators/contrib/defenseclaw/src/agent_control_evaluator_defenseclaw/rule_pack/config.py
+++ b/evaluators/contrib/defenseclaw/src/agent_control_evaluator_defenseclaw/rule_pack/config.py
@@ -1,0 +1,50 @@
+"""Typed configuration for the DefenseClaw rule-pack evaluator."""
+
+from __future__ import annotations
+
+from typing import Literal, Self
+
+from agent_control_evaluators import EvaluatorConfig
+from pydantic import BaseModel, Field, model_validator
+
+from ..common import STRICT_PROVIDER_CONFIG, NonEmptyString, Severity
+
+
+class RuleConfig(BaseModel):
+    """One DefenseClaw rule."""
+
+    model_config = STRICT_PROVIDER_CONFIG
+
+    id: NonEmptyString
+    pattern: NonEmptyString
+    title: NonEmptyString
+    severity: Severity
+    confidence: float = Field(ge=0.0, le=1.0)
+    tags: list[NonEmptyString]
+
+
+class RulePack(BaseModel):
+    """Versioned DefenseClaw rule pack."""
+
+    model_config = STRICT_PROVIDER_CONFIG
+
+    version: Literal[1] = 1
+    category: Literal["agent-control"] = "agent-control"
+    rules: list[RuleConfig] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def validate_unique_rule_ids(self) -> Self:
+        """Reject ambiguous rule packs containing duplicate identifiers."""
+        rule_ids = [rule.id for rule in self.rules]
+        if len(rule_ids) != len(set(rule_ids)):
+            raise ValueError("rule ids must be unique within a rule pack")
+        return self
+
+
+class DefenseClawRulePackConfig(EvaluatorConfig):
+    """Configuration envelope for `defenseclaw.rule_pack`."""
+
+    model_config = STRICT_PROVIDER_CONFIG
+
+    schema_version: Literal[1] = 1
+    rule_pack: RulePack

--- a/evaluators/contrib/defenseclaw/src/agent_control_evaluator_defenseclaw/rule_pack/evaluator.py
+++ b/evaluators/contrib/defenseclaw/src/agent_control_evaluator_defenseclaw/rule_pack/evaluator.py
@@ -1,0 +1,35 @@
+"""DefenseClaw rule-pack evaluator."""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any
+
+from agent_control_evaluators import Evaluator, EvaluatorMetadata, register_evaluator
+from agent_control_models import EvaluatorResult
+
+from ..common import no_op_result
+from .config import DefenseClawRulePackConfig
+
+
+def _resolve_package_version() -> str:
+    try:
+        return version("agent-control-evaluator-defenseclaw")
+    except PackageNotFoundError:
+        return "0.0.0.dev"
+
+
+@register_evaluator
+class DefenseClawRulePackEvaluator(Evaluator[DefenseClawRulePackConfig]):
+    """Evaluate selected data with a typed DefenseClaw rule pack."""
+
+    metadata = EvaluatorMetadata(
+        name="defenseclaw.rule_pack",
+        version=_resolve_package_version(),
+        description="DefenseClaw rule-pack evaluation",
+    )
+    config_model = DefenseClawRulePackConfig
+
+    async def evaluate(self, data: Any) -> EvaluatorResult:
+        """Return the intentional no-op result for all selected data."""
+        return no_op_result()

--- a/evaluators/contrib/defenseclaw/tests/test_configs.py
+++ b/evaluators/contrib/defenseclaw/tests/test_configs.py
@@ -1,0 +1,155 @@
+"""Contract tests for the DefenseClaw evaluator configurations."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from agent_control_evaluator_defenseclaw import (
+    DefenseClawOpaPolicyConfig,
+    DefenseClawRulePackConfig,
+)
+
+
+def _rule_pack_config() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "rule_pack": {
+            "version": 1,
+            "category": "agent-control",
+            "rules": [
+                {
+                    "id": "AC-CMD-RM-RF",
+                    "pattern": "rm\\s+-rf",
+                    "title": "Recursive deletion",
+                    "severity": "HIGH",
+                    "confidence": 0.99,
+                    "tags": ["filesystem"],
+                }
+            ],
+        },
+    }
+
+
+def test_rule_pack_example_round_trips_with_fixed_fields() -> None:
+    # Given: the supplied rule-pack example
+    config = _rule_pack_config()
+
+    # When: validating and serializing it
+    serialized = DefenseClawRulePackConfig.model_validate(config).model_dump()
+
+    # Then: fixed fields and nested rules are preserved
+    assert serialized == config
+
+
+def test_rule_pack_defaults_are_serialized() -> None:
+    # Given: a rule pack omitting fields with fixed v1 defaults
+    config = _rule_pack_config()
+    config.pop("schema_version")
+    rule_pack = config["rule_pack"]
+    assert isinstance(rule_pack, dict)
+    rule_pack.pop("version")
+    rule_pack.pop("category")
+
+    # When: validating and serializing it
+    serialized = DefenseClawRulePackConfig.model_validate(config).model_dump()
+
+    # Then: the wire-contract constants are materialized
+    assert serialized["schema_version"] == 1
+    assert serialized["rule_pack"]["version"] == 1
+    assert serialized["rule_pack"]["category"] == "agent-control"
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("schema_version",), 2),
+        (("rule_pack", "version"), 2),
+        (("rule_pack", "category"), "other"),
+        (("rule_pack", "rules", 0, "severity"), "URGENT"),
+        (("rule_pack", "rules", 0, "confidence"), -0.1),
+        (("rule_pack", "rules", 0, "confidence"), 1.1),
+    ],
+)
+def test_rule_pack_rejects_unsupported_values(path: tuple[object, ...], value: object) -> None:
+    # Given: a valid config with one unsupported nested value
+    config = _rule_pack_config()
+    target: object = config
+    for part in path[:-1]:
+        target = target[part]  # type: ignore[index]
+    target[path[-1]] = value  # type: ignore[index]
+
+    # When/Then: typed validation rejects it
+    with pytest.raises(ValidationError):
+        DefenseClawRulePackConfig.model_validate(config)
+
+
+def test_rule_pack_rejects_empty_and_duplicate_rules() -> None:
+    # Given: an empty rule list
+    empty = _rule_pack_config()
+    empty["rule_pack"]["rules"] = []  # type: ignore[index]
+
+    # When/Then: at least one rule is required
+    with pytest.raises(ValidationError):
+        DefenseClawRulePackConfig.model_validate(empty)
+
+    # Given: duplicate rule IDs
+    duplicate = _rule_pack_config()
+    first_rule = duplicate["rule_pack"]["rules"][0]  # type: ignore[index]
+    duplicate["rule_pack"]["rules"].append(dict(first_rule))  # type: ignore[index,union-attr]
+
+    # When/Then: duplicate IDs are rejected
+    with pytest.raises(ValidationError, match="rule ids must be unique"):
+        DefenseClawRulePackConfig.model_validate(duplicate)
+
+
+def test_rule_pack_rejects_blank_strings_and_unknown_fields() -> None:
+    # Given: whitespace-only required values and an unknown provider key
+    config = _rule_pack_config()
+    rule = config["rule_pack"]["rules"][0]  # type: ignore[index]
+    rule["id"] = "   "
+    rule["unknown"] = True
+
+    # When/Then: strict validation rejects both errors
+    with pytest.raises(ValidationError) as exc_info:
+        DefenseClawRulePackConfig.model_validate(config)
+    errors = exc_info.value.errors()
+    assert any(error["loc"][-1] == "id" for error in errors)
+    assert any(error["loc"][-1] == "unknown" for error in errors)
+
+
+def test_opa_policy_example_and_defaults() -> None:
+    # Given: the supplied policy example
+    config = {
+        "schema_version": 1,
+        "policy": {
+            "domain": "guardrail",
+            "block_at": "HIGH",
+            "alert_at": "MEDIUM",
+            "cisco_trust_level": "full",
+        },
+    }
+
+    # When: validating it and validating a default policy
+    serialized = DefenseClawOpaPolicyConfig.model_validate(config).model_dump()
+    defaults = DefenseClawOpaPolicyConfig.model_validate({"policy": {}}).model_dump()
+
+    # Then: both serialize to the canonical policy envelope
+    assert serialized == config
+    assert defaults == config
+
+
+@pytest.mark.parametrize(
+    "policy",
+    [
+        {"domain": "other"},
+        {"block_at": "URGENT"},
+        {"alert_at": "URGENT"},
+        {"cisco_trust_level": "partial"},
+        {"unexpected": True},
+    ],
+)
+def test_opa_policy_rejects_unsupported_values(policy: dict[str, object]) -> None:
+    # Given/When/Then: an unsupported provider value is rejected
+    with pytest.raises(ValidationError):
+        DefenseClawOpaPolicyConfig.model_validate({"policy": policy})

--- a/evaluators/contrib/defenseclaw/tests/test_evaluators.py
+++ b/evaluators/contrib/defenseclaw/tests/test_evaluators.py
@@ -1,0 +1,85 @@
+"""Behavior tests for the DefenseClaw no-op evaluators."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+from agent_control_evaluator_defenseclaw import (
+    DefenseClawOpaPolicyEvaluator,
+    DefenseClawRulePackEvaluator,
+)
+
+
+def _rule_pack_config() -> dict[str, object]:
+    return {
+        "rule_pack": {
+            "rules": [
+                {
+                    "id": "rule-1",
+                    "pattern": "example",
+                    "title": "Example",
+                    "severity": "LOW",
+                    "confidence": 1.0,
+                    "tags": [],
+                }
+            ]
+        }
+    }
+
+
+def test_metadata_names_are_distinct_public_identifiers() -> None:
+    assert DefenseClawRulePackEvaluator.metadata.name == "defenseclaw.rule_pack"
+    assert DefenseClawOpaPolicyEvaluator.metadata.name == "defenseclaw.opa_policy"
+    assert DefenseClawRulePackEvaluator is not DefenseClawOpaPolicyEvaluator
+
+
+def test_entry_points_match_public_metadata_names() -> None:
+    # Given: the installed-package manifest contract
+    manifest_path = Path(__file__).parent.parent / "pyproject.toml"
+    manifest = tomllib.loads(manifest_path.read_text())
+
+    # When: reading evaluator entry points
+    entry_points = manifest["project"]["entry-points"]["agent_control.evaluators"]
+
+    # Then: both exact global names resolve to their distinct classes
+    assert entry_points == {
+        "defenseclaw.rule_pack": (
+            "agent_control_evaluator_defenseclaw.rule_pack:DefenseClawRulePackEvaluator"
+        ),
+        "defenseclaw.opa_policy": (
+            "agent_control_evaluator_defenseclaw.opa_policy:DefenseClawOpaPolicyEvaluator"
+        ),
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("data", [None, "", "selected data", {"tool": "rm"}])
+async def test_rule_pack_evaluation_is_a_no_op(data: object) -> None:
+    # Given: a valid rule-pack evaluator
+    evaluator = DefenseClawRulePackEvaluator.from_dict(_rule_pack_config())
+
+    # When: evaluating any selected data
+    result = await evaluator.evaluate(data)
+
+    # Then: execution is intentionally inert and healthy
+    assert result.matched is False
+    assert result.confidence == 1.0
+    assert result.error is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("data", [None, "", "selected data", {"tool": "rm"}])
+async def test_opa_policy_evaluation_is_a_no_op(data: object) -> None:
+    # Given: a valid OPA-policy evaluator
+    evaluator = DefenseClawOpaPolicyEvaluator.from_dict({"policy": {}})
+
+    # When: evaluating any selected data
+    result = await evaluator.evaluate(data)
+
+    # Then: execution is intentionally inert and healthy
+    assert result.matched is False
+    assert result.confidence == 1.0
+    assert result.error is None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ version_toml = [
     "evaluators/builtin/pyproject.toml:project.version",
     "evaluators/contrib/budget/pyproject.toml:project.version",
     "evaluators/contrib/cisco/pyproject.toml:project.version",
+    "evaluators/contrib/defenseclaw/pyproject.toml:project.version",
     "evaluators/contrib/galileo/pyproject.toml:project.version",
 ]
 version_source = "tag"

--- a/ui/src/core/evaluators/defenseclaw/index.ts
+++ b/ui/src/core/evaluators/defenseclaw/index.ts
@@ -1,0 +1,140 @@
+import type { EvaluatorDefinition } from '../types';
+import { DefenseClawOpaPolicyForm } from './opa-policy-form';
+import {
+  createBlankDefenseClawRule,
+  DefenseClawRulePackForm,
+} from './rule-pack-form';
+import {
+  DEFENSECLAW_SEVERITIES,
+  type DefenseClawOpaPolicyFormValues,
+  type DefenseClawRuleFormValue,
+  type DefenseClawRulePackFormValues,
+} from './types';
+
+const severityValues = new Set<string>(DEFENSECLAW_SEVERITIES);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const normalizeRule = (value: unknown): DefenseClawRuleFormValue => {
+  if (!isRecord(value)) return createBlankDefenseClawRule();
+  return {
+    id: typeof value.id === 'string' ? value.id : '',
+    pattern: typeof value.pattern === 'string' ? value.pattern : '',
+    title: typeof value.title === 'string' ? value.title : '',
+    severity: severityValues.has(String(value.severity))
+      ? (value.severity as DefenseClawRuleFormValue['severity'])
+      : 'HIGH',
+    confidence: typeof value.confidence === 'number' ? value.confidence : 0.99,
+    tags: Array.isArray(value.tags)
+      ? value.tags.filter((tag): tag is string => typeof tag === 'string')
+      : [],
+  };
+};
+
+const validateRules = (value: unknown): string | null => {
+  if (!Array.isArray(value) || value.length === 0) {
+    return 'At least one rule is required';
+  }
+  const rules = value as DefenseClawRuleFormValue[];
+  const ids = rules.map((rule) => rule.id.trim());
+  if (
+    rules.some(
+      (rule) => !rule.id.trim() || !rule.title.trim() || !rule.pattern.trim()
+    )
+  ) {
+    return 'Every rule requires an ID, title, and pattern';
+  }
+  if (new Set(ids).size !== ids.length) return 'Rule IDs must be unique';
+  if (
+    rules.some(
+      (rule) =>
+        !Number.isFinite(rule.confidence) ||
+        rule.confidence < 0 ||
+        rule.confidence > 1
+    )
+  ) {
+    return 'Rule confidence must be between 0 and 1';
+  }
+  if (rules.some((rule) => !severityValues.has(rule.severity))) {
+    return 'Every rule requires a supported severity';
+  }
+  if (rules.some((rule) => rule.tags.some((tag) => !tag.trim()))) {
+    return 'Rule tags cannot be blank';
+  }
+  return null;
+};
+
+export const defenseClawRulePackEvaluator: EvaluatorDefinition<DefenseClawRulePackFormValues> =
+  {
+    id: 'defenseclaw.rule_pack',
+    displayName: 'DefenseClaw Rule Pack',
+    initialValues: { rules: [createBlankDefenseClawRule()] },
+    validate: { rules: validateRules },
+    toConfig: (values) => ({
+      schema_version: 1,
+      rule_pack: {
+        version: 1,
+        category: 'agent-control',
+        rules: values.rules,
+      },
+    }),
+    fromConfig: (config) => {
+      const rulePack = isRecord(config.rule_pack) ? config.rule_pack : {};
+      const rules = Array.isArray(rulePack.rules)
+        ? rulePack.rules.map(normalizeRule)
+        : [];
+      return {
+        rules: rules.length > 0 ? rules : [createBlankDefenseClawRule()],
+      };
+    },
+    FormComponent: DefenseClawRulePackForm,
+  };
+
+export const defenseClawOpaPolicyEvaluator: EvaluatorDefinition<DefenseClawOpaPolicyFormValues> =
+  {
+    id: 'defenseclaw.opa_policy',
+    displayName: 'DefenseClaw OPA Policy',
+    initialValues: {
+      domain: 'guardrail',
+      block_at: 'HIGH',
+      alert_at: 'MEDIUM',
+      cisco_trust_level: 'full',
+    },
+    validate: {
+      domain: (value) =>
+        value === 'guardrail' ? null : 'Domain must be guardrail',
+      block_at: (value) =>
+        severityValues.has(String(value))
+          ? null
+          : 'Select a supported block severity',
+      alert_at: (value) =>
+        severityValues.has(String(value))
+          ? null
+          : 'Select a supported alert severity',
+      cisco_trust_level: (value) =>
+        value === 'full' ? null : 'Cisco trust level must be full',
+    },
+    toConfig: (values) => ({ schema_version: 1, policy: { ...values } }),
+    fromConfig: (config) => {
+      const policy = isRecord(config.policy) ? config.policy : {};
+      return {
+        domain: 'guardrail',
+        block_at: severityValues.has(String(policy.block_at))
+          ? (policy.block_at as DefenseClawOpaPolicyFormValues['block_at'])
+          : 'HIGH',
+        alert_at: severityValues.has(String(policy.alert_at))
+          ? (policy.alert_at as DefenseClawOpaPolicyFormValues['alert_at'])
+          : 'MEDIUM',
+        cisco_trust_level: 'full',
+      };
+    },
+    FormComponent: DefenseClawOpaPolicyForm,
+  };
+
+export type {
+  DefenseClawOpaPolicyFormValues,
+  DefenseClawRuleFormValue,
+  DefenseClawRulePackFormValues,
+  DefenseClawSeverity,
+} from './types';

--- a/ui/src/core/evaluators/defenseclaw/index.ts
+++ b/ui/src/core/evaluators/defenseclaw/index.ts
@@ -69,6 +69,8 @@ export const defenseClawRulePackEvaluator: EvaluatorDefinition<DefenseClawRulePa
   {
     id: 'defenseclaw.rule_pack',
     displayName: 'DefenseClaw Rule Pack',
+    defaultExecution: 'sdk',
+    supportedExecutions: ['sdk'],
     initialValues: { rules: [createBlankDefenseClawRule()] },
     validate: { rules: validateRules },
     toConfig: (values) => ({
@@ -95,6 +97,8 @@ export const defenseClawOpaPolicyEvaluator: EvaluatorDefinition<DefenseClawOpaPo
   {
     id: 'defenseclaw.opa_policy',
     displayName: 'DefenseClaw OPA Policy',
+    defaultExecution: 'sdk',
+    supportedExecutions: ['sdk'],
     initialValues: {
       domain: 'guardrail',
       block_at: 'HIGH',

--- a/ui/src/core/evaluators/defenseclaw/opa-policy-form.tsx
+++ b/ui/src/core/evaluators/defenseclaw/opa-policy-form.tsx
@@ -1,0 +1,48 @@
+import { Divider, Select, Stack } from '@mantine/core';
+
+import type { EvaluatorFormProps } from '../types';
+import {
+  DEFENSECLAW_SEVERITIES,
+  type DefenseClawOpaPolicyFormValues,
+} from './types';
+
+const severityOptions = DEFENSECLAW_SEVERITIES.map((severity) => ({
+  value: severity,
+  label: severity,
+}));
+
+export const DefenseClawOpaPolicyForm = ({
+  form,
+}: EvaluatorFormProps<DefenseClawOpaPolicyFormValues>) => (
+  <Stack gap="md">
+    <Divider label="Policy" labelPosition="left" />
+    <Select
+      label="Domain"
+      data={[{ value: 'guardrail', label: 'Guardrail' }]}
+      allowDeselect={false}
+      required
+      {...form.getInputProps('domain')}
+    />
+    <Select
+      label="Block at"
+      data={severityOptions}
+      allowDeselect={false}
+      required
+      {...form.getInputProps('block_at')}
+    />
+    <Select
+      label="Alert at"
+      data={severityOptions}
+      allowDeselect={false}
+      required
+      {...form.getInputProps('alert_at')}
+    />
+    <Select
+      label="Cisco trust level"
+      data={[{ value: 'full', label: 'Full' }]}
+      allowDeselect={false}
+      required
+      {...form.getInputProps('cisco_trust_level')}
+    />
+  </Stack>
+);

--- a/ui/src/core/evaluators/defenseclaw/rule-pack-form.tsx
+++ b/ui/src/core/evaluators/defenseclaw/rule-pack-form.tsx
@@ -1,0 +1,133 @@
+import {
+  ActionIcon,
+  Box,
+  Divider,
+  Group,
+  NumberInput,
+  Paper,
+  Select,
+  Stack,
+  TagsInput,
+  Text,
+  Textarea,
+  TextInput,
+} from '@mantine/core';
+import { Button } from '@rungalileo/jupiter-ds';
+import { IconTrash } from '@tabler/icons-react';
+
+import type { EvaluatorFormProps } from '../types';
+import {
+  DEFENSECLAW_SEVERITIES,
+  type DefenseClawRuleFormValue,
+  type DefenseClawRulePackFormValues,
+} from './types';
+
+export const createBlankDefenseClawRule = (): DefenseClawRuleFormValue => ({
+  id: '',
+  pattern: '',
+  title: '',
+  severity: 'HIGH',
+  confidence: 0.99,
+  tags: [],
+});
+
+const severityOptions = DEFENSECLAW_SEVERITIES.map((severity) => ({
+  value: severity,
+  label: severity,
+}));
+
+export const DefenseClawRulePackForm = ({
+  form,
+}: EvaluatorFormProps<DefenseClawRulePackFormValues>) => (
+  <Stack gap="md">
+    <Divider label="Rules" labelPosition="left" />
+
+    {form.values.rules.map((rule, index) => (
+      <Paper key={index} withBorder p="md" radius="sm">
+        <Stack gap="sm">
+          <Group justify="space-between">
+            <Text fw={600} size="sm">
+              Rule {index + 1}
+            </Text>
+            <ActionIcon
+              aria-label={`Remove rule ${index + 1}`}
+              data-testid={`defenseclaw-remove-rule-${index}`}
+              type="button"
+              color="red"
+              variant="subtle"
+              disabled={form.values.rules.length === 1}
+              onClick={() => form.removeListItem('rules', index)}
+            >
+              <IconTrash size={16} />
+            </ActionIcon>
+          </Group>
+
+          <TextInput
+            label="Rule ID"
+            placeholder="AC-CMD-RM-RF"
+            required
+            {...form.getInputProps(`rules.${index}.id`)}
+          />
+          <TextInput
+            label="Title"
+            placeholder="Recursive deletion"
+            required
+            {...form.getInputProps(`rules.${index}.title`)}
+          />
+          <Textarea
+            label="Pattern"
+            placeholder="Enter the DefenseClaw pattern"
+            required
+            minRows={3}
+            autosize
+            styles={{ input: { fontFamily: 'monospace' } }}
+            {...form.getInputProps(`rules.${index}.pattern`)}
+          />
+          <Group grow align="flex-start">
+            <Select
+              label="Severity"
+              data={severityOptions}
+              allowDeselect={false}
+              required
+              {...form.getInputProps(`rules.${index}.severity`)}
+            />
+            <NumberInput
+              label="Confidence"
+              min={0}
+              max={1}
+              step={0.01}
+              decimalScale={2}
+              required
+              {...form.getInputProps(`rules.${index}.confidence`)}
+            />
+          </Group>
+          <TagsInput
+            label="Tags"
+            placeholder="Type a tag and press Enter"
+            clearable
+            {...form.getInputProps(`rules.${index}.tags`)}
+          />
+        </Stack>
+      </Paper>
+    ))}
+
+    {form.errors.rules ? (
+      <Text c="red" size="sm" role="alert">
+        {String(form.errors.rules)}
+      </Text>
+    ) : null}
+
+    <Box>
+      <Button
+        data-testid="defenseclaw-add-rule"
+        type="button"
+        variant="secondary"
+        onClick={() =>
+          form.insertListItem('rules', createBlankDefenseClawRule())
+        }
+      >
+        Add rule
+      </Button>
+    </Box>
+  </Stack>
+);

--- a/ui/src/core/evaluators/defenseclaw/types.ts
+++ b/ui/src/core/evaluators/defenseclaw/types.ts
@@ -1,0 +1,28 @@
+export const DEFENSECLAW_SEVERITIES = [
+  'LOW',
+  'MEDIUM',
+  'HIGH',
+  'CRITICAL',
+] as const;
+
+export type DefenseClawSeverity = (typeof DEFENSECLAW_SEVERITIES)[number];
+
+export type DefenseClawRuleFormValue = {
+  id: string;
+  pattern: string;
+  title: string;
+  severity: DefenseClawSeverity;
+  confidence: number;
+  tags: string[];
+};
+
+export type DefenseClawRulePackFormValues = {
+  rules: DefenseClawRuleFormValue[];
+};
+
+export type DefenseClawOpaPolicyFormValues = {
+  domain: 'guardrail';
+  block_at: DefenseClawSeverity;
+  alert_at: DefenseClawSeverity;
+  cisco_trust_level: 'full';
+};

--- a/ui/src/core/evaluators/index.ts
+++ b/ui/src/core/evaluators/index.ts
@@ -33,6 +33,10 @@
  * ```
  */
 
+import {
+  defenseClawOpaPolicyEvaluator,
+  defenseClawRulePackEvaluator,
+} from './defenseclaw';
 import { jsonEvaluator } from './json';
 import { listEvaluator } from './list';
 import { lunaEvaluator } from './luna';
@@ -45,6 +49,8 @@ import type { AnyEvaluatorDefinition } from './types';
  * Add new evaluators here to make them available in the UI.
  */
 export const evaluators: AnyEvaluatorDefinition[] = [
+  defenseClawRulePackEvaluator,
+  defenseClawOpaPolicyEvaluator,
   regexEvaluator,
   listEvaluator,
   jsonEvaluator,
@@ -72,6 +78,10 @@ export const getEvaluator = (id: string): AnyEvaluatorDefinition | undefined =>
 export const hasEvaluator = (id: string): boolean => evaluatorRegistry.has(id);
 
 // Re-export types and individual evaluators for direct imports
+export {
+  defenseClawOpaPolicyEvaluator,
+  defenseClawRulePackEvaluator,
+} from './defenseclaw';
 export { jsonEvaluator } from './json';
 export { listEvaluator } from './list';
 export { lunaEvaluator } from './luna';

--- a/ui/src/core/evaluators/types.ts
+++ b/ui/src/core/evaluators/types.ts
@@ -1,5 +1,7 @@
 import type { UseFormReturnType } from '@mantine/form';
 
+import type { ControlExecution } from '@/core/api/types';
+
 /**
  * Base interface for evaluator definitions.
  *
@@ -19,6 +21,12 @@ export type EvaluatorDefinition<TFormValues = any> = {
 
   /** Initial form values when creating a new control */
   initialValues: TFormValues;
+
+  /** Execution environment selected when creating a control for this evaluator. */
+  defaultExecution?: ControlExecution;
+
+  /** Execution environments supported by this evaluator. */
+  supportedExecutions?: readonly ControlExecution[];
 
   /**
    * Validation rules for the form.

--- a/ui/src/core/page-components/agent-detail/modals/add-new-control/index.tsx
+++ b/ui/src/core/page-components/agent-detail/modals/add-new-control/index.tsx
@@ -52,6 +52,32 @@ const DEFAULT_EVALUATOR_CONFIGS: Record<string, Record<string, unknown>> = {
     timeout_ms: 10000,
     config: null,
   },
+  'defenseclaw.rule_pack': {
+    schema_version: 1,
+    rule_pack: {
+      version: 1,
+      category: 'agent-control',
+      rules: [
+        {
+          id: '',
+          pattern: '',
+          title: '',
+          severity: 'HIGH',
+          confidence: 0.99,
+          tags: [],
+        },
+      ],
+    },
+  },
+  'defenseclaw.opa_policy': {
+    schema_version: 1,
+    policy: {
+      domain: 'guardrail',
+      block_at: 'HIGH',
+      alert_at: 'MEDIUM',
+      cisco_trust_level: 'full',
+    },
+  },
 };
 
 function getDefaultConfigForEvaluator(

--- a/ui/src/core/page-components/agent-detail/modals/add-new-control/index.tsx
+++ b/ui/src/core/page-components/agent-detail/modals/add-new-control/index.tsx
@@ -19,6 +19,7 @@ import { useMemo, useState } from 'react';
 import { ErrorBoundary } from '@/components/error-boundary';
 import type { EvaluatorInfo } from '@/core/api/types';
 import { MODAL_NAMES, SUBMODAL_NAMES } from '@/core/constants/modal-routes';
+import { getEvaluator } from '@/core/evaluators';
 import { useEvaluators } from '@/core/hooks/query-hooks/use-evaluators';
 import { useModalRoute } from '@/core/hooks/use-modal-route';
 
@@ -177,6 +178,7 @@ export function AddNewControlModal({
 
   const draftControl = useMemo(() => {
     if (selectedEvaluator) {
+      const evaluatorDefinition = getEvaluator(selectedEvaluator.id);
       const name = `new-${sanitizeControlNamePart(selectedEvaluator.name)}-control`;
       return {
         id: 0,
@@ -184,7 +186,7 @@ export function AddNewControlModal({
         control: {
           description: selectedEvaluator.description,
           enabled: true,
-          execution: 'server' as const,
+          execution: evaluatorDefinition?.defaultExecution ?? 'server',
           scope: {
             step_types: ['llm'],
             stages: ['post'] as ('post' | 'pre')[],

--- a/ui/src/core/page-components/agent-detail/modals/edit-control/control-definition-form.tsx
+++ b/ui/src/core/page-components/agent-detail/modals/edit-control/control-definition-form.tsx
@@ -25,13 +25,24 @@ import type { ControlDefinitionFormProps } from './types';
 export type ControlDefinitionFormWithStepsProps = ControlDefinitionFormProps & {
   /** Available steps from the agent */
   steps?: StepSchema[];
+  /** Execution environments supported by the selected installed evaluator. */
+  supportedExecutions?: readonly ControlExecution[];
 };
 
 export const ControlDefinitionForm = ({
   form,
   steps,
   disableSelectorPath = false,
+  supportedExecutions,
 }: ControlDefinitionFormWithStepsProps) => {
+  const executionOptions = [
+    { value: 'server' as const, label: 'Server' },
+    { value: 'sdk' as const, label: 'SDK' },
+  ].filter(
+    (option) =>
+      !supportedExecutions || supportedExecutions.includes(option.value)
+  );
+
   return (
     <Stack gap="md">
       <Switch
@@ -137,10 +148,11 @@ export const ControlDefinitionForm = ({
           />
         }
         labelProps={labelPropsInline}
-        data={[
-          { value: 'server', label: 'Server' },
-          { value: 'sdk', label: 'SDK' },
-        ]}
+        data={executionOptions}
+        disabled={
+          executionOptions.length === 1 &&
+          executionOptions[0].value === form.values.execution
+        }
         size="sm"
         {...form.getInputProps('execution')}
         onChange={(value) =>

--- a/ui/src/core/page-components/agent-detail/modals/edit-control/edit-control-content.tsx
+++ b/ui/src/core/page-components/agent-detail/modals/edit-control/edit-control-content.tsx
@@ -205,6 +205,10 @@ const RawEditControlContent = ({
       null,
     [availableEvaluators, evaluatorId]
   );
+  const installedEvaluatorSupportedExecutions =
+    activeEvaluatorOption?.source === 'global'
+      ? evaluator?.supportedExecutions
+      : undefined;
 
   const definitionForm = useForm<ControlDefinitionFormValues>({
     initialValues: {
@@ -223,6 +227,12 @@ const RawEditControlContent = ({
     },
     validate: {
       name: (value) => (!value?.trim() ? 'Control name is required' : null),
+      execution: (value) =>
+        installedEvaluatorSupportedExecutions?.includes(value)
+          ? null
+          : installedEvaluatorSupportedExecutions
+            ? `This evaluator only supports: ${installedEvaluatorSupportedExecutions.join(', ')}`
+            : null,
       selector_path: (value) => {
         if (editorMode === 'json' || !canEditLeafCondition) {
           return null;
@@ -944,6 +954,7 @@ const RawEditControlContent = ({
                 form={definitionForm}
                 steps={steps}
                 disableSelectorPath={!canEditLeafCondition}
+                supportedExecutions={installedEvaluatorSupportedExecutions}
               />
             </Grid.Col>
 

--- a/ui/tests/control-store.spec.ts
+++ b/ui/tests/control-store.spec.ts
@@ -238,6 +238,24 @@ test.describe('Add New Control Modal', () => {
     }
   });
 
+  test('does not show DefenseClaw when its evaluator package is unavailable', async ({
+    mockedPage,
+  }) => {
+    const evaluatorsWithoutDefenseClaw = Object.fromEntries(
+      Object.entries(mockData.evaluators).filter(
+        ([id]) => !id.startsWith('defenseclaw.')
+      )
+    );
+    await mockRoutes.evaluators(mockedPage, {
+      data: evaluatorsWithoutDefenseClaw,
+    });
+
+    const modal = await openAddNewControlModal(mockedPage);
+
+    await expect(modal.getByText('DefenseClaw Rule Pack')).toHaveCount(0);
+    await expect(modal.getByText('DefenseClaw OPA Policy')).toHaveCount(0);
+  });
+
   test('can search for evaluators', async ({ mockedPage }) => {
     const modal = await openAddNewControlModal(mockedPage);
     const searchInput = modal.getByPlaceholder('Search evaluators...');

--- a/ui/tests/evaluators/defenseclaw.spec.ts
+++ b/ui/tests/evaluators/defenseclaw.spec.ts
@@ -9,6 +9,11 @@ test.describe('DefenseClaw Rule Pack Evaluator', () => {
   }) => {
     await openEvaluatorForm(mockedPage, 'DefenseClaw Rule Pack');
 
+    await expect(mockedPage.getByLabel('Execution environment')).toHaveValue(
+      'sdk'
+    );
+    await expect(mockedPage.getByLabel('Execution environment')).toBeDisabled();
+
     await expect(mockedPage.getByLabel('Rule ID')).toBeVisible();
     await expect(mockedPage.getByLabel('Title')).toBeVisible();
     await expect(mockedPage.getByLabel('Pattern')).toBeVisible();
@@ -49,6 +54,11 @@ test.describe('DefenseClaw OPA Policy Evaluator', () => {
     mockedPage,
   }) => {
     await openEvaluatorForm(mockedPage, 'DefenseClaw OPA Policy');
+
+    await expect(mockedPage.getByLabel('Execution environment')).toHaveValue(
+      'sdk'
+    );
+    await expect(mockedPage.getByLabel('Execution environment')).toBeDisabled();
 
     await expect(
       mockedPage.getByRole('textbox', { name: 'Domain' })

--- a/ui/tests/evaluators/defenseclaw.spec.ts
+++ b/ui/tests/evaluators/defenseclaw.spec.ts
@@ -11,7 +11,7 @@ test.describe('DefenseClaw Rule Pack Evaluator', () => {
 
     await expect(
       mockedPage.getByRole('textbox', { name: 'Execution environment' })
-    ).toHaveValue('sdk');
+    ).toHaveValue('SDK');
     await expect(
       mockedPage.getByRole('textbox', { name: 'Execution environment' })
     ).toBeDisabled();
@@ -59,7 +59,7 @@ test.describe('DefenseClaw OPA Policy Evaluator', () => {
 
     await expect(
       mockedPage.getByRole('textbox', { name: 'Execution environment' })
-    ).toHaveValue('sdk');
+    ).toHaveValue('SDK');
     await expect(
       mockedPage.getByRole('textbox', { name: 'Execution environment' })
     ).toBeDisabled();

--- a/ui/tests/evaluators/defenseclaw.spec.ts
+++ b/ui/tests/evaluators/defenseclaw.spec.ts
@@ -9,20 +9,12 @@ test.describe('DefenseClaw Rule Pack Evaluator', () => {
   }) => {
     await openEvaluatorForm(mockedPage, 'DefenseClaw Rule Pack');
 
-    await expect(
-      mockedPage.getByText('Rule ID', { exact: true })
-    ).toBeVisible();
-    await expect(mockedPage.getByText('Title', { exact: true })).toBeVisible();
-    await expect(
-      mockedPage.getByText('Pattern', { exact: true })
-    ).toBeVisible();
-    await expect(
-      mockedPage.getByText('Severity', { exact: true })
-    ).toBeVisible();
-    await expect(
-      mockedPage.getByText('Confidence', { exact: true })
-    ).toBeVisible();
-    await expect(mockedPage.getByText('Tags', { exact: true })).toBeVisible();
+    await expect(mockedPage.getByLabel('Rule ID')).toBeVisible();
+    await expect(mockedPage.getByLabel('Title')).toBeVisible();
+    await expect(mockedPage.getByLabel('Pattern')).toBeVisible();
+    await expect(mockedPage.getByLabel('Severity')).toBeVisible();
+    await expect(mockedPage.getByLabel('Confidence')).toBeVisible();
+    await expect(mockedPage.getByLabel('Tags')).toBeVisible();
 
     await expect(
       mockedPage.getByText('Schema version', { exact: true })
@@ -54,16 +46,10 @@ test.describe('DefenseClaw OPA Policy Evaluator', () => {
   }) => {
     await openEvaluatorForm(mockedPage, 'DefenseClaw OPA Policy');
 
-    await expect(mockedPage.getByText('Domain', { exact: true })).toBeVisible();
-    await expect(
-      mockedPage.getByText('Block at', { exact: true })
-    ).toBeVisible();
-    await expect(
-      mockedPage.getByText('Alert at', { exact: true })
-    ).toBeVisible();
-    await expect(
-      mockedPage.getByText('Cisco trust level', { exact: true })
-    ).toBeVisible();
+    await expect(mockedPage.getByLabel('Domain')).toBeVisible();
+    await expect(mockedPage.getByLabel('Block at')).toBeVisible();
+    await expect(mockedPage.getByLabel('Alert at')).toBeVisible();
+    await expect(mockedPage.getByLabel('Cisco trust level')).toBeVisible();
     await expect(
       mockedPage.getByText('Schema version', { exact: true })
     ).toHaveCount(0);

--- a/ui/tests/evaluators/defenseclaw.spec.ts
+++ b/ui/tests/evaluators/defenseclaw.spec.ts
@@ -12,9 +12,13 @@ test.describe('DefenseClaw Rule Pack Evaluator', () => {
     await expect(mockedPage.getByLabel('Rule ID')).toBeVisible();
     await expect(mockedPage.getByLabel('Title')).toBeVisible();
     await expect(mockedPage.getByLabel('Pattern')).toBeVisible();
-    await expect(mockedPage.getByLabel('Severity')).toBeVisible();
+    await expect(
+      mockedPage.getByRole('textbox', { name: 'Severity' })
+    ).toBeVisible();
     await expect(mockedPage.getByLabel('Confidence')).toBeVisible();
-    await expect(mockedPage.getByLabel('Tags')).toBeVisible();
+    await expect(
+      mockedPage.getByRole('textbox', { name: 'Tags' })
+    ).toBeVisible();
 
     await expect(
       mockedPage.getByText('Schema version', { exact: true })
@@ -46,10 +50,18 @@ test.describe('DefenseClaw OPA Policy Evaluator', () => {
   }) => {
     await openEvaluatorForm(mockedPage, 'DefenseClaw OPA Policy');
 
-    await expect(mockedPage.getByLabel('Domain')).toBeVisible();
-    await expect(mockedPage.getByLabel('Block at')).toBeVisible();
-    await expect(mockedPage.getByLabel('Alert at')).toBeVisible();
-    await expect(mockedPage.getByLabel('Cisco trust level')).toBeVisible();
+    await expect(
+      mockedPage.getByRole('textbox', { name: 'Domain' })
+    ).toBeVisible();
+    await expect(
+      mockedPage.getByRole('textbox', { name: 'Block at' })
+    ).toBeVisible();
+    await expect(
+      mockedPage.getByRole('textbox', { name: 'Alert at' })
+    ).toBeVisible();
+    await expect(
+      mockedPage.getByRole('textbox', { name: 'Cisco trust level' })
+    ).toBeVisible();
     await expect(
       mockedPage.getByText('Schema version', { exact: true })
     ).toHaveCount(0);

--- a/ui/tests/evaluators/defenseclaw.spec.ts
+++ b/ui/tests/evaluators/defenseclaw.spec.ts
@@ -1,0 +1,71 @@
+/** Integration tests for the DefenseClaw evaluator forms. */
+
+import { expect, test } from '../fixtures';
+import { openEvaluatorForm } from './helpers';
+
+test.describe('DefenseClaw Rule Pack Evaluator', () => {
+  test('shows typed rule fields and hides wire constants', async ({
+    mockedPage,
+  }) => {
+    await openEvaluatorForm(mockedPage, 'DefenseClaw Rule Pack');
+
+    await expect(
+      mockedPage.getByText('Rule ID', { exact: true })
+    ).toBeVisible();
+    await expect(mockedPage.getByText('Title', { exact: true })).toBeVisible();
+    await expect(
+      mockedPage.getByText('Pattern', { exact: true })
+    ).toBeVisible();
+    await expect(
+      mockedPage.getByText('Severity', { exact: true })
+    ).toBeVisible();
+    await expect(
+      mockedPage.getByText('Confidence', { exact: true })
+    ).toBeVisible();
+    await expect(mockedPage.getByText('Tags', { exact: true })).toBeVisible();
+
+    await expect(
+      mockedPage.getByText('Schema version', { exact: true })
+    ).toHaveCount(0);
+    await expect(mockedPage.getByText('Version', { exact: true })).toHaveCount(
+      0
+    );
+    await expect(mockedPage.getByText('Category', { exact: true })).toHaveCount(
+      0
+    );
+  });
+
+  test('can add and remove rules', async ({ mockedPage }) => {
+    await openEvaluatorForm(mockedPage, 'DefenseClaw Rule Pack');
+
+    await mockedPage.getByRole('button', { name: 'Add rule' }).click();
+    await expect(mockedPage.getByText('Rule 2', { exact: true })).toBeVisible();
+
+    await mockedPage.getByRole('button', { name: 'Remove rule 2' }).click();
+    await expect(mockedPage.getByText('Rule 2', { exact: true })).toHaveCount(
+      0
+    );
+  });
+});
+
+test.describe('DefenseClaw OPA Policy Evaluator', () => {
+  test('shows policy fields and hides schema version', async ({
+    mockedPage,
+  }) => {
+    await openEvaluatorForm(mockedPage, 'DefenseClaw OPA Policy');
+
+    await expect(mockedPage.getByText('Domain', { exact: true })).toBeVisible();
+    await expect(
+      mockedPage.getByText('Block at', { exact: true })
+    ).toBeVisible();
+    await expect(
+      mockedPage.getByText('Alert at', { exact: true })
+    ).toBeVisible();
+    await expect(
+      mockedPage.getByText('Cisco trust level', { exact: true })
+    ).toBeVisible();
+    await expect(
+      mockedPage.getByText('Schema version', { exact: true })
+    ).toHaveCount(0);
+  });
+});

--- a/ui/tests/evaluators/defenseclaw.spec.ts
+++ b/ui/tests/evaluators/defenseclaw.spec.ts
@@ -9,10 +9,12 @@ test.describe('DefenseClaw Rule Pack Evaluator', () => {
   }) => {
     await openEvaluatorForm(mockedPage, 'DefenseClaw Rule Pack');
 
-    await expect(mockedPage.getByLabel('Execution environment')).toHaveValue(
-      'sdk'
-    );
-    await expect(mockedPage.getByLabel('Execution environment')).toBeDisabled();
+    await expect(
+      mockedPage.getByRole('textbox', { name: 'Execution environment' })
+    ).toHaveValue('sdk');
+    await expect(
+      mockedPage.getByRole('textbox', { name: 'Execution environment' })
+    ).toBeDisabled();
 
     await expect(mockedPage.getByLabel('Rule ID')).toBeVisible();
     await expect(mockedPage.getByLabel('Title')).toBeVisible();
@@ -55,10 +57,12 @@ test.describe('DefenseClaw OPA Policy Evaluator', () => {
   }) => {
     await openEvaluatorForm(mockedPage, 'DefenseClaw OPA Policy');
 
-    await expect(mockedPage.getByLabel('Execution environment')).toHaveValue(
-      'sdk'
-    );
-    await expect(mockedPage.getByLabel('Execution environment')).toBeDisabled();
+    await expect(
+      mockedPage.getByRole('textbox', { name: 'Execution environment' })
+    ).toHaveValue('sdk');
+    await expect(
+      mockedPage.getByRole('textbox', { name: 'Execution environment' })
+    ).toBeDisabled();
 
     await expect(
       mockedPage.getByRole('textbox', { name: 'Domain' })

--- a/ui/tests/fixtures.ts
+++ b/ui/tests/fixtures.ts
@@ -1,4 +1,4 @@
-import { expect, type Page, test as base } from '@playwright/test';
+import { type Page, test as base } from '@playwright/test';
 
 import type {
   AgentControlsResponse,
@@ -448,6 +448,76 @@ const evaluatorsResponse: EvaluatorsResponse = {
         payload_field: { type: 'string', enum: ['input', 'output'] },
         timeout_ms: { type: 'integer', minimum: 1000, maximum: 60000 },
         config: { type: 'object' },
+      },
+    },
+  },
+  'defenseclaw.rule_pack': {
+    name: 'DefenseClaw Rule Pack',
+    version: '1.0.0',
+    description: 'DefenseClaw rule-pack evaluation',
+    requires_api_key: false,
+    timeout_ms: 10000,
+    config_schema: {
+      type: 'object',
+      properties: {
+        schema_version: { type: 'integer', const: 1, default: 1 },
+        rule_pack: {
+          type: 'object',
+          properties: {
+            version: { type: 'integer', const: 1, default: 1 },
+            category: {
+              type: 'string',
+              const: 'agent-control',
+              default: 'agent-control',
+            },
+            rules: {
+              type: 'array',
+              minItems: 1,
+              items: {
+                type: 'object',
+                properties: {
+                  id: { type: 'string', minLength: 1 },
+                  pattern: { type: 'string', minLength: 1 },
+                  title: { type: 'string', minLength: 1 },
+                  severity: {
+                    type: 'string',
+                    enum: ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'],
+                  },
+                  confidence: { type: 'number', minimum: 0, maximum: 1 },
+                  tags: { type: 'array', items: { type: 'string' } },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  'defenseclaw.opa_policy': {
+    name: 'DefenseClaw OPA Policy',
+    version: '1.0.0',
+    description: 'DefenseClaw OPA-policy evaluation',
+    requires_api_key: false,
+    timeout_ms: 10000,
+    config_schema: {
+      type: 'object',
+      properties: {
+        schema_version: { type: 'integer', const: 1, default: 1 },
+        policy: {
+          type: 'object',
+          properties: {
+            domain: { type: 'string', const: 'guardrail' },
+            block_at: {
+              type: 'string',
+              enum: ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'],
+            },
+            alert_at: {
+              type: 'string',
+              enum: ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'],
+            },
+            cisco_trust_level: { type: 'string', const: 'full' },
+          },
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary

Added two global external evaluator integrations:
- `defenseclaw.rule_pack`
- `defenseclaw.opa_policy`

- Added strict, typed Pydantic configuration models and distinct JSON Schemas.
- Added dedicated Agent Control UI forms with canonical serialization of hidden protocol fields.
- Both evaluator execution paths are intentionally no-ops and do not install or invoke DefenseClaw OSS packages.

## Scope

**User-facing/API changes:**
- Both evaluators appear independently in `GET /api/v1/evaluators`.
- Added typed UI forms for rule-pack and OPA-policy configuration.
- Rule-pack forms support adding and removing rules.
- Fixed protocol fields remain hidden in Form mode but are always serialized.
- DefenseClaw configurations are preserved in `get_server_controls()` output.

**Internal changes:**
- Added the `agent-control-evaluator-defenseclaw` contrib package.
- Added evaluator entry-point registration and package/release wiring.
- Added strict nested validation, including unique rule IDs and confidence bounds.
- Added default configurations and UI registry entries.
- Added focused backend and UI tests.

**Out of scope:**
- DefenseClaw transport, authentication, or provider invocation.
- Installing or calling DefenseClaw OSS packages.
- Changes to the separate `~/code/ui` Galileo UI repository.
- Orbit production packaging changes.

## Risk and Rollout

**Risk level:** medium

**Primary risk:**
- The evaluator package must be installed in the server runtime for catalog discovery and server execution.
- It must also be installed in SDK runtimes for controls using `execution: "sdk"`.

**Rollout requirements:**
- Publish `agent-control-evaluator-defenseclaw`.
- Add the package to the Orbit Agent Control image dependencies.
- Verify both evaluator identifiers appear in `GET /api/v1/evaluators` before activating controls.

**Rollback plan:**
- Remove or disable controls referencing the DefenseClaw evaluator names.
- Remove the DefenseClaw package from runtime dependencies.
- Revert the evaluator registry and UI form registration changes.

## Testing

- [x] Added or updated automated tests
  - Ran `make check` (full repository check was not run).
  - Ran 26 focused Python tests successfully.
  - Ran Ruff and mypy successfully.
  - Ran TypeScript, ESLint, and Prettier checks successfully.
  - Verified contrib package wiring, evaluator registration, and server catalog schemas.
  - Playwright could not run in the sandbox because it could not bind the local UI server port.

- [x] Manually verified behavior
  - Registration and generated catalog schemas were verified programmatically.
  - Full browser-based Form/JSON interaction should be verified locally using the supplied testing guide.

## Checklist

- [ ] **Linked issue/spec**
  - Technical spec: `defenseclaw-external-evaluators-technical-spec.md`
  - Add the appropriate issue/spec URL before merging.

- [x] **Updated docs/examples for user-facing changes**
  - Added the contrib package README.
  - Created a first-time local setup and testing guide.

- [x] **Included required follow-up tasks**
  - Add DefenseClaw packaging to `~/code/orbit`.
  - Implement the corresponding forms in `~/code/ui`.
  - Run the full Playwright suite.
  - Install the evaluator package in every SDK runtime that evaluates DefenseClaw controls.
