### PR TITLE
feat(server): support optionally disabling uvicorn access logs

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -50,3 +50,21 @@ AGENT_CONTROL_DB_PORT=5432
 AGENT_CONTROL_DB_USER=agent_control
 AGENT_CONTROL_DB_PASSWORD=agent_control
 AGENT_CONTROL_DB_DATABASE=agent_control
+
+###########
+# Logging #
+###########
+
+# Log level for the server's own loggers (e.g. INFO, DEBUG, WARNING).
+# AGENT_CONTROL_LOG_LEVEL=INFO
+
+# Emit logs as JSON instead of plain text.
+# AGENT_CONTROL_LOG_JSON=false
+
+# Whether the server installs its own logging handlers. Set to false to let an
+# embedding host own the logging configuration (passes log_config=None to uvicorn).
+# AGENT_CONTROL_CONFIGURE_LOGGING=true
+
+# Whether uvicorn's built-in per-request access log is emitted. Set to false to
+# suppress it, e.g. when an embedding host already emits its own request log.
+# AGENT_CONTROL_ACCESS_LOG=true

--- a/server/src/agent_control_server/config.py
+++ b/server/src/agent_control_server/config.py
@@ -280,6 +280,7 @@ class LoggingSettings(BaseSettings):
     model_config = SettingsConfigDict(**_COMMON_SETTINGS_CONFIG, env_prefix="AGENT_CONTROL_LOG_")
 
     configure_logging: bool = _env_alias_field(True, "AGENT_CONTROL_CONFIGURE_LOGGING")
+    access_log: bool = _env_alias_field(True, "AGENT_CONTROL_ACCESS_LOG")
     level: str | None = None
     json_logs: bool = _env_alias_field(False, "AGENT_CONTROL_LOG_JSON")
 

--- a/server/src/agent_control_server/logging_utils.py
+++ b/server/src/agent_control_server/logging_utils.py
@@ -71,6 +71,11 @@ def should_configure_logging() -> bool:
     return LoggingSettings().configure_logging
 
 
+def access_log_enabled() -> bool:
+    """Return whether uvicorn's per-request access log should be emitted."""
+    return LoggingSettings().access_log
+
+
 def configure_logging(
     *,
     level: str | int | None = None,

--- a/server/src/agent_control_server/main.py
+++ b/server/src/agent_control_server/main.py
@@ -37,7 +37,12 @@ from .errors import (
     http_exception_handler,
     validation_exception_handler,
 )
-from .logging_utils import configure_logging, get_uvicorn_log_level_name, should_configure_logging
+from .logging_utils import (
+    access_log_enabled,
+    configure_logging,
+    get_uvicorn_log_level_name,
+    should_configure_logging,
+)
 from .observability.ingest import DirectEventIngestor
 from .observability.sinks import (
     EventStoreControlEventSink,
@@ -417,6 +422,7 @@ def run() -> None:
         "host": settings.host,
         "port": settings.port,
         "log_level": get_uvicorn_log_level_name(_default_log_level()).lower(),
+        "access_log": access_log_enabled(),
     }
     if not should_configure_logging():
         uvicorn_kwargs["log_config"] = None

--- a/server/tests/test_config.py
+++ b/server/tests/test_config.py
@@ -287,3 +287,17 @@ def test_logging_settings_supports_host_owned_logging(monkeypatch) -> None:
     config = LoggingSettings()
 
     assert config.configure_logging is False
+
+
+def test_logging_settings_access_log_defaults_to_true() -> None:
+    config = LoggingSettings()
+
+    assert config.access_log is True
+
+
+def test_logging_settings_access_log_can_be_disabled(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_CONTROL_ACCESS_LOG", "false")
+
+    config = LoggingSettings()
+
+    assert config.access_log is False

--- a/server/tests/test_logging_utils.py
+++ b/server/tests/test_logging_utils.py
@@ -5,6 +5,7 @@ import logging
 from agent_control_server.logging_utils import (
     _parse_json,
     _parse_level,
+    access_log_enabled,
     configure_logging,
     get_log_level_name,
     get_uvicorn_log_level_name,
@@ -145,6 +146,16 @@ def test_should_configure_logging_can_be_disabled(monkeypatch) -> None:
     monkeypatch.setenv("AGENT_CONTROL_CONFIGURE_LOGGING", "false")
 
     assert should_configure_logging() is False
+
+
+def test_access_log_enabled_defaults_to_true() -> None:
+    assert access_log_enabled() is True
+
+
+def test_access_log_enabled_can_be_disabled(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_CONTROL_ACCESS_LOG", "false")
+
+    assert access_log_enabled() is False
 
 
 def test_configure_logging_noops_when_host_owns_logging(monkeypatch) -> None:

--- a/server/tests/test_main_lifespan.py
+++ b/server/tests/test_main_lifespan.py
@@ -273,10 +273,11 @@ def test_run_uses_settings(monkeypatch) -> None:
     # Given: patched settings and uvicorn.run
     called = {}
 
-    def fake_run(app, host, port, log_level):
+    def fake_run(app, host, port, log_level, access_log):
         called["host"] = host
         called["port"] = port
         called["log_level"] = log_level
+        called["access_log"] = access_log
 
     monkeypatch.setattr(main_module.uvicorn, "run", fake_run)
     monkeypatch.setattr(settings, "host", "127.0.0.1")
@@ -290,6 +291,7 @@ def test_run_uses_settings(monkeypatch) -> None:
     assert called["host"] == "127.0.0.1"
     assert called["port"] == 9999
     assert called["log_level"] == "debug"
+    assert called["access_log"] is True
 
 
 def test_run_disables_uvicorn_log_config_when_host_owns_logging(monkeypatch) -> None:
@@ -307,3 +309,20 @@ def test_run_disables_uvicorn_log_config_when_host_owns_logging(monkeypatch) -> 
     main_module.run()
 
     assert called["log_config"] is None
+
+
+def test_run_disables_uvicorn_access_log_when_requested(monkeypatch) -> None:
+    called = {}
+
+    def fake_run(app, **kwargs):  # type: ignore[no-untyped-def]
+        called.update(kwargs)
+
+    monkeypatch.setenv("AGENT_CONTROL_ACCESS_LOG", "false")
+    monkeypatch.setattr(main_module.uvicorn, "run", fake_run)
+    monkeypatch.setattr(settings, "host", "127.0.0.1")
+    monkeypatch.setattr(settings, "port", 9999)
+    monkeypatch.setattr(settings, "debug", False)
+
+    main_module.run()
+
+    assert called["access_log"] is False


### PR DESCRIPTION
## Summary

Adds an `access_log` setting that lets embedders suppress uvicorn's built-in per-request access log, defaulting to `True` (no behavior change for existing users).

When `agent_control_server` is embedded in a host that already emits its own structured request log, uvicorn's `uvicorn.access` line produces a duplicate per request. The existing `AGENT_CONTROL_CONFIGURE_LOGGING=false` opt-out does **not** stop it — uvicorn's `Config.configure_logging()` unconditionally resets `uvicorn.access` to INFO. The reliable lever is uvicorn's `access_log` kwarg: with `access_log=False`, uvicorn clears the logger's handlers and sets `propagate=False`, so the line is never emitted.

## Changes

- **`config.py`** — add `access_log: bool = _env_alias_field(True, "AGENT_CONTROL_ACCESS_LOG")` to `LoggingSettings` (matches the `configure_logging` alias pattern).
- **`logging_utils.py`** — add an `access_log_enabled()` helper mirroring `should_configure_logging()`, so `main.py` reads logging config via helpers (repo convention) rather than importing `LoggingSettings` directly.
- **`main.py`** — pass `"access_log": access_log_enabled()` into `uvicorn_kwargs` in `run()`.
- **Tests** — update `test_run_uses_settings` (its fixed positional `fake_run` signature would otherwise break) to assert `access_log is True`; add `test_run_disables_uvicorn_access_log_when_requested`; add default/disable tests in `test_config.py` and `test_logging_utils.py`.
- **`.env.example`** — add a Logging section documenting `AGENT_CONTROL_ACCESS_LOG` alongside the previously-undocumented `AGENT_CONTROL_LOG_LEVEL`, `AGENT_CONTROL_LOG_JSON`, and `AGENT_CONTROL_CONFIGURE_LOGGING`.

## Acceptance criteria

- [x] New `access_log` setting on `LoggingSettings`, defaulting to `True`.
- [x] Configurable via `AGENT_CONTROL_ACCESS_LOG`.
- [x] With `AGENT_CONTROL_ACCESS_LOG=false`, no `uvicorn.access` line is emitted, whether `configure_logging` is on or off.
- [x] Error/app logging (`uvicorn.error`, application loggers) unaffected.
- [x] Documented in `.env.example`.

## Testing

All 47 tests across the affected suites pass (`test_config.py`, `test_main_lifespan.py`, `test_logging_utils.py`), run against a local dev Postgres.

## Notes

- `server/README.md` defers config docs to `https://docs.agentcontrol.dev/components/server` (out of repo scope) — worth updating there separately as a follow-up.

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)