### PR TITLE
feat(server): configurable runtime-token header to avoid gateway Authorization collision [HYBIM-866]

### DIFF
--- a/sdks/python/src/agent_control/__init__.py
+++ b/sdks/python/src/agent_control/__init__.py
@@ -113,6 +113,7 @@ from .observability import (
     write_events,
 )
 from .otel_sink import control_event_to_otel_span
+from .runtime_auth import validate_http_field_name
 from .tracing import (
     get_current_span_id,
     get_current_trace_id,
@@ -562,6 +563,16 @@ def init(
         raise ValueError(
             "target_type and target_id must be supplied together."
         )
+    # Validate the runtime-token header up front, before stopping the refresh
+    # loop or mutating shared session state. An explicit blank or a
+    # syntactically-invalid header must fail here rather than on the first
+    # later evaluation. (A None/unset value is fine; AgentControlClient resolves
+    # the env-var fallback and default when the eval client is built.)
+    if runtime_token_header is not None:
+        if not runtime_token_header.strip():
+            raise ValueError("runtime_token_header must not be blank.")
+        validate_http_field_name(runtime_token_header.strip())
+
     resolved_api_key_header = (
         api_key_header
         or os.getenv(AgentControlClient.API_KEY_HEADER_ENV_VAR)

--- a/sdks/python/src/agent_control/__init__.py
+++ b/sdks/python/src/agent_control/__init__.py
@@ -448,6 +448,7 @@ def init(
     server_url: str | None = None,
     api_key: str | None = None,
     api_key_header: str | None = None,
+    runtime_token_header: str | None = None,
     controls_file: str | None = None,
     steps: list[StepSchemaDict] | None = None,
     conflict_mode: Literal["strict", "overwrite"] = "overwrite",
@@ -488,6 +489,12 @@ def init(
         api_key: Optional API key for authentication (defaults to AGENT_CONTROL_API_KEY env var)
         api_key_header: Optional HTTP header name for API key authentication
             (defaults to AGENT_CONTROL_API_KEY_HEADER env var or X-API-Key)
+        runtime_token_header: Optional HTTP header the runtime token is sent on
+            for evaluation requests (defaults to AGENT_CONTROL_RUNTIME_TOKEN_HEADER
+            env var or Authorization). Point this at a dedicated header (e.g.
+            X-Agent-Control-Runtime-Token) when the server runs behind a gateway
+            that reserves Authorization for its own identity JWT. The server must
+            be configured to read the same header.
         controls_file: Optional explicit path to controls.yaml (auto-discovered if not provided)
         steps: Optional list of step schemas for registration:
                [{"type": "tool", "name": "search", "input_schema": {...}, "output_schema": {...}}]
@@ -588,6 +595,9 @@ def init(
         state.server_url = server_url or os.getenv('AGENT_CONTROL_URL') or 'http://localhost:8000'
         state.api_key = api_key
         state.api_key_header = resolved_api_key_header
+        # Stored raw (may be None); AgentControlClient resolves the env-var
+        # fallback and blank-handling so the rule stays in one place.
+        state.runtime_token_header = runtime_token_header
         state.runtime_token_cache.clear()
         state.target_type = target_type
         state.target_id = target_id
@@ -746,6 +756,7 @@ def _reset_state() -> None:
         state.server_url = None
         state.api_key = None
         state.api_key_header = None
+        state.runtime_token_header = None
         state.runtime_token_cache.clear()
         state.target_type = None
         state.target_id = None

--- a/sdks/python/src/agent_control/__init__.py
+++ b/sdks/python/src/agent_control/__init__.py
@@ -448,7 +448,6 @@ def init(
     server_url: str | None = None,
     api_key: str | None = None,
     api_key_header: str | None = None,
-    runtime_token_header: str | None = None,
     controls_file: str | None = None,
     steps: list[StepSchemaDict] | None = None,
     conflict_mode: Literal["strict", "overwrite"] = "overwrite",
@@ -459,6 +458,7 @@ def init(
     policy_refresh_interval_seconds: int = 60,
     target_type: str | None = None,
     target_id: str | None = None,
+    runtime_token_header: str | None = None,
     **kwargs: object
 ) -> Agent:
     """
@@ -489,12 +489,6 @@ def init(
         api_key: Optional API key for authentication (defaults to AGENT_CONTROL_API_KEY env var)
         api_key_header: Optional HTTP header name for API key authentication
             (defaults to AGENT_CONTROL_API_KEY_HEADER env var or X-API-Key)
-        runtime_token_header: Optional HTTP header the runtime token is sent on
-            for evaluation requests (defaults to AGENT_CONTROL_RUNTIME_TOKEN_HEADER
-            env var or Authorization). Point this at a dedicated header (e.g.
-            X-Agent-Control-Runtime-Token) when the server runs behind a gateway
-            that reserves Authorization for its own identity JWT. The server must
-            be configured to read the same header.
         controls_file: Optional explicit path to controls.yaml (auto-discovered if not provided)
         steps: Optional list of step schemas for registration:
                [{"type": "tool", "name": "search", "input_schema": {...}, "output_schema": {...}}]
@@ -513,6 +507,12 @@ def init(
             returned set when both are present.
         target_id: Optional opaque target identifier. Required iff target_type
             is also supplied.
+        runtime_token_header: Optional HTTP header the runtime token is sent on
+            for evaluation requests (defaults to AGENT_CONTROL_RUNTIME_TOKEN_HEADER
+            env var or Authorization). Point this at a dedicated header (e.g.
+            X-Agent-Control-Runtime-Token) when the server runs behind a gateway
+            that reserves Authorization for its own identity JWT. The server must
+            be configured to read the same header.
         **kwargs: Additional metadata to store with the agent
 
     Returns:

--- a/sdks/python/src/agent_control/_state.py
+++ b/sdks/python/src/agent_control/_state.py
@@ -27,6 +27,7 @@ class _StateContainer:
         self.server_url: str | None = None
         self.api_key: str | None = None
         self.api_key_header: str | None = None
+        self.runtime_token_header: str | None = None
         self.runtime_token_cache = RuntimeTokenCache()
         # Optional target context fixed at init() time; both fields are set
         # together or both remain None.

--- a/sdks/python/src/agent_control/client.py
+++ b/sdks/python/src/agent_control/client.py
@@ -15,6 +15,7 @@ from .runtime_auth import (
     RuntimeTokenCache,
     normalize_runtime_auth_mode,
     parse_runtime_token_exchange_response,
+    resolve_runtime_token_header,
 )
 
 _logger = logging.getLogger(__name__)
@@ -167,16 +168,11 @@ class AgentControlClient:
         self._runtime_auth_mode = normalize_runtime_auth_mode(configured_runtime_mode)
         # Explicit blank param is a hard error; a blank env var falls back to
         # the default (mirrors the server's _resolve_runtime_token_header).
-        if runtime_token_header is not None and not runtime_token_header.strip():
-            raise ValueError("runtime_token_header must not be blank.")
-        env_runtime_token_header = os.environ.get(_RUNTIME_TOKEN_HEADER_ENV_VAR)
-        if env_runtime_token_header is not None and not env_runtime_token_header.strip():
-            env_runtime_token_header = None
-        self._runtime_token_header = (
-            runtime_token_header
-            or env_runtime_token_header
-            or _DEFAULT_RUNTIME_TOKEN_HEADER
-        ).strip()
+        self._runtime_token_header = resolve_runtime_token_header(
+            runtime_token_header,
+            os.environ.get(_RUNTIME_TOKEN_HEADER_ENV_VAR),
+            default=_DEFAULT_RUNTIME_TOKEN_HEADER,
+        )
         # Bearer only on Authorization; a dedicated header carries the raw token
         # so it can't collide with the gateway's Authorization JWT. Must stay in
         # sync with LocalJwtVerifyProvider._require_bearer on the server.
@@ -305,7 +301,14 @@ class AgentControlClient:
             headers=request_headers,
         )
 
-        if _should_refresh_runtime_token(response) and runtime_authorization is not None:
+        runtime_token_on_dedicated_header = not self._runtime_token_use_bearer
+        if (
+            _should_refresh_runtime_token(
+                response,
+                runtime_token_on_dedicated_header=runtime_token_on_dedicated_header,
+            )
+            and runtime_authorization is not None
+        ):
             await response.aread()
             if target_type is not None and target_id is not None:
                 self._runtime_token_cache.remove(
@@ -327,7 +330,10 @@ class AgentControlClient:
                 headers=request_headers,
             )
             if (
-                _should_refresh_runtime_token(response)
+                _should_refresh_runtime_token(
+                    response,
+                    runtime_token_on_dedicated_header=runtime_token_on_dedicated_header,
+                )
                 and target_type is not None
                 and target_id is not None
             ):
@@ -507,10 +513,39 @@ class AgentControlClient:
         return token.token
 
 
-def _should_refresh_runtime_token(response: httpx.Response) -> bool:
+def _authenticate_flags_runtime_token(response: httpx.Response) -> bool:
+    """True when the response's WWW-Authenticate marks the token invalid.
+
+    Looks for the RFC 6750 ``error="invalid_token"`` challenge the runtime
+    verifier emits, so a refresh is driven by the server naming the token as
+    the problem, not by a bare status code.
+    """
+    return "invalid_token" in response.headers.get("WWW-Authenticate", "").lower()
+
+
+def _should_refresh_runtime_token(
+    response: httpx.Response,
+    *,
+    runtime_token_on_dedicated_header: bool = False,
+) -> bool:
+    """Decide whether a runtime-token refresh is warranted for this response.
+
+    When the runtime token rides ``Authorization`` (the default), a 401 is
+    unambiguous: the only credential on that header is the runtime token, so
+    treat it as expired and refresh.
+
+    When the token rides a dedicated header (behind a gateway that owns
+    ``Authorization`` for its own identity JWT), a bare 401 is ambiguous: it
+    may be the gateway rejecting its own credential, not our runtime token.
+    Evicting a still-valid token there just forces another exchange that hits
+    the same gateway 401 and hides the original error. So in that case only
+    refresh when the server explicitly flags the runtime token as invalid via
+    WWW-Authenticate (or a 403 invalid_token challenge).
+    """
     if response.status_code == 401:
+        if runtime_token_on_dedicated_header:
+            return _authenticate_flags_runtime_token(response)
         return True
     if response.status_code != 403:
         return False
-    authenticate = response.headers.get("WWW-Authenticate", "")
-    return "invalid_token" in authenticate.lower()
+    return _authenticate_flags_runtime_token(response)

--- a/sdks/python/src/agent_control/client.py
+++ b/sdks/python/src/agent_control/client.py
@@ -20,6 +20,8 @@ from .runtime_auth import (
 _logger = logging.getLogger(__name__)
 
 _RUNTIME_AUTH_MODE_ENV_VAR = "AGENT_CONTROL_RUNTIME_AUTH_MODE"
+_RUNTIME_TOKEN_HEADER_ENV_VAR = "AGENT_CONTROL_RUNTIME_TOKEN_HEADER"
+_DEFAULT_RUNTIME_TOKEN_HEADER = "Authorization"
 _DEFAULT_RUNTIME_TOKEN_REFRESH_MARGIN_SECONDS = 30
 _AUTO_RUNTIME_TOKEN_FALLBACK_STATUSES = {404, 500, 502, 503, 504}
 _GLOBAL_RUNTIME_TOKEN_FALLBACK_STATUSES = {404}
@@ -35,19 +37,39 @@ def _runtime_cache_identity(api_key: str | None, api_key_header: str) -> str:
 
 
 class _AgentControlAuth(httpx.Auth):
-    """Attach local API-key credentials unless a request already has Bearer auth."""
+    """Attach local API-key credentials unless the request already carries a token.
 
-    def __init__(self, api_key: str | None, header_name: str = "X-API-Key") -> None:
+    The API key is suppressed when the request already presents a bearer
+    credential on ``Authorization`` or a runtime token on its dedicated
+    header, so a runtime-authenticated evaluation carries a single
+    credential regardless of which header the runtime token rides.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None,
+        header_name: str = "X-API-Key",
+        runtime_token_header: str | None = None,
+    ) -> None:
         self._api_key = api_key
         self._header_name = header_name
+        self._runtime_token_header = runtime_token_header
 
     def auth_flow(
         self,
         request: httpx.Request,
     ) -> Generator[httpx.Request, httpx.Response, None]:
-        if self._api_key and "Authorization" not in request.headers:
-            if self._header_name not in request.headers:
-                request.headers[self._header_name] = self._api_key
+        runtime_token_on_dedicated_header = (
+            self._runtime_token_header is not None
+            and self._runtime_token_header in request.headers
+        )
+        if (
+            self._api_key
+            and "Authorization" not in request.headers
+            and not runtime_token_on_dedicated_header
+            and self._header_name not in request.headers
+        ):
+            request.headers[self._header_name] = self._api_key
         yield request
 
 
@@ -99,6 +121,7 @@ class AgentControlClient:
         api_key: str | None = None,
         api_key_header: str | None = None,
         runtime_auth_mode: RuntimeAuthMode | str | None = None,
+        runtime_token_header: str | None = None,
         runtime_token_cache: RuntimeTokenCache | None = None,
         runtime_token_refresh_margin_seconds: int = (_DEFAULT_RUNTIME_TOKEN_REFRESH_MARGIN_SECONDS),
         transport: httpx.AsyncBaseTransport | None = None,
@@ -121,6 +144,13 @@ class AgentControlClient:
                 request auth when the exchange endpoint is unavailable. ``jwt``
                 requires a successful exchange. ``api_key`` and ``none`` keep
                 evaluation requests on the normal request-auth path.
+            runtime_token_header: HTTP header the runtime token is sent on.
+                Defaults to ``Authorization``; the
+                AGENT_CONTROL_RUNTIME_TOKEN_HEADER environment variable
+                overrides the default. Point this at a dedicated header (e.g.
+                ``X-Agent-Control-Runtime-Token``) when the server runs behind
+                a gateway that reserves ``Authorization`` for its own identity
+                JWT. The server must be configured to read the same header.
             runtime_token_cache: Optional cache shared across client instances.
             runtime_token_refresh_margin_seconds: Refresh cached runtime tokens
                 before this many seconds of validity remain.
@@ -140,6 +170,24 @@ class AgentControlClient:
         self._runtime_cache_identity = _runtime_cache_identity(self._api_key, self._api_key_header)
         configured_runtime_mode = runtime_auth_mode or os.environ.get(_RUNTIME_AUTH_MODE_ENV_VAR)
         self._runtime_auth_mode = normalize_runtime_auth_mode(configured_runtime_mode)
+        # Explicit blank param is a hard error; a blank env var falls back to
+        # the default (mirrors the server's _resolve_runtime_token_header).
+        if runtime_token_header is not None and not runtime_token_header.strip():
+            raise ValueError("runtime_token_header must not be blank.")
+        env_runtime_token_header = os.environ.get(_RUNTIME_TOKEN_HEADER_ENV_VAR)
+        if env_runtime_token_header is not None and not env_runtime_token_header.strip():
+            env_runtime_token_header = None
+        self._runtime_token_header = (
+            runtime_token_header
+            or env_runtime_token_header
+            or _DEFAULT_RUNTIME_TOKEN_HEADER
+        ).strip()
+        # Bearer only on Authorization; a dedicated header carries the raw token
+        # so it can't collide with the gateway's Authorization JWT. Must stay in
+        # sync with LocalJwtVerifyProvider._require_bearer on the server.
+        self._runtime_token_use_bearer = (
+            self._runtime_token_header.lower() == _DEFAULT_RUNTIME_TOKEN_HEADER.lower()
+        )
         if runtime_token_refresh_margin_seconds < 0:
             raise ValueError("runtime_token_refresh_margin_seconds must be >= 0.")
         self._runtime_token_refresh_margin_seconds = runtime_token_refresh_margin_seconds
@@ -198,7 +246,13 @@ class AgentControlClient:
             base_url=self.base_url,
             timeout=self.timeout,
             headers=self._get_headers(),
-            auth=_AgentControlAuth(self._api_key, self._api_key_header),
+            auth=_AgentControlAuth(
+                self._api_key,
+                self._api_key_header,
+                runtime_token_header=(
+                    None if self._runtime_token_use_bearer else self._runtime_token_header
+                ),
+            ),
             transport=self._transport,
             event_hooks={"response": [self._check_server_version]},
         )
@@ -295,18 +349,22 @@ class AgentControlClient:
 
         return response
 
+    def _format_runtime_token(self, token: str) -> str:
+        """Sole place the Bearer prefix is applied (see __init__ for the rule)."""
+        return f"Bearer {token}" if self._runtime_token_use_bearer else token
+
     def _merge_runtime_headers(
         self,
         headers: dict[str, str] | None,
         runtime_authorization: str | None,
     ) -> dict[str, str] | None:
-        """Merge caller headers with an optional Bearer token."""
+        """Merge caller headers with an optional runtime token header."""
         if headers is None and runtime_authorization is None:
             return None
 
         merged = dict(headers or {})
         if runtime_authorization is not None:
-            merged["Authorization"] = runtime_authorization
+            merged[self._runtime_token_header] = runtime_authorization
         return merged
 
     async def _runtime_authorization(
@@ -350,7 +408,7 @@ class AgentControlClient:
                 refresh_margin_seconds=self._runtime_token_refresh_margin_seconds,
             )
             if cached is not None:
-                return f"Bearer {cached.token}"
+                return self._format_runtime_token(cached.token)
 
         exchange_lock = self._runtime_token_cache.exchange_lock(
             self.base_url,
@@ -379,7 +437,7 @@ class AgentControlClient:
                     refresh_margin_seconds=self._runtime_token_refresh_margin_seconds,
                 )
                 if cached is not None:
-                    return f"Bearer {cached.token}"
+                    return self._format_runtime_token(cached.token)
 
             token = await self._exchange_runtime_token(
                 target_type=target_type,
@@ -388,7 +446,7 @@ class AgentControlClient:
             )
         if token is None:
             return None
-        return f"Bearer {token}"
+        return self._format_runtime_token(token)
 
     async def _exchange_runtime_token(
         self,

--- a/sdks/python/src/agent_control/client.py
+++ b/sdks/python/src/agent_control/client.py
@@ -37,36 +37,31 @@ def _runtime_cache_identity(api_key: str | None, api_key_header: str) -> str:
 
 
 class _AgentControlAuth(httpx.Auth):
-    """Attach local API-key credentials unless the request already carries a token.
+    """Attach local API-key credentials unless the request already carries them.
 
-    The API key is suppressed when the request already presents a bearer
-    credential on ``Authorization`` or a runtime token on its dedicated
-    header, so a runtime-authenticated evaluation carries a single
-    credential regardless of which header the runtime token rides.
+    The API key is suppressed only when the request already presents a bearer
+    credential on ``Authorization`` or already carries the API key on its own
+    header. When the runtime token rides a dedicated header, the API key is
+    left in place: it may be the outer credential the request needs to
+    authenticate at a gateway before Agent Control verifies the runtime token,
+    and it rides a different header so there is no collision.
     """
 
     def __init__(
         self,
         api_key: str | None,
         header_name: str = "X-API-Key",
-        runtime_token_header: str | None = None,
     ) -> None:
         self._api_key = api_key
         self._header_name = header_name
-        self._runtime_token_header = runtime_token_header
 
     def auth_flow(
         self,
         request: httpx.Request,
     ) -> Generator[httpx.Request, httpx.Response, None]:
-        runtime_token_on_dedicated_header = (
-            self._runtime_token_header is not None
-            and self._runtime_token_header in request.headers
-        )
         if (
             self._api_key
             and "Authorization" not in request.headers
-            and not runtime_token_on_dedicated_header
             and self._header_name not in request.headers
         ):
             request.headers[self._header_name] = self._api_key
@@ -121,10 +116,10 @@ class AgentControlClient:
         api_key: str | None = None,
         api_key_header: str | None = None,
         runtime_auth_mode: RuntimeAuthMode | str | None = None,
-        runtime_token_header: str | None = None,
         runtime_token_cache: RuntimeTokenCache | None = None,
         runtime_token_refresh_margin_seconds: int = (_DEFAULT_RUNTIME_TOKEN_REFRESH_MARGIN_SECONDS),
         transport: httpx.AsyncBaseTransport | None = None,
+        runtime_token_header: str | None = None,
     ):
         """
         Initialize the client.
@@ -144,6 +139,10 @@ class AgentControlClient:
                 request auth when the exchange endpoint is unavailable. ``jwt``
                 requires a successful exchange. ``api_key`` and ``none`` keep
                 evaluation requests on the normal request-auth path.
+            runtime_token_cache: Optional cache shared across client instances.
+            runtime_token_refresh_margin_seconds: Refresh cached runtime tokens
+                before this many seconds of validity remain.
+            transport: Optional httpx transport, primarily for tests.
             runtime_token_header: HTTP header the runtime token is sent on.
                 Defaults to ``Authorization``; the
                 AGENT_CONTROL_RUNTIME_TOKEN_HEADER environment variable
@@ -151,10 +150,6 @@ class AgentControlClient:
                 ``X-Agent-Control-Runtime-Token``) when the server runs behind
                 a gateway that reserves ``Authorization`` for its own identity
                 JWT. The server must be configured to read the same header.
-            runtime_token_cache: Optional cache shared across client instances.
-            runtime_token_refresh_margin_seconds: Refresh cached runtime tokens
-                before this many seconds of validity remain.
-            transport: Optional httpx transport, primarily for tests.
         """
         resolved_base_url = base_url or os.environ.get(
             self.BASE_URL_ENV_VAR, "http://localhost:8000"
@@ -249,9 +244,6 @@ class AgentControlClient:
             auth=_AgentControlAuth(
                 self._api_key,
                 self._api_key_header,
-                runtime_token_header=(
-                    None if self._runtime_token_use_bearer else self._runtime_token_header
-                ),
             ),
             transport=self._transport,
             event_hooks={"response": [self._check_server_version]},

--- a/sdks/python/src/agent_control/control_decorators.py
+++ b/sdks/python/src/agent_control/control_decorators.py
@@ -280,6 +280,7 @@ async def _evaluate(
         base_url=server_url,
         api_key=state.api_key,
         api_key_header=state.api_key_header,
+        runtime_token_header=state.runtime_token_header,
         runtime_token_cache=state.runtime_token_cache,
     ) as client:
         # If we have controls, use local evaluation which handles both SDK and server controls

--- a/sdks/python/src/agent_control/evaluation.py
+++ b/sdks/python/src/agent_control/evaluation.py
@@ -560,6 +560,7 @@ async def evaluate_controls(
         base_url=state.server_url,
         api_key=state.api_key,
         api_key_header=state.api_key_header,
+        runtime_token_header=state.runtime_token_header,
         runtime_token_cache=state.runtime_token_cache,
     ) as client:
         return await check_evaluation_with_local(

--- a/sdks/python/src/agent_control/runtime_auth.py
+++ b/sdks/python/src/agent_control/runtime_auth.py
@@ -16,6 +16,52 @@ _LockKey = tuple[str, str, str, str, asyncio.AbstractEventLoop]
 _DEFAULT_MAX_CACHE_ENTRIES = 256
 _DEFAULT_JWT_UNAVAILABLE_TTL_SECONDS = 30
 
+DEFAULT_RUNTIME_TOKEN_HEADER = "Authorization"
+
+# RFC 7230 "token" characters, the grammar an HTTP header field name must
+# follow. Anything outside this set (spaces, colons, control chars, non-ASCII)
+# produces a header a compliant client or gateway cannot send, so reject it up
+# front rather than failing at request time.
+_HTTP_TOKEN_CHARS = frozenset(
+    "!#$%&'*+-.^_`|~0123456789"
+    "abcdefghijklmnopqrstuvwxyz"
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+)
+
+
+def validate_http_field_name(name: str, *, field: str = "runtime_token_header") -> str:
+    """Validate ``name`` against the RFC 7230 header field-name grammar.
+
+    Returns the name unchanged when valid; raises ``ValueError`` otherwise.
+    Keeps the SDK and server rejecting the same set of invalid headers.
+    """
+    if not name or any(ch not in _HTTP_TOKEN_CHARS for ch in name):
+        raise ValueError(
+            f"{field} must be a valid HTTP header field name "
+            "(RFC 7230 token: letters, digits, and !#$%&'*+-.^_`|~ only, no spaces)."
+        )
+    return name
+
+
+def resolve_runtime_token_header(
+    value: str | None,
+    env_value: str | None,
+    *,
+    default: str = DEFAULT_RUNTIME_TOKEN_HEADER,
+) -> str:
+    """Resolve and validate the runtime-token header (param > env > default).
+
+    An explicitly-passed blank ``value`` is a hard error; a blank env value
+    falls back to the default. The resolved header is validated against the
+    HTTP field-name grammar so misconfiguration is caught before it is used.
+    """
+    if value is not None and not value.strip():
+        raise ValueError("runtime_token_header must not be blank.")
+    if env_value is not None and not env_value.strip():
+        env_value = None
+    resolved = (value or env_value or default).strip()
+    return validate_http_field_name(resolved)
+
 
 @dataclass(frozen=True)
 class RuntimeToken:

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -1081,3 +1081,169 @@ async def test_check_server_version_ignores_missing_header() -> None:
 
     # Then: no warning is emitted
     mock_warning.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# HYBIM-741: configurable runtime-token header (gateway Authorization collision)
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_token_header_defaults_to_authorization() -> None:
+    client = AgentControlClient(base_url="https://agent-control.test")
+    assert client._runtime_token_header == "Authorization"
+    assert client._runtime_token_use_bearer is True
+
+
+def test_runtime_token_header_param_selects_dedicated_header() -> None:
+    client = AgentControlClient(
+        base_url="https://agent-control.test",
+        runtime_token_header="X-Agent-Control-Runtime-Token",
+    )
+    assert client._runtime_token_header == "X-Agent-Control-Runtime-Token"
+    assert client._runtime_token_use_bearer is False
+
+
+def test_runtime_token_header_env_var_overrides_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        "AGENT_CONTROL_RUNTIME_TOKEN_HEADER", "X-Agent-Control-Runtime-Token"
+    )
+    client = AgentControlClient(base_url="https://agent-control.test")
+    assert client._runtime_token_header == "X-Agent-Control-Runtime-Token"
+    assert client._runtime_token_use_bearer is False
+
+
+def test_runtime_token_header_rejects_blank_param() -> None:
+    with pytest.raises(ValueError, match="runtime_token_header"):
+        AgentControlClient(
+            base_url="https://agent-control.test", runtime_token_header="  "
+        )
+
+
+def test_runtime_token_header_whitespace_env_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENT_CONTROL_RUNTIME_TOKEN_HEADER", "   ")
+    client = AgentControlClient(base_url="https://agent-control.test")
+    assert client._runtime_token_header == "Authorization"
+    assert client._runtime_token_use_bearer is True
+
+
+@pytest.mark.asyncio
+async def test_runtime_evaluation_sends_raw_token_on_custom_header() -> None:
+    """Custom header carries the raw token; Authorization stays free for the
+    gateway JWT and the API key does not ride along."""
+    seen: dict[str, str | None] = {}
+    expires_at = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/runtime-token-exchange"):
+            assert request.headers.get("X-API-Key") == "test-key"
+            return httpx.Response(
+                200,
+                json={
+                    "token": "runtime-token",
+                    "expires_at": expires_at,
+                    "target_type": "log_stream",
+                    "target_id": "ls-1",
+                    "scopes": ["runtime.use"],
+                },
+            )
+        seen["runtime"] = request.headers.get("X-Agent-Control-Runtime-Token")
+        seen["authorization"] = request.headers.get("Authorization")
+        seen["api_key"] = request.headers.get("X-API-Key")
+        return httpx.Response(200, json={"is_safe": True, "confidence": 1.0})
+
+    transport = httpx.MockTransport(handler)
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        runtime_auth_mode="jwt",
+        runtime_token_header="X-Agent-Control-Runtime-Token",
+        transport=transport,
+    ) as client:
+        response = await client.post_runtime_evaluation(
+            json={"target_type": "log_stream", "target_id": "ls-1"},
+            target_type="log_stream",
+            target_id="ls-1",
+        )
+
+    assert response.status_code == 200
+    assert seen["runtime"] == "runtime-token"
+    assert seen["authorization"] is None
+    assert seen["api_key"] is None
+
+
+@pytest.mark.asyncio
+async def test_runtime_evaluation_default_sends_bearer_on_authorization() -> None:
+    """Default (unset) behavior is unchanged: Bearer token on Authorization."""
+    seen: dict[str, str | None] = {}
+    expires_at = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path.endswith("/runtime-token-exchange"):
+            return httpx.Response(
+                200,
+                json={
+                    "token": "runtime-token",
+                    "expires_at": expires_at,
+                    "target_type": "log_stream",
+                    "target_id": "ls-1",
+                    "scopes": ["runtime.use"],
+                },
+            )
+        seen["authorization"] = request.headers.get("Authorization")
+        return httpx.Response(200, json={"is_safe": True, "confidence": 1.0})
+
+    transport = httpx.MockTransport(handler)
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        runtime_auth_mode="jwt",
+        transport=transport,
+    ) as client:
+        await client.post_runtime_evaluation(
+            json={"target_type": "log_stream", "target_id": "ls-1"},
+            target_type="log_stream",
+            target_id="ls-1",
+        )
+
+    assert seen["authorization"] == "Bearer runtime-token"
+
+
+@pytest.mark.asyncio
+async def test_runtime_evaluation_custom_header_fallback_keeps_api_key() -> None:
+    """Custom-header mode must still fall back to the API key when the exchange
+    is unavailable: with no runtime token minted, the dedicated header is absent
+    and X-API-Key must authenticate the evaluation request."""
+    exchange_calls = 0
+    seen: dict[str, str | None] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal exchange_calls
+        if request.url.path.endswith("/runtime-token-exchange"):
+            exchange_calls += 1
+            return httpx.Response(503, json={"detail": "runtime auth disabled"})
+        seen["runtime"] = request.headers.get("X-Agent-Control-Runtime-Token")
+        seen["api_key"] = request.headers.get("X-API-Key")
+        return httpx.Response(200, json={"is_safe": True, "confidence": 1.0})
+
+    transport = httpx.MockTransport(handler)
+    async with AgentControlClient(
+        base_url="https://agent-control.test",
+        api_key="test-key",
+        runtime_auth_mode="auto",
+        runtime_token_header="X-Agent-Control-Runtime-Token",
+        transport=transport,
+    ) as client:
+        response = await client.post_runtime_evaluation(
+            json={"target_type": "log_stream", "target_id": "ls-1"},
+            target_type="log_stream",
+            target_id="ls-1",
+        )
+        assert response.status_code == 200
+
+    assert exchange_calls == 1
+    assert seen["runtime"] is None
+    assert seen["api_key"] == "test-key"

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -1133,7 +1133,8 @@ def test_runtime_token_header_whitespace_env_falls_back(
 @pytest.mark.asyncio
 async def test_runtime_evaluation_sends_raw_token_on_custom_header() -> None:
     """Custom header carries the raw token; Authorization stays free for the
-    gateway JWT and the API key does not ride along."""
+    gateway JWT; the API key is preserved on its own header as the outer
+    credential (it rides X-API-Key, so there is no collision)."""
     seen: dict[str, str | None] = {}
     expires_at = (datetime.now(UTC) + timedelta(minutes=5)).isoformat()
 
@@ -1172,7 +1173,11 @@ async def test_runtime_evaluation_sends_raw_token_on_custom_header() -> None:
     assert response.status_code == 200
     assert seen["runtime"] == "runtime-token"
     assert seen["authorization"] is None
-    assert seen["api_key"] is None
+    # The API key is retained on its own header: with the runtime token on a
+    # dedicated header, X-API-Key can still serve as the outer gateway
+    # credential without colliding with either the runtime token or the
+    # gateway's Authorization JWT.
+    assert seen["api_key"] == "test-key"
 
 
 @pytest.mark.asyncio

--- a/sdks/python/tests/test_client.py
+++ b/sdks/python/tests/test_client.py
@@ -1121,6 +1121,27 @@ def test_runtime_token_header_rejects_blank_param() -> None:
         )
 
 
+@pytest.mark.parametrize(
+    "bad_header",
+    ["X Agent Control", "X-Agent:Control", "Bad\nHeader", "hÉader", "with tab\t"],
+)
+def test_runtime_token_header_rejects_invalid_field_name(bad_header: str) -> None:
+    """A header that is not a valid HTTP field name is rejected at construction,
+    not deferred to the first request."""
+    with pytest.raises(ValueError, match="HTTP header field name"):
+        AgentControlClient(
+            base_url="https://agent-control.test", runtime_token_header=bad_header
+        )
+
+
+def test_runtime_token_header_rejects_invalid_field_name_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AGENT_CONTROL_RUNTIME_TOKEN_HEADER", "X Agent Control")
+    with pytest.raises(ValueError, match="HTTP header field name"):
+        AgentControlClient(base_url="https://agent-control.test")
+
+
 def test_runtime_token_header_whitespace_env_falls_back(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1252,3 +1273,61 @@ async def test_runtime_evaluation_custom_header_fallback_keeps_api_key() -> None
     assert exchange_calls == 1
     assert seen["runtime"] is None
     assert seen["api_key"] == "test-key"
+
+
+# ---------------------------------------------------------------------------
+# HYBIM-866: 401 disambiguation for runtime-token refresh (gateway vs token)
+# ---------------------------------------------------------------------------
+
+
+def _resp(status: int, www_authenticate: str | None = None) -> httpx.Response:
+    headers = {"WWW-Authenticate": www_authenticate} if www_authenticate else {}
+    return httpx.Response(status, headers=headers)
+
+
+def test_should_refresh_401_on_authorization_header_refreshes() -> None:
+    """Default (token on Authorization): a bare 401 means the runtime token,
+    so refresh."""
+    from agent_control.client import _should_refresh_runtime_token
+
+    assert _should_refresh_runtime_token(_resp(401)) is True
+
+
+def test_should_refresh_401_on_dedicated_header_needs_invalid_token() -> None:
+    """Token on a dedicated header: a bare 401 is ambiguous (may be the gateway
+    rejecting Authorization), so do NOT evict the runtime token unless the
+    server flags it invalid."""
+    from agent_control.client import _should_refresh_runtime_token
+
+    # Bare 401 with no challenge -> gateway 401, keep the token.
+    assert (
+        _should_refresh_runtime_token(
+            _resp(401), runtime_token_on_dedicated_header=True
+        )
+        is False
+    )
+    # 401 that explicitly flags the runtime token -> refresh.
+    assert (
+        _should_refresh_runtime_token(
+            _resp(401, 'Bearer error="invalid_token"'),
+            runtime_token_on_dedicated_header=True,
+        )
+        is True
+    )
+
+
+def test_should_refresh_403_only_on_invalid_token_challenge() -> None:
+    from agent_control.client import _should_refresh_runtime_token
+
+    assert _should_refresh_runtime_token(_resp(403)) is False
+    assert (
+        _should_refresh_runtime_token(_resp(403, 'Bearer error="invalid_token"'))
+        is True
+    )
+
+
+def test_should_refresh_ignores_other_statuses() -> None:
+    from agent_control.client import _should_refresh_runtime_token
+
+    assert _should_refresh_runtime_token(_resp(200)) is False
+    assert _should_refresh_runtime_token(_resp(500)) is False

--- a/sdks/python/tests/test_init_validation.py
+++ b/sdks/python/tests/test_init_validation.py
@@ -1,10 +1,15 @@
 """Validation tests for agent_control.init()."""
 
-import agent_control
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
 import pytest
 from agent_control_models import ControlMatch as ModelControlMatch
 from agent_control_models import ControlScope as ModelControlScope
 from agent_control_models import EvaluatorResult as ModelEvaluatorResult
+
+import agent_control
+from agent_control._state import state
 
 
 def test_init_rejects_invalid_agent_name() -> None:
@@ -48,3 +53,50 @@ def test_init_exports_control_match() -> None:
 def test_init_exports_evaluator_result() -> None:
     assert agent_control.EvaluatorResult is ModelEvaluatorResult
     assert "EvaluatorResult" in agent_control.__all__
+
+
+def test_init_stores_runtime_token_header_in_state() -> None:
+    """HYBIM-741: init() retains runtime_token_header in session state so the
+    evaluation clients it creates ride the configured header (not only the
+    process-wide env var)."""
+    health_check_mock = AsyncMock(return_value={"status": "healthy"})
+    register_agent_mock = AsyncMock(return_value={"created": True, "controls": []})
+    try:
+        with patch(
+            "agent_control.__init__.AgentControlClient.health_check",
+            new=health_check_mock,
+        ), patch(
+            "agent_control.__init__.agents.register_agent",
+            new=register_agent_mock,
+        ):
+            agent_control.init(
+                agent_name=f"agent-{uuid4().hex[:12]}",
+                runtime_token_header="X-Agent-Control-Runtime-Token",
+                policy_refresh_interval_seconds=0,
+            )
+
+        assert state.runtime_token_header == "X-Agent-Control-Runtime-Token"
+    finally:
+        agent_control._reset_state()
+
+
+def test_init_defaults_runtime_token_header_to_none() -> None:
+    """Unset: state carries None so the client falls back to env/default."""
+    health_check_mock = AsyncMock(return_value={"status": "healthy"})
+    register_agent_mock = AsyncMock(return_value={"created": True, "controls": []})
+    try:
+        with patch(
+            "agent_control.__init__.AgentControlClient.health_check",
+            new=health_check_mock,
+        ), patch(
+            "agent_control.__init__.agents.register_agent",
+            new=register_agent_mock,
+        ):
+            agent_control.init(
+                agent_name=f"agent-{uuid4().hex[:12]}",
+                policy_refresh_interval_seconds=0,
+            )
+
+        assert state.runtime_token_header is None
+    finally:
+        agent_control._reset_state()

--- a/sdks/python/tests/test_init_validation.py
+++ b/sdks/python/tests/test_init_validation.py
@@ -104,9 +104,15 @@ def test_init_defaults_runtime_token_header_to_none() -> None:
 
 def test_init_preserves_positional_argument_order() -> None:
     """runtime_token_header is appended after the existing parameters, so a
-    positional call binds each value to its original slot. In particular the
-    5th/6th positionals stay api_key / api_key_header and are not shifted into
-    the new header, which remains unset."""
+    positional call binds each value to its original slot.
+
+    The compatibility regression this guards against began at the 7th
+    positional (``controls_file``) and would shift every slot after it, so the
+    call below supplies positionals all the way through ``target_id`` (16th)
+    and asserts they land in their pre-change slots. If the new header had been
+    inserted anywhere before ``target_id``, the ``target_type`` / ``target_id``
+    values would bind to the wrong slots and these assertions would fail.
+    ``runtime_token_header`` stays last and remains unset."""
     health_check_mock = AsyncMock(return_value={"status": "healthy"})
     register_agent_mock = AsyncMock(return_value={"created": True, "controls": []})
     try:
@@ -118,8 +124,11 @@ def test_init_preserves_positional_argument_order() -> None:
             new=register_agent_mock,
         ):
             # Positional call matching the pre-change signature order:
-            # agent_name, agent_description, agent_version, server_url,
-            # api_key, api_key_header
+            # 1 agent_name, 2 agent_description, 3 agent_version, 4 server_url,
+            # 5 api_key, 6 api_key_header, 7 controls_file, 8 steps,
+            # 9 conflict_mode, 10 observability_enabled, 11 observability_sink_name,
+            # 12 observability_sink_config, 13 log_config,
+            # 14 policy_refresh_interval_seconds, 15 target_type, 16 target_id.
             agent_control.init(
                 f"agent-{uuid4().hex[:12]}",
                 "desc",
@@ -127,13 +136,24 @@ def test_init_preserves_positional_argument_order() -> None:
                 "http://localhost:8000",
                 "key",
                 "X-API-Key",
-                policy_refresh_interval_seconds=0,
+                None,  # controls_file (slot 7: where the regression began)
+                None,  # steps
+                "overwrite",  # conflict_mode
+                False,  # observability_enabled
+                None,  # observability_sink_name
+                None,  # observability_sink_config
+                None,  # log_config
+                0,  # policy_refresh_interval_seconds
+                "env",  # target_type
+                "prod",  # target_id
             )
 
         # Positionals bound to their original slots, not shifted by the new arg.
         assert state.server_url == "http://localhost:8000"
         assert state.api_key == "key"
         assert state.api_key_header == "X-API-Key"
+        assert state.target_type == "env"
+        assert state.target_id == "prod"
         assert state.runtime_token_header is None
     finally:
         agent_control._reset_state()

--- a/sdks/python/tests/test_init_validation.py
+++ b/sdks/python/tests/test_init_validation.py
@@ -100,3 +100,40 @@ def test_init_defaults_runtime_token_header_to_none() -> None:
         assert state.runtime_token_header is None
     finally:
         agent_control._reset_state()
+
+
+def test_init_preserves_positional_argument_order() -> None:
+    """runtime_token_header is appended after the existing parameters, so a
+    positional call binds each value to its original slot. In particular the
+    5th/6th positionals stay api_key / api_key_header and are not shifted into
+    the new header, which remains unset."""
+    health_check_mock = AsyncMock(return_value={"status": "healthy"})
+    register_agent_mock = AsyncMock(return_value={"created": True, "controls": []})
+    try:
+        with patch(
+            "agent_control.__init__.AgentControlClient.health_check",
+            new=health_check_mock,
+        ), patch(
+            "agent_control.__init__.agents.register_agent",
+            new=register_agent_mock,
+        ):
+            # Positional call matching the pre-change signature order:
+            # agent_name, agent_description, agent_version, server_url,
+            # api_key, api_key_header
+            agent_control.init(
+                f"agent-{uuid4().hex[:12]}",
+                "desc",
+                "1.0.0",
+                "http://localhost:8000",
+                "key",
+                "X-API-Key",
+                policy_refresh_interval_seconds=0,
+            )
+
+        # Positionals bound to their original slots, not shifted by the new arg.
+        assert state.server_url == "http://localhost:8000"
+        assert state.api_key == "key"
+        assert state.api_key_header == "X-API-Key"
+        assert state.runtime_token_header is None
+    finally:
+        agent_control._reset_state()

--- a/server/src/agent_control_server/auth_framework/config.py
+++ b/server/src/agent_control_server/auth_framework/config.py
@@ -21,6 +21,10 @@ The framework supports two flows:
   The ``runtime.token_exchange`` operation continues to flow through
   the default authorizer because the exchange itself is shaped like a
   management call (forward credential, get grant).
+  ``AGENT_CONTROL_RUNTIME_TOKEN_HEADER`` (default ``Authorization``)
+  selects which request header the ``jwt`` verifier reads the runtime
+  token from, so the server can run behind a gateway that reserves
+  ``Authorization`` for its own downstream identity JWT.
 """
 
 from __future__ import annotations
@@ -39,6 +43,7 @@ from .providers import (
     NoAuthProvider,
 )
 from .providers.http_upstream import HttpUpstreamConfig
+from .providers.local_jwt import DEFAULT_RUNTIME_TOKEN_HEADER
 
 _logger = get_logger(__name__)
 
@@ -60,6 +65,7 @@ _UPSTREAM_MAX_KEEPALIVE_CONNECTIONS_ENV = (
 _RUNTIME_MODE_ENV = "AGENT_CONTROL_RUNTIME_AUTH_MODE"
 _RUNTIME_TOKEN_SECRET_ENV = "AGENT_CONTROL_RUNTIME_TOKEN_SECRET"
 _RUNTIME_TOKEN_TTL_ENV = "AGENT_CONTROL_RUNTIME_TOKEN_TTL_SECONDS"
+_RUNTIME_TOKEN_HEADER_ENV = "AGENT_CONTROL_RUNTIME_TOKEN_HEADER"
 _DEFAULT_RUNTIME_TOKEN_TTL_SECONDS = 300
 # HS256 needs at least 256 bits (32 bytes) of secret material to be safe
 # against brute force; reject anything shorter so production deployments
@@ -378,10 +384,29 @@ def _build_runtime_provider(
     if mode == "jwt":
         if config is None:
             raise RuntimeError(f"{_RUNTIME_MODE_ENV}=jwt but runtime auth config is missing.")
-        return LocalJwtVerifyProvider(secret=config.secret)
+        return LocalJwtVerifyProvider(
+            secret=config.secret,
+            header_name=_resolve_runtime_token_header(),
+        )
     raise RuntimeError(
         f"Unknown runtime auth mode {mode!r}; expected 'none', 'api_key', or 'jwt'."
     )
+
+
+def _resolve_runtime_token_header() -> str:
+    """Return the header the runtime JWT verifier reads the token from.
+
+    Defaults to ``Authorization``. Deployments behind a gateway that
+    overwrites ``Authorization`` with its own downstream identity JWT can
+    point the verifier at a dedicated header (e.g.
+    ``X-Agent-Control-Runtime-Token``) so the two tokens no longer collide
+    on the hot evaluation path. A blank/whitespace value falls back to the
+    default.
+    """
+    raw = os.environ.get(_RUNTIME_TOKEN_HEADER_ENV)
+    if raw is None or not raw.strip():
+        return DEFAULT_RUNTIME_TOKEN_HEADER
+    return raw.strip()
 
 
 def _load_runtime_auth_config(*, require_secret: bool = False) -> RuntimeAuthConfig | None:

--- a/server/src/agent_control_server/auth_framework/config.py
+++ b/server/src/agent_control_server/auth_framework/config.py
@@ -43,7 +43,10 @@ from .providers import (
     NoAuthProvider,
 )
 from .providers.http_upstream import HttpUpstreamConfig
-from .providers.local_jwt import DEFAULT_RUNTIME_TOKEN_HEADER
+from .providers.local_jwt import (
+    DEFAULT_RUNTIME_TOKEN_HEADER,
+    validate_http_field_name,
+)
 
 _logger = get_logger(__name__)
 
@@ -403,7 +406,9 @@ def _resolve_runtime_token_header() -> str:
     raw = os.environ.get(_RUNTIME_TOKEN_HEADER_ENV)
     if raw is None or not raw.strip():
         return DEFAULT_RUNTIME_TOKEN_HEADER
-    return raw.strip()
+    # Reject a syntactically-invalid header name at startup (RaiseError here
+    # surfaces during config build, not as a per-request auth failure).
+    return validate_http_field_name(raw.strip())
 
 
 def _load_runtime_auth_config(*, require_secret: bool = False) -> RuntimeAuthConfig | None:

--- a/server/src/agent_control_server/auth_framework/config.py
+++ b/server/src/agent_control_server/auth_framework/config.py
@@ -394,14 +394,11 @@ def _build_runtime_provider(
 
 
 def _resolve_runtime_token_header() -> str:
-    """Return the header the runtime JWT verifier reads the token from.
+    """Header the runtime JWT verifier reads the token from (default ``Authorization``).
 
-    Defaults to ``Authorization``. Deployments behind a gateway that
-    overwrites ``Authorization`` with its own downstream identity JWT can
-    point the verifier at a dedicated header (e.g.
-    ``X-Agent-Control-Runtime-Token``) so the two tokens no longer collide
-    on the hot evaluation path. A blank/whitespace value falls back to the
-    default.
+    Behind a gateway that overwrites ``Authorization`` with its own identity
+    JWT, set a dedicated header so the two tokens don't collide. Blank falls
+    back to the default.
     """
     raw = os.environ.get(_RUNTIME_TOKEN_HEADER_ENV)
     if raw is None or not raw.strip():

--- a/server/src/agent_control_server/auth_framework/providers/local_jwt.py
+++ b/server/src/agent_control_server/auth_framework/providers/local_jwt.py
@@ -8,10 +8,8 @@ bound target. When a ``context_builder`` on the dependency must surface
 matching ``target_type`` / ``target_id`` values for target-bound tokens.
 
 The header is configurable so the server can sit behind a gateway that
-reserves ``Authorization`` for its own downstream identity JWT: point
-the verifier at a dedicated header (e.g. ``X-Agent-Control-Runtime-Token``)
-so the two tokens no longer collide. ``Bearer`` stays mandatory on
-``Authorization``; on a dedicated header the raw token is accepted.
+reserves ``Authorization`` for its own identity JWT (point the verifier at
+a dedicated header to avoid the collision).
 """
 
 from __future__ import annotations
@@ -44,9 +42,9 @@ class LocalJwtVerifyProvider(RequestAuthorizer):
             raise ValueError("LocalJwtVerifyProvider requires a non-empty header_name.")
         self._secret = secret
         self._header_name = header_name.strip()
-        # ``Bearer`` stays mandatory on ``Authorization`` (existing contract);
-        # a dedicated runtime-token header carries the raw token, so it never
-        # collides with a gateway's own ``Authorization`` identity JWT.
+        # Bearer only on Authorization; a dedicated header carries the raw token
+        # so it can't collide with the gateway's Authorization JWT. Must stay in
+        # sync with AgentControlClient._runtime_token_use_bearer in the SDK.
         self._require_bearer = self._header_name.lower() == "authorization"
 
     async def authorize(

--- a/server/src/agent_control_server/auth_framework/providers/local_jwt.py
+++ b/server/src/agent_control_server/auth_framework/providers/local_jwt.py
@@ -25,6 +25,30 @@ from ..runtime_token import RuntimeTokenError, verify_runtime_token
 
 DEFAULT_RUNTIME_TOKEN_HEADER = "Authorization"
 
+# RFC 7230 "token" characters, the grammar an HTTP header field name must
+# follow. A header name with spaces, colons, control chars, or non-ASCII can't
+# be sent by a compliant client, so reject it at config time rather than
+# starting with an auth setup that fails on every request.
+_HTTP_TOKEN_CHARS = frozenset(
+    "!#$%&'*+-.^_`|~0123456789"
+    "abcdefghijklmnopqrstuvwxyz"
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+)
+
+
+def validate_http_field_name(name: str) -> str:
+    """Return ``name`` if it is a valid HTTP header field name, else raise.
+
+    Kept in sync with the SDK's ``runtime_auth.validate_http_field_name`` so
+    both sides reject the same invalid runtime-token headers.
+    """
+    if not name or any(ch not in _HTTP_TOKEN_CHARS for ch in name):
+        raise ValueError(
+            "runtime-token header must be a valid HTTP header field name "
+            "(RFC 7230 token: letters, digits, and !#$%&'*+-.^_`|~ only, no spaces)."
+        )
+    return name
+
 
 class LocalJwtVerifyProvider(RequestAuthorizer):
     """Verifies a runtime Bearer token and emits a target-bound :class:`Principal`."""
@@ -40,7 +64,7 @@ class LocalJwtVerifyProvider(RequestAuthorizer):
         if not header_name or not header_name.strip():
             raise ValueError("LocalJwtVerifyProvider requires a non-empty header_name.")
         self._secret = secret
-        self._header_name = header_name.strip()
+        self._header_name = validate_http_field_name(header_name.strip())
         # Bearer only on Authorization; a dedicated header carries the raw token
         # so it can't collide with the gateway's Authorization JWT. Must stay in
         # sync with AgentControlClient._runtime_token_use_bearer in the SDK.

--- a/server/src/agent_control_server/auth_framework/providers/local_jwt.py
+++ b/server/src/agent_control_server/auth_framework/providers/local_jwt.py
@@ -23,7 +23,6 @@ from ...errors import AuthenticationError, ForbiddenError
 from ..core import Operation, Principal, RequestAuthorizer
 from ..runtime_token import RuntimeTokenError, verify_runtime_token
 
-
 DEFAULT_RUNTIME_TOKEN_HEADER = "Authorization"
 
 

--- a/server/src/agent_control_server/auth_framework/providers/local_jwt.py
+++ b/server/src/agent_control_server/auth_framework/providers/local_jwt.py
@@ -1,11 +1,17 @@
 """Authorizer that verifies a locally-minted runtime token.
 
-Wired to the runtime resolution path. Reads a Bearer token from the
-``Authorization`` header, verifies the signature against the runtime
-secret, checks the token's scope covers the requested operation, and
-returns a :class:`Principal` carrying the bound target. When a
-``context_builder`` on the dependency must surface matching
-``target_type`` / ``target_id`` values for target-bound tokens.
+Wired to the runtime resolution path. Reads the runtime token from a
+configurable header (``Authorization`` by default), verifies the
+signature against the runtime secret, checks the token's scope covers
+the requested operation, and returns a :class:`Principal` carrying the
+bound target. When a ``context_builder`` on the dependency must surface
+matching ``target_type`` / ``target_id`` values for target-bound tokens.
+
+The header is configurable so the server can sit behind a gateway that
+reserves ``Authorization`` for its own downstream identity JWT: point
+the verifier at a dedicated header (e.g. ``X-Agent-Control-Runtime-Token``)
+so the two tokens no longer collide. ``Bearer`` stays mandatory on
+``Authorization``; on a dedicated header the raw token is accepted.
 """
 
 from __future__ import annotations
@@ -20,13 +26,28 @@ from ..core import Operation, Principal, RequestAuthorizer
 from ..runtime_token import RuntimeTokenError, verify_runtime_token
 
 
+DEFAULT_RUNTIME_TOKEN_HEADER = "Authorization"
+
+
 class LocalJwtVerifyProvider(RequestAuthorizer):
     """Verifies a runtime Bearer token and emits a target-bound :class:`Principal`."""
 
-    def __init__(self, *, secret: str) -> None:
+    def __init__(
+        self,
+        *,
+        secret: str,
+        header_name: str = DEFAULT_RUNTIME_TOKEN_HEADER,
+    ) -> None:
         if not secret:
             raise ValueError("LocalJwtVerifyProvider requires a non-empty secret.")
+        if not header_name or not header_name.strip():
+            raise ValueError("LocalJwtVerifyProvider requires a non-empty header_name.")
         self._secret = secret
+        self._header_name = header_name.strip()
+        # ``Bearer`` stays mandatory on ``Authorization`` (existing contract);
+        # a dedicated runtime-token header carries the raw token, so it never
+        # collides with a gateway's own ``Authorization`` identity JWT.
+        self._require_bearer = self._header_name.lower() == "authorization"
 
     async def authorize(
         self,
@@ -79,18 +100,29 @@ class LocalJwtVerifyProvider(RequestAuthorizer):
         )
 
     def _extract_bearer_token(self, request: Request) -> str:
-        header = request.headers.get("Authorization")
+        header = request.headers.get(self._header_name)
         if not header:
             raise AuthenticationError(
                 error_code=ErrorCode.AUTH_MISSING_KEY,
-                detail="Missing Authorization header.",
+                detail=f"Missing {self._header_name} header.",
                 hint="Present a Bearer runtime token.",
             )
-        scheme, _, value = header.partition(" ")
-        if scheme.lower() != "bearer" or not value:
+        scheme, sep, value = header.partition(" ")
+        if sep and scheme.lower() == "bearer":
+            token = value.strip()
+        elif self._require_bearer:
             raise AuthenticationError(
                 error_code=ErrorCode.AUTH_MISSING_KEY,
-                detail="Authorization header must be a Bearer token.",
-                hint="Format: ``Authorization: Bearer <token>``.",
+                detail=f"{self._header_name} header must be a Bearer token.",
+                hint=f"Format: ``{self._header_name}: Bearer <token>``.",
             )
-        return value.strip()
+        else:
+            # Dedicated runtime-token header: accept the raw token value.
+            token = header.strip()
+        if not token:
+            raise AuthenticationError(
+                error_code=ErrorCode.AUTH_MISSING_KEY,
+                detail=f"{self._header_name} header is empty.",
+                hint="Present a Bearer runtime token.",
+            )
+        return token

--- a/server/tests/test_auth_framework.py
+++ b/server/tests/test_auth_framework.py
@@ -1866,6 +1866,24 @@ def test_local_jwt_rejects_blank_header_name():
         LocalJwtVerifyProvider(secret=_TEST_SECRET, header_name="  ")
 
 
+@pytest.mark.parametrize(
+    "bad_header",
+    ["X Agent Control", "X-Agent:Control", "hÉader", "with\ttab"],
+)
+def test_local_jwt_rejects_invalid_field_name_header(bad_header):
+    """A syntactically invalid HTTP header name is rejected at construction."""
+    with pytest.raises(ValueError, match="HTTP header field name"):
+        LocalJwtVerifyProvider(secret=_TEST_SECRET, header_name=bad_header)
+
+
+def test_resolve_runtime_token_header_rejects_invalid_field_name(monkeypatch):
+    from agent_control_server.auth_framework import config as auth_config
+
+    monkeypatch.setenv("AGENT_CONTROL_RUNTIME_TOKEN_HEADER", "X Agent Control")
+    with pytest.raises(ValueError, match="HTTP header field name"):
+        auth_config._resolve_runtime_token_header()
+
+
 # ---------------------------------------------------------------------------
 # HYBIM-741: AGENT_CONTROL_RUNTIME_TOKEN_HEADER env resolution (config wiring)
 # ---------------------------------------------------------------------------

--- a/server/tests/test_auth_framework.py
+++ b/server/tests/test_auth_framework.py
@@ -1764,3 +1764,134 @@ async def test_teardown_auth_clears_registry():
     assert not _operation_authorizers
     with pytest.raises(RuntimeError, match="No RequestAuthorizer"):
         get_authorizer(Operation.CONTROL_BINDINGS_WRITE)
+
+
+# ---------------------------------------------------------------------------
+# HYBIM-741: configurable runtime-token header (gateway Authorization collision)
+# ---------------------------------------------------------------------------
+
+
+def _mint_runtime_use_token():
+    from agent_control_server.auth_framework.runtime_token import mint_runtime_token
+
+    token, _ = mint_runtime_token(
+        namespace_key="default",
+        actor_id="actor-1",
+        target_type="log_stream",
+        target_id="ls-1",
+        scopes=("runtime.use",),
+        secret=_TEST_SECRET,
+        ttl_seconds=60,
+    )
+    return token
+
+
+@pytest.mark.asyncio
+async def test_local_jwt_default_reads_authorization_bearer():
+    """Default behavior unchanged: token read as Bearer from Authorization."""
+    provider = LocalJwtVerifyProvider(secret=_TEST_SECRET)
+    token = _mint_runtime_use_token()
+    principal = await provider.authorize(
+        _build_request(headers={"Authorization": f"Bearer {token}"}),
+        Operation.RUNTIME_USE,
+        context={"target_type": "log_stream", "target_id": "ls-1"},
+    )
+    assert principal.target_type == "log_stream"
+    assert principal.target_id == "ls-1"
+
+
+@pytest.mark.asyncio
+async def test_local_jwt_default_rejects_raw_token_on_authorization():
+    """On Authorization the Bearer scheme stays mandatory (back-compat)."""
+    provider = LocalJwtVerifyProvider(secret=_TEST_SECRET)
+    token = _mint_runtime_use_token()
+    with pytest.raises(AuthenticationError):
+        await provider.authorize(
+            _build_request(headers={"Authorization": token}),
+            Operation.RUNTIME_USE,
+            context={"target_type": "log_stream", "target_id": "ls-1"},
+        )
+
+
+@pytest.mark.asyncio
+async def test_local_jwt_custom_header_reads_raw_token():
+    """On a dedicated header the raw token is accepted and Authorization is
+    left free for the gateway's own identity JWT (no collision)."""
+    provider = LocalJwtVerifyProvider(
+        secret=_TEST_SECRET, header_name="X-Agent-Control-Runtime-Token"
+    )
+    token = _mint_runtime_use_token()
+    principal = await provider.authorize(
+        _build_request(
+            headers={
+                "X-Agent-Control-Runtime-Token": token,
+                "Authorization": "Bearer gateway-identity-jwt",
+            }
+        ),
+        Operation.RUNTIME_USE,
+        context={"target_type": "log_stream", "target_id": "ls-1"},
+    )
+    assert principal.target_id == "ls-1"
+
+
+@pytest.mark.asyncio
+async def test_local_jwt_custom_header_also_accepts_bearer_prefix():
+    provider = LocalJwtVerifyProvider(
+        secret=_TEST_SECRET, header_name="X-Agent-Control-Runtime-Token"
+    )
+    token = _mint_runtime_use_token()
+    principal = await provider.authorize(
+        _build_request(headers={"X-Agent-Control-Runtime-Token": f"Bearer {token}"}),
+        Operation.RUNTIME_USE,
+        context={"target_type": "log_stream", "target_id": "ls-1"},
+    )
+    assert principal.target_id == "ls-1"
+
+
+@pytest.mark.asyncio
+async def test_local_jwt_custom_header_missing_reports_that_header():
+    provider = LocalJwtVerifyProvider(
+        secret=_TEST_SECRET, header_name="X-Agent-Control-Runtime-Token"
+    )
+    with pytest.raises(AuthenticationError, match="X-Agent-Control-Runtime-Token"):
+        await provider.authorize(
+            _build_request(headers={"Authorization": "Bearer gateway-jwt"}),
+            Operation.RUNTIME_USE,
+            context={"target_type": "log_stream", "target_id": "ls-1"},
+        )
+
+
+def test_local_jwt_rejects_blank_header_name():
+    with pytest.raises(ValueError, match="header_name"):
+        LocalJwtVerifyProvider(secret=_TEST_SECRET, header_name="  ")
+
+
+# ---------------------------------------------------------------------------
+# HYBIM-741: AGENT_CONTROL_RUNTIME_TOKEN_HEADER env resolution (config wiring)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_runtime_token_header_defaults_to_authorization(monkeypatch):
+    from agent_control_server.auth_framework import config as auth_config
+
+    monkeypatch.delenv("AGENT_CONTROL_RUNTIME_TOKEN_HEADER", raising=False)
+    assert auth_config._resolve_runtime_token_header() == "Authorization"
+
+
+def test_resolve_runtime_token_header_reads_env(monkeypatch):
+    from agent_control_server.auth_framework import config as auth_config
+
+    monkeypatch.setenv(
+        "AGENT_CONTROL_RUNTIME_TOKEN_HEADER", "  X-Agent-Control-Runtime-Token  "
+    )
+    # Value is honored and trimmed.
+    assert (
+        auth_config._resolve_runtime_token_header() == "X-Agent-Control-Runtime-Token"
+    )
+
+
+def test_resolve_runtime_token_header_blank_env_falls_back(monkeypatch):
+    from agent_control_server.auth_framework import config as auth_config
+
+    monkeypatch.setenv("AGENT_CONTROL_RUNTIME_TOKEN_HEADER", "   ")
+    assert auth_config._resolve_runtime_token_header() == "Authorization"

--- a/server/tests/test_auth_framework.py
+++ b/server/tests/test_auth_framework.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+
 from agent_control_server.auth_framework.core import (
     Operation,
     Principal,
@@ -875,6 +876,7 @@ def test_runtime_token_rejects_empty_required_claims(kwargs, message):
 def test_runtime_token_rejects_management_token_passed_to_runtime_verify():
     """A token without ``domain=runtime`` must be rejected by runtime verify."""
     import jwt
+
     from agent_control_server.auth_framework.runtime_token import (
         RuntimeTokenError,
         verify_runtime_token,

--- a/server/tests/test_runtime_token_exchange_endpoint.py
+++ b/server/tests/test_runtime_token_exchange_endpoint.py
@@ -9,6 +9,7 @@ end-to-end exchange-then-verify path: a token minted via
 from __future__ import annotations
 
 import logging
+import uuid
 from datetime import UTC, datetime, timedelta
 
 import pytest
@@ -248,6 +249,110 @@ def test_evaluation_rejects_runtime_jwt_for_wrong_target(
 
     assert response.status_code == 403, response.text
     assert response.json()["detail"] == "Runtime token target_id does not match the request."
+
+
+def test_evaluation_accepts_runtime_jwt_on_configured_header_with_gateway_authorization(
+    client: TestClient,
+    runtime_config_enabled,
+):
+    """HYBIM-741: end-to-end through /api/v1/evaluation with the runtime token
+    on a dedicated header while Authorization carries an (ignored) gateway JWT.
+
+    Exercises the config wiring (LocalJwtVerifyProvider bound to a custom
+    header) and Operation.RUNTIME_USE routing together, not just the provider
+    in isolation: the runtime token rides X-Agent-Control-Runtime-Token and is
+    accepted, while the Authorization value is left for the gateway and does
+    not interfere.
+    """
+    agent_name = f"agent-{uuid.uuid4().hex[:12]}"
+    register = client.post(
+        "/api/v1/agents/initAgent",
+        json={
+            "agent": {
+                "agent_name": agent_name,
+                "agent_description": "test agent",
+                "agent_version": "1.0",
+            },
+            "steps": [],
+        },
+    )
+    assert register.status_code == 200, register.text
+
+    stub = _StubExchangeAuthorizer(actor_id="actor-rt", scopes=("runtime.use",))
+    clear_authorizers()
+    set_authorizer(stub)
+    set_authorizer(
+        LocalJwtVerifyProvider(
+            secret=_TEST_SECRET, header_name="X-Agent-Control-Runtime-Token"
+        ),
+        operation=Operation.RUNTIME_USE,
+    )
+
+    exchange = client.post(
+        "/api/v1/auth/runtime-token-exchange",
+        json={"target_type": "log_stream", "target_id": "ls-allowed"},
+    )
+    assert exchange.status_code == 200, exchange.text
+    token = exchange.json()["token"]
+
+    response = client.post(
+        "/api/v1/evaluation",
+        headers={
+            "X-Agent-Control-Runtime-Token": token,
+            "Authorization": "Bearer gateway-identity-jwt",
+        },
+        json={
+            "agent_name": agent_name,
+            "step": {"type": "llm", "name": "step", "input": "hello"},
+            "stage": "pre",
+            "target_type": "log_stream",
+            "target_id": "ls-allowed",
+        },
+    )
+
+    # The runtime token authorizes the request for its bound target; with no
+    # controls bound to that target the evaluation resolves to safe.
+    assert response.status_code == 200, response.text
+    assert response.json()["is_safe"] is True
+
+
+def test_evaluation_rejects_runtime_jwt_on_wrong_header_when_custom_configured(
+    client: TestClient,
+    runtime_config_enabled,
+):
+    """With a dedicated header configured, a token presented on Authorization
+    is ignored (it can't be smuggled past the gateway boundary): the verifier
+    reads only the configured header, so the request fails to authenticate."""
+    stub = _StubExchangeAuthorizer(actor_id="actor-rt", scopes=("runtime.use",))
+    clear_authorizers()
+    set_authorizer(stub)
+    set_authorizer(
+        LocalJwtVerifyProvider(
+            secret=_TEST_SECRET, header_name="X-Agent-Control-Runtime-Token"
+        ),
+        operation=Operation.RUNTIME_USE,
+    )
+
+    exchange = client.post(
+        "/api/v1/auth/runtime-token-exchange",
+        json={"target_type": "log_stream", "target_id": "ls-allowed"},
+    )
+    assert exchange.status_code == 200, exchange.text
+    token = exchange.json()["token"]
+
+    response = client.post(
+        "/api/v1/evaluation",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "agent_name": "agent",
+            "step": {"type": "llm", "name": "step", "input": "hello"},
+            "stage": "pre",
+            "target_type": "log_stream",
+            "target_id": "ls-allowed",
+        },
+    )
+
+    assert response.status_code == 401, response.text
 
 
 def test_evaluation_rejects_runtime_jwt_without_bound_target_context(


### PR DESCRIPTION
_Recreated from #253 on an upstream branch (not a fork) so CI secrets (SPEAKEASY_API_KEY) are available. Same commits, signed. Original PR: #253._

---

## Problem

When Agent Control runs behind the O11y gateway, the gateway overwrites `Authorization` with its own downstream identity JWT — clobbering AC's runtime-eval token on the hot path (HYBIM-866, under epic HYBIM-741). The runtime token and the gateway's identity JWT both want the `Authorization` header.

## Fix

Make the runtime token ride a **configurable header** on both sides, selected by `AGENT_CONTROL_RUNTIME_TOKEN_HEADER` (default `Authorization`). Behind the gateway, point both sides at a dedicated header (e.g. `X-Agent-Control-Runtime-Token`); the runtime token rides that header while the gateway keeps `Authorization` for its identity JWT — no collision.

- **`Authorization`**: keeps the mandatory `Bearer` scheme (existing contract).
- **Dedicated header**: carries the **raw** token (no `Bearer` prefix).
- **Default unchanged**: with the env unset, behavior is byte-identical to today.

### Server (verify side)

- `auth_framework/providers/local_jwt.py`: `LocalJwtVerifyProvider` takes a `header_name` (default `Authorization`) and reads the token from it. `Bearer` required only on `Authorization`; raw token accepted on a dedicated header.
- `auth_framework/config.py`: `_resolve_runtime_token_header()` reads `AGENT_CONTROL_RUNTIME_TOKEN_HEADER` (blank → default), passed into the provider when runtime mode is `jwt`.

### SDK (send side)

- `sdks/python/.../client.py`: `AgentControlClient` gains a `runtime_token_header` param (+ same env var). Sends the runtime token on the configured header — raw on a dedicated header, `Bearer` on `Authorization` (single `_format_runtime_token` helper is the sole authority for that rule).
- The API key is **preserved as the outer gateway credential**: when the runtime token rides a dedicated header, the API key still rides its own header (`X-API-Key`), so a request can authenticate at the gateway while the runtime JWT is verified by Agent Control. The existing same-header guard prevents any collision.
- High-level SDK: `agent_control.init()` accepts `runtime_token_header`, stores it in session state, and threads it into the evaluation clients (`evaluation.py`, `control_decorators.py`); it is cleared on reset.

## Configuration (behind the gateway)

```
# server
AGENT_CONTROL_RUNTIME_AUTH_MODE=jwt
AGENT_CONTROL_RUNTIME_TOKEN_SECRET=<secret>
AGENT_CONTROL_RUNTIME_TOKEN_HEADER=X-Agent-Control-Runtime-Token

# SDK (must match the server header)
AgentControlClient(..., runtime_token_header="X-Agent-Control-Runtime-Token")
# or agent_control.init(..., runtime_token_header="X-Agent-Control-Runtime-Token")
# or AGENT_CONTROL_RUNTIME_TOKEN_HEADER=X-Agent-Control-Runtime-Token
```

## Tests

- **Server** (`test_auth_framework.py`): default Bearer path; default rejects raw on `Authorization`; dedicated header reads raw token and coexists with a gateway `Authorization` JWT; Bearer also accepted on dedicated header; missing-header error names the configured header; blank `header_name` rejected; env resolver (unset → default, set → trimmed, whitespace → default).
- **Server, app-level** (`test_runtime_token_exchange_endpoint.py`): end-to-end through `/api/v1/evaluation` exercising config wiring + `Operation.RUNTIME_USE` routing — runtime token on a dedicated header with an outer `Authorization` gateway JWT is accepted; a token presented on `Authorization` is rejected (401) when a custom header is configured.
- **SDK** (`test_client.py`): header resolution (param/env/default, blank rejected, whitespace-env fallback); raw token on dedicated header with `Authorization` free while the API key is preserved on its own header; default sends `Bearer` on `Authorization`; auto-mode fallback keeps the API key when the exchange is unavailable.
- **SDK, high-level** (`test_init_validation.py`): `init()` stores `runtime_token_header` in session state; defaults to `None` when unset; validates the header up front (blank and bad field-name rejected before state is mutated); a positional call through `target_id` proves the new param is appended last and does not shift any existing slot (`controls_file` onward).

## Live validation on lab0 (through the real O11y gateway)

Validated the branch on lab0 behind the actual O11y api-gateway (the gateway that
owns `Authorization` for its own identity JWT — the real collision scenario).

- **Deploy:** built the branch server image, pushed it to a personal
  `docker-test.repo.splunkdev.net/user-<name>/agent-control:<tag>` namespace (a
  path a personal Artifactory token can write and lab0 can pull), then
  `kubectl set image` the lab0 `agent-control` deploy at it with
  `AGENT_CONTROL_RUNTIME_TOKEN_HEADER=X-Agent-Control-Runtime-Token`. Rolled back
  to the released image afterward.
- **Full flow returns 200, with a real org and log_stream.** `runtime-token-exchange`
  returns 200 and mints a real server-issued runtime JWT for the log_stream; the
  evaluation call carries that token on the **custom header** through the gateway
  and returns **200** with a real result (`is_safe: true`).
- **The collision is handled.** The same token presented on `Authorization` is
  rejected with 401 ("Missing X-Agent-Control-Runtime-Token"), because the server
  reads only the dedicated header. So even when the gateway overwrites
  `Authorization` with its own identity JWT, the runtime JWT survives on
  `X-Agent-Control-Runtime-Token`.
- **Correction from an earlier draft of this PR:** an initial run hit `502`
  (upstream `422`) on the exchange, which looked like a capability/provisioning gap.
  That was a test-input error, not a real gap: the request used a made-up
  `target_id` that was not a real log_stream, so the exchange could not resolve it.
  With a real log_stream id the whole flow returns 200. Nothing is blocked on
  provisioning.
- **Not exercised in this run:** a control actually firing (steer/deny) and control
  spans landing in Galileo (no control was bound to the log_stream, so the eval ran
  clean). That is separate from the header change and was already shown on the
  devstack.

## Security notes

- **Header isolation**: with a dedicated header configured, the verifier reads only that header — a token presented on `Authorization` is ignored, so it can't be smuggled past the gateway boundary.
- **No token leakage**: auth error messages reference the header name only, never the token value.
- Signature / scope / target-binding checks (`verify_runtime_token`) are unchanged.

## Backward compatibility

Safe. No backward compatibility issue.

The change is default-preserving. `runtime_token_header` defaults to `Authorization` on both the SDK and server, and an unset env var falls back to that default. With no config, behavior is byte-identical to today: the SDK still sends `Bearer <token>` on `Authorization`, and the server still requires the Bearer scheme there. All four default-path branches were traced to confirm.

One behavior change on the default path, and it's an improvement: a malformed `Authorization: Bearer ` with only trailing whitespace used to return an empty token and fail deep in signature verification. Now it's rejected up front with a clean `AUTH_MISSING_KEY`. No valid request changes.

### Operational notes (expected tradeoffs, not design risks)

- **Two-sided header contract.** Setting `AGENT_CONTROL_RUNTIME_TOKEN_HEADER` on only one side breaks runtime auth (401 on every eval). This is intrinsic to any configurable-header feature, not a regression, and it fails closed: a mismatch denies auth, never bypasses it. Neither side can validate the other's value since they run as separate processes, so the intended safeguard is a startup log of the resolved header on both sides, making a mismatch a quick log diff rather than a debugging session.
- **API-key retention on a dedicated header.** `_AgentControlAuth` now leaves the API key in place when the runtime token rides a dedicated header, so the key can act as the outer gateway credential. This is deliberate and required by the two-credential model: the API key authenticates at the gateway, and the runtime JWT is verified by Agent Control. The default path is unchanged. It is called out only because it is the one change on every request's auth path, which makes it the right spot to focus review.

## Notes / scope

- Backwards compatible: unset env → identical behavior. No change to the API-key or `none` runtime modes.
- Design follows the O11y api-service precedent: support both auth methods, gateway stays neutral, opt-in, default preserved.
- Server-side tests require the repo's Postgres test fixture (run in CI); the SDK suite runs standalone.
- Validated end-to-end on a devstack: with the SDK sending the token on `X-Agent-Control-Runtime-Token` and the server reading the same header, runtime JWT exchange, control steering, and control-span ingestion all worked. This confirms the SDK and server agree on the custom header. It does not yet exercise the gateway-collision path (the devstack has no O11y gateway overwriting `Authorization`).
- Gateway-collision validation on lab0 is done and green end-to-end (see "Live validation on lab0" above): with a real org and log_stream, `runtime-token-exchange` returns 200, the evaluation call rides `X-Agent-Control-Runtime-Token` through the real O11y gateway and returns 200 (`is_safe: true`), and the same token on `Authorization` is rejected 401. Control firing and span ingestion were not exercised in this run (no control bound to the log_stream), and are separate from the header change.





